### PR TITLE
Add launch signals and speed up the admin insights dashboard

### DIFF
--- a/.agents/skills/control-kody/references/features/admin.md
+++ b/.agents/skills/control-kody/references/features/admin.md
@@ -10,7 +10,10 @@ Operator tools. Seed and preview users are **not** admin.
 `/admin/community-reports`, `/admin/insights`, `/admin/platform-feedback`,
 `/admin/system-email`). `/admin/insights` shows launch MRR, paid mix, the
 stamp-based activation funnel (overall and since 2026-09-10), active-user
-windows, MCP client mix, entitlement ladders, and open platform feedback.
+windows, MCP client mix, entitlement ladders, open platform feedback, and
+estimated Dynamic Worker cost vs catalog list pay (underwater users).
+`/admin/users/:stableUserId` shows the same cost-vs-pay estimate for one
+account.
 
 ## Drive it
 

--- a/.agents/skills/control-kody/references/features/admin.md
+++ b/.agents/skills/control-kody/references/features/admin.md
@@ -8,7 +8,9 @@ Operator tools. Seed and preview users are **not** admin.
 `/admin/reserved-usernames`, `/admin/feature-flags`, `/admin/banners`,
 `/admin/platform-integrations`, `/admin/provider-marks`, `/admin/codemods`,
 `/admin/community-reports`, `/admin/insights`, `/admin/platform-feedback`,
-`/admin/system-email`).
+`/admin/system-email`). `/admin/insights` shows launch MRR, paid mix, the
+stamp-based activation funnel (overall and since 2026-09-10), active-user
+windows, MCP client mix, entitlement ladders, and open platform feedback.
 
 ## Drive it
 

--- a/docs/contributing/architecture/run-records.md
+++ b/docs/contributing/architecture/run-records.md
@@ -459,16 +459,19 @@ cursors remain valid.
 
 ### Admin insights RunLog reads
 
-The role-gated `/admin/insights` dashboard loads workflow status totals and job
-success/error totals, plus activation funnel/latency, from **bounded,
-content-free per-user RunLog point reads** (`getAdminInsightsSnapshot`;
-concurrency capped by `adminInsightsRunLogConcurrency`). Each snapshot returns
-aggregate workflow statuses, job outcome counts, and activation milestone
-timestamps/ids only — never workflow or job names, errors, logs, or other
-user-authored content. The page exposes `runLogCompleteness` (`usersAttempted`,
-`usersLoaded`, `complete`) so partial fanout degrades run-derived charts with an
-explicit warning instead of failing the whole dashboard. D1 supplies only job
-schedule totals (`totalJobs` and `enabledJobs`) on that path.
+The role-gated `/admin/insights` dashboard does **not** fan out per-user RunLog
+reads on the request path. The hourly `usage_aggregation` lane writes a
+content-free KV snapshot (`admin-insights-runlog:v1`) from bounded
+`getAdminInsightsSnapshot` point reads (concurrency capped by
+`adminInsightsRunLogConcurrency`). Each snapshot holds aggregate workflow
+statuses, job outcome counts, and activation milestone timestamps/ids only —
+never workflow or job names, errors, logs, or other user-authored content. The
+page reads that snapshot and exposes `runLogCompleteness` (`usersAttempted`,
+`usersLoaded`, `complete`, `snapshotUpdatedAt`) so a missing or partial snapshot
+degrades run-derived charts with an explicit warning instead of failing the
+whole dashboard. D1 supplies only job schedule totals (`totalJobs` and
+`enabledJobs`) on that path. Launch funnels (signup through first saved package)
+come from indexed `users` stamp columns, not RunLog.
 
 ## Related
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -535,6 +535,16 @@ WHERE timestamp > NOW() - INTERVAL '1' HOUR
   `users.entitlement_ladder` so legacy Standard/Pro is scored against
   `legacyPlanLimits`. Queries are `LIMIT`-bounded; entitlement reads run with
   modest concurrency.
+- **Launch signals** (`/admin/insights`, loader in
+  `packages/worker/src/admin/launch-signals.ts`): COUNT / GROUP BY over indexed
+  `users` columns and `platform_feedback.status`. Rough MRR maps
+  `users.stripe_price_id` through the known Standard/Pro catalog (public
+  $12 /
+  $120 and $49 / $480, plus retired list prices) and never calls Stripe
+  or pages the user table. `plan`, `stripe_plan`, and overlay-aware
+  `effectivePlan` stay separate so gift/referral Standard does not look like
+  paid MRR. The 5-minute insights KV cache (`admin-insights:v9`) covers the
+  assembled page; RunLog-derived charts come from the hourly RunLog KV snapshot.
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emits `fleet.entitlement.crossed` to admin-owned packages

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -543,8 +543,10 @@ WHERE timestamp > NOW() - INTERVAL '1' HOUR
   $120 and $49 / $480, plus retired list prices) and never calls Stripe
   or pages the user table. `plan`, `stripe_plan`, and overlay-aware
   `effectivePlan` stay separate so gift/referral Standard does not look like
-  paid MRR. The 5-minute insights KV cache (`admin-insights:v9`) covers the
-  assembled page; RunLog-derived charts come from the hourly RunLog KV snapshot.
+  paid MRR. Cost-vs-pay ranks the current month's top unique-worker-day
+  consumers (bounded scan) against that same catalog list MRR. The 5-minute
+  insights KV cache (`admin-insights:v10`) covers the assembled page; RunLog-
+  derived charts come from the hourly RunLog KV snapshot.
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emits `fleet.entitlement.crossed` to admin-owned packages

--- a/packages/worker/client/routes/admin-insights-cost.tsx
+++ b/packages/worker/client/routes/admin-insights-cost.tsx
@@ -1,0 +1,204 @@
+import { css } from 'remix/ui'
+import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
+import { formatIntegerNumber } from '#client/charts/chart-theme.ts'
+import {
+	costVsPayFootnote,
+	formatDynamicWorkerUsd,
+} from '#universal/dynamic-worker-cost.ts'
+import {
+	type AdminInsightsDynamicWorkerCost,
+	type AdminInsightsDynamicWorkerCostConsumer,
+} from '#universal/loader-data.ts'
+import {
+	adminUserDetailHref,
+	formatUsdFromCents,
+} from './admin-insights-shared.ts'
+import { ChartCard } from './admin-insights-sections.tsx'
+
+function formatMarginUsd(amount: number) {
+	const formatted = formatDynamicWorkerUsd(Math.abs(amount))
+	if (amount > 0) return `+${formatted}`
+	if (amount < 0) return `−${formatted}`
+	return formatted
+}
+
+function renderCostVsPayTable(input: {
+	ariaLabel: string
+	emptyText: string
+	rows: Array<AdminInsightsDynamicWorkerCostConsumer>
+}) {
+	if (input.rows.length === 0) {
+		return (
+			<p mix={css({ margin: 0, color: colors.textMuted })}>{input.emptyText}</p>
+		)
+	}
+	return (
+		<table
+			aria-label={input.ariaLabel}
+			mix={css({
+				width: '100%',
+				borderCollapse: 'collapse',
+				fontSize: typography.fontSize.sm,
+			})}
+		>
+			<thead>
+				<tr>
+					<th
+						scope="col"
+						mix={css({
+							textAlign: 'left',
+							padding: `${spacing.xs} ${spacing.sm}`,
+							color: colors.textMuted,
+							fontWeight: typography.fontWeight.medium,
+						})}
+					>
+						User
+					</th>
+					<th
+						scope="col"
+						mix={css({
+							textAlign: 'right',
+							padding: `${spacing.xs} ${spacing.sm}`,
+							color: colors.textMuted,
+							fontWeight: typography.fontWeight.medium,
+						})}
+					>
+						Est. cost
+					</th>
+					<th
+						scope="col"
+						mix={css({
+							textAlign: 'right',
+							padding: `${spacing.xs} ${spacing.sm}`,
+							color: colors.textMuted,
+							fontWeight: typography.fontWeight.medium,
+						})}
+					>
+						Paid
+					</th>
+					<th
+						scope="col"
+						mix={css({
+							textAlign: 'right',
+							padding: `${spacing.xs} ${spacing.sm}`,
+							color: colors.textMuted,
+							fontWeight: typography.fontWeight.medium,
+						})}
+					>
+						Margin
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				{input.rows.map((row) => (
+					<tr key={row.stableUserId}>
+						<td mix={css({ padding: `${spacing.xs} ${spacing.sm}` })}>
+							<a
+								href={adminUserDetailHref(row.stableUserId)}
+								mix={css({ color: colors.text, textDecoration: 'none' })}
+							>
+								{row.username}
+							</a>
+							{row.underwater ? (
+								<span
+									mix={css({
+										marginLeft: spacing.xs,
+										color: colors.danger,
+										fontSize: typography.fontSize.xs,
+									})}
+								>
+									underwater
+								</span>
+							) : null}
+						</td>
+						<td
+							mix={css({
+								padding: `${spacing.xs} ${spacing.sm}`,
+								textAlign: 'right',
+								fontVariantNumeric: 'tabular-nums',
+							})}
+						>
+							{formatDynamicWorkerUsd(row.estimatedGrossUsd)}
+							<span mix={css({ color: colors.textMuted })}>
+								{' '}
+								({formatIntegerNumber(row.uniqueWorkerDays)})
+							</span>
+						</td>
+						<td
+							mix={css({
+								padding: `${spacing.xs} ${spacing.sm}`,
+								textAlign: 'right',
+								color: colors.textMuted,
+								fontVariantNumeric: 'tabular-nums',
+							})}
+						>
+							{formatUsdFromCents(row.estimatedPaidUsdCents)}
+						</td>
+						<td
+							mix={css({
+								padding: `${spacing.xs} ${spacing.sm}`,
+								textAlign: 'right',
+								color: row.underwater ? colors.danger : colors.textMuted,
+								fontVariantNumeric: 'tabular-nums',
+							})}
+						>
+							{formatMarginUsd(row.estimatedMarginUsd)}
+						</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	)
+}
+
+export function renderCostVsPay(cost: AdminInsightsDynamicWorkerCost) {
+	return (
+		<ChartCard
+			title="Cost vs pay"
+			sub={`${costVsPayFootnote} Top unique-worker-day users this month, then the underwater subset.`}
+			span={12}
+		>
+			<div
+				mix={css({
+					display: 'grid',
+					gap: spacing.lg,
+					gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+					[mq.tablet]: {
+						gridTemplateColumns: 'minmax(0, 1fr)',
+					},
+				})}
+			>
+				<div mix={css({ display: 'grid', gap: spacing.sm })}>
+					<h3
+						mix={css({
+							margin: 0,
+							fontSize: typography.fontSize.base,
+						})}
+					>
+						Highest estimated cost
+					</h3>
+					{renderCostVsPayTable({
+						ariaLabel: 'Highest estimated Dynamic Worker cost vs list pay',
+						emptyText: 'No unique Dynamic Worker days recorded this month yet.',
+						rows: cost.topConsumers,
+					})}
+				</div>
+				<div mix={css({ display: 'grid', gap: spacing.sm })}>
+					<h3
+						mix={css({
+							margin: 0,
+							fontSize: typography.fontSize.base,
+						})}
+					>
+						Underwater
+					</h3>
+					{renderCostVsPayTable({
+						ariaLabel: 'Users whose estimated cost exceeds catalog list pay',
+						emptyText: 'No scanned users are underwater this month.',
+						rows: cost.underwaterConsumers,
+					})}
+				</div>
+			</div>
+		</ChartCard>
+	)
+}

--- a/packages/worker/client/routes/admin-insights-dashboard.tsx
+++ b/packages/worker/client/routes/admin-insights-dashboard.tsx
@@ -27,6 +27,7 @@ import {
 	planColors,
 	workflowStatusColors,
 } from './admin-insights-shared.ts'
+import { renderLaunchSignals } from './admin-insights-launch.tsx'
 import {
 	ChartCard,
 	activationSubtitle,
@@ -68,6 +69,7 @@ export function renderDashboard(data: AdminInsightsLoaderData) {
 					{runLogWarning}
 				</AccountManagementMessage>
 			) : null}
+			{renderLaunchSignals(data.launchSignals)}
 			<div
 				mix={css({
 					display: 'grid',
@@ -152,7 +154,7 @@ export function renderDashboard(data: AdminInsightsLoaderData) {
 				})}
 			>
 				<ChartCard
-					title="Activation funnel"
+					title="Package activation"
 					sub={activationSubtitle(data.activation)}
 					span={8}
 				>
@@ -284,7 +286,7 @@ export function renderDashboard(data: AdminInsightsLoaderData) {
 				</ChartCard>
 				<ChartCard
 					title="Entitlement pressure"
-					sub="Accounts above 80% of a plan limit among the ~15 most active users this month."
+					sub="Accounts above 80% of a plan limit among the ~15 most active users this month. Bounded usage_rollups sweep — not a full user scan."
 					span={6}
 				>
 					{renderEntitlementPressure(data.entitlementPressure)}
@@ -330,7 +332,7 @@ export function renderDashboard(data: AdminInsightsLoaderData) {
 				</ChartCard>
 				<ChartCard
 					title="Users by plan"
-					sub="Current plan distribution."
+					sub="Manual grant (`plan`) only — not Stripe or overlays. See Plan sources above."
 					span={4}
 				>
 					<DonutChart

--- a/packages/worker/client/routes/admin-insights-dashboard.tsx
+++ b/packages/worker/client/routes/admin-insights-dashboard.tsx
@@ -27,6 +27,7 @@ import {
 	planColors,
 	workflowStatusColors,
 } from './admin-insights-shared.ts'
+import { renderCostVsPay } from './admin-insights-cost.tsx'
 import { renderLaunchSignals } from './admin-insights-launch.tsx'
 import {
 	ChartCard,
@@ -70,6 +71,7 @@ export function renderDashboard(data: AdminInsightsLoaderData) {
 				</AccountManagementMessage>
 			) : null}
 			{renderLaunchSignals(data.launchSignals)}
+			{renderCostVsPay(data.dynamicWorkerCost)}
 			<div
 				mix={css({
 					display: 'grid',

--- a/packages/worker/client/routes/admin-insights-launch.tsx
+++ b/packages/worker/client/routes/admin-insights-launch.tsx
@@ -1,0 +1,437 @@
+import { css } from 'remix/ui'
+import { colors, mq, spacing, typography } from '#universal/styles/tokens.ts'
+import { DonutChart } from '#client/charts/donut-chart.tsx'
+import { StatCard } from '#client/charts/stat-card.tsx'
+import {
+	chartColor,
+	formatIntegerNumber,
+	formatPercentShare,
+} from '#client/charts/chart-theme.ts'
+import {
+	type AdminInsightsLaunchFunnelStep,
+	type AdminInsightsLaunchSignals,
+} from '#universal/loader-data.ts'
+import { formatPlanLabel, formatUsdFromCents } from './admin-insights-shared.ts'
+import { ChartCard } from './admin-insights-sections.tsx'
+
+const launchFunnelLabels: Record<
+	AdminInsightsLaunchFunnelStep['step'],
+	string
+> = {
+	signed_up: 'Signed up',
+	email_verified: 'Verified email',
+	first_mcp: 'Connected MCP',
+	first_search: 'First search',
+	first_execute: 'First execute',
+	first_saved_package: 'Saved a package',
+}
+
+const mcpClientColors: Record<string, string> = {
+	cursor: chartColor.blue,
+	'claude-code': chartColor.amber,
+	codex: chartColor.violet,
+	'claude-desktop': chartColor.rose,
+	chatgpt: chartColor.emerald,
+	other: chartColor.cyan,
+}
+
+function formatOpenedDay(day: string) {
+	const [year, month, dayOfMonth] = day.split('-')
+	if (!year || !month || !dayOfMonth) return day
+	return `${year}-${month}-${dayOfMonth}`
+}
+
+function renderLaunchFunnel(input: {
+	id: string
+	steps: Array<AdminInsightsLaunchFunnelStep>
+	ariaLabel: string
+}) {
+	const total = input.steps[0]?.users ?? 0
+	return (
+		<div mix={css({ display: 'grid', gap: spacing.sm })}>
+			{input.steps.map((entry) => {
+				const share = total > 0 ? entry.users / total : 0
+				return (
+					<div
+						key={`${input.id}-${entry.step}`}
+						mix={css({ display: 'grid', gap: spacing.xs })}
+					>
+						<div
+							mix={css({
+								display: 'flex',
+								justifyContent: 'space-between',
+								gap: spacing.sm,
+								fontSize: typography.fontSize.sm,
+								color: colors.text,
+							})}
+						>
+							<span>{launchFunnelLabels[entry.step]}</span>
+							<span mix={css({ color: colors.textMuted })}>
+								{formatIntegerNumber(entry.users)} · {formatPercentShare(share)}
+							</span>
+						</div>
+						<div
+							role="img"
+							aria-label={`${launchFunnelLabels[entry.step]}: ${entry.users} users, ${formatPercentShare(share)} of signups`}
+							mix={css({
+								height: '10px',
+								borderRadius: '999px',
+								background: colors.border,
+								overflow: 'hidden',
+							})}
+						>
+							<div
+								mix={css({
+									height: '100%',
+									width: `${Math.round(share * 100)}%`,
+									background:
+										entry.step === 'first_saved_package'
+											? chartColor.emerald
+											: chartColor.blue,
+								})}
+							/>
+						</div>
+					</div>
+				)
+			})}
+		</div>
+	)
+}
+
+function renderPlanTable(input: {
+	ariaLabel: string
+	rows: Array<{
+		label: string
+		slices: Array<{ plan: string; count: number }>
+	}>
+}) {
+	const plans = ['free', 'standard', 'pro', 'max', 'none']
+	const present = new Set(
+		input.rows.flatMap((row) => row.slices.map((slice) => slice.plan)),
+	)
+	const columns = plans.filter((plan) => present.has(plan))
+	return (
+		<table
+			aria-label={input.ariaLabel}
+			mix={css({
+				width: '100%',
+				borderCollapse: 'collapse',
+				fontSize: typography.fontSize.sm,
+			})}
+		>
+			<caption
+				mix={css({
+					captionSide: 'top',
+					textAlign: 'left',
+					color: colors.textMuted,
+					paddingBottom: spacing.xs,
+				})}
+			>
+				Manual `plan` is the admin grant. `stripePlan` is the paid Stripe
+				subscription. `effectivePlan` is the entitlement after overlays.
+			</caption>
+			<thead>
+				<tr>
+					<th
+						scope="col"
+						mix={css({
+							textAlign: 'left',
+							padding: `${spacing.xs} ${spacing.sm}`,
+							color: colors.textMuted,
+							fontWeight: typography.fontWeight.medium,
+						})}
+					>
+						Source
+					</th>
+					{columns.map((plan) => (
+						<th
+							key={plan}
+							scope="col"
+							mix={css({
+								textAlign: 'right',
+								padding: `${spacing.xs} ${spacing.sm}`,
+								color: colors.textMuted,
+								fontWeight: typography.fontWeight.medium,
+							})}
+						>
+							{formatPlanLabel(plan)}
+						</th>
+					))}
+				</tr>
+			</thead>
+			<tbody>
+				{input.rows.map((row) => {
+					const byPlan = new Map(
+						row.slices.map((slice) => [slice.plan, slice.count]),
+					)
+					return (
+						<tr key={row.label}>
+							<th
+								scope="row"
+								mix={css({
+									textAlign: 'left',
+									padding: `${spacing.xs} ${spacing.sm}`,
+									fontWeight: typography.fontWeight.medium,
+								})}
+							>
+								{row.label}
+							</th>
+							{columns.map((plan) => (
+								<td
+									key={plan}
+									mix={css({
+										textAlign: 'right',
+										padding: `${spacing.xs} ${spacing.sm}`,
+										fontVariantNumeric: 'tabular-nums',
+										color: colors.textMuted,
+									})}
+								>
+									{formatIntegerNumber(byPlan.get(plan) ?? 0)}
+								</td>
+							))}
+						</tr>
+					)
+				})}
+			</tbody>
+		</table>
+	)
+}
+
+export function renderLaunchSignals(signals: AdminInsightsLaunchSignals) {
+	const paidLabel =
+		signals.unpricedPaidSubscribers > 0
+			? `${formatIntegerNumber(signals.paidSubscribers)} paid · ${formatIntegerNumber(signals.unpricedPaidSubscribers)} unpriced`
+			: `${formatIntegerNumber(signals.paidSubscribers)} paid Standard/Pro`
+	const sinceOpenSignups =
+		signals.activation.sinceOpen.find((step) => step.step === 'signed_up')
+			?.users ?? 0
+
+	return (
+		<>
+			<div
+				mix={css({
+					display: 'grid',
+					gap: spacing.md,
+					gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+					[mq.tablet]: { gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' },
+					[mq.mobile]: { gridTemplateColumns: 'minmax(0, 1fr)' },
+				})}
+			>
+				<StatCard
+					id="stat-mrr"
+					label="Rough MRR"
+					value={formatUsdFromCents(signals.mrrUsdCents)}
+					sub={paidLabel}
+					color={chartColor.emerald}
+				/>
+				<StatCard
+					id="stat-active"
+					label="Active users"
+					value={formatIntegerNumber(signals.activeUsers.hours24)}
+					sub={`${formatIntegerNumber(signals.activeUsers.hours48)} in 48h · ${formatIntegerNumber(signals.activeUsers.days7)} in 7d`}
+					color={chartColor.blue}
+					sparkValues={[
+						signals.activeUsers.hours24,
+						signals.activeUsers.hours48,
+						signals.activeUsers.days7,
+					]}
+				/>
+				<StatCard
+					id="stat-since-open"
+					label="New since open"
+					value={formatIntegerNumber(sinceOpenSignups)}
+					sub={`Cohort from ${formatOpenedDay(signals.openedDay)}`}
+					color={chartColor.violet}
+				/>
+				<StatCard
+					id="stat-feedback"
+					label="Open feedback"
+					value={formatIntegerNumber(signals.openPlatformFeedback)}
+					sub="Open items in Platform feedback"
+					color={chartColor.amber}
+				/>
+			</div>
+
+			<div
+				mix={css({
+					display: 'grid',
+					gap: spacing.lg,
+					gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+					[mq.tablet]: { gridTemplateColumns: 'minmax(0, 1fr)' },
+				})}
+			>
+				<ChartCard
+					title="Launch activation"
+					sub="Signup through first saved package from user stamps. Not effective-plan overlays and not RunLog package-activation."
+					span={6}
+				>
+					{renderLaunchFunnel({
+						id: 'overall',
+						steps: signals.activation.overall,
+						ariaLabel: 'Overall launch activation funnel',
+					})}
+				</ChartCard>
+				<ChartCard
+					title="Since open"
+					sub={`Same funnel for accounts created on or after ${formatOpenedDay(signals.openedDay)}.`}
+					span={6}
+				>
+					{renderLaunchFunnel({
+						id: 'since-open',
+						steps: signals.activation.sinceOpen,
+						ariaLabel: 'Since-open launch activation funnel',
+					})}
+				</ChartCard>
+
+				<ChartCard
+					title="Paid subscriptions"
+					sub="Active Standard and Pro from stripe_plan + stripe_price_id. Yearly counts at list/12. Gift and referral overlays are excluded."
+					span={6}
+				>
+					{signals.paidSlices.length === 0 ? (
+						<p mix={css({ margin: 0, color: colors.textMuted })}>
+							No paid Stripe subscriptions yet.
+						</p>
+					) : (
+						<table
+							aria-label="Paid subscriptions by plan and interval"
+							mix={css({
+								width: '100%',
+								borderCollapse: 'collapse',
+								fontSize: typography.fontSize.sm,
+							})}
+						>
+							<thead>
+								<tr>
+									<th
+										scope="col"
+										mix={css({
+											textAlign: 'left',
+											padding: `${spacing.xs} ${spacing.sm}`,
+											color: colors.textMuted,
+											fontWeight: typography.fontWeight.medium,
+										})}
+									>
+										Plan
+									</th>
+									<th
+										scope="col"
+										mix={css({
+											textAlign: 'right',
+											padding: `${spacing.xs} ${spacing.sm}`,
+											color: colors.textMuted,
+											fontWeight: typography.fontWeight.medium,
+										})}
+									>
+										Subs
+									</th>
+									<th
+										scope="col"
+										mix={css({
+											textAlign: 'right',
+											padding: `${spacing.xs} ${spacing.sm}`,
+											color: colors.textMuted,
+											fontWeight: typography.fontWeight.medium,
+										})}
+									>
+										MRR
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{signals.paidSlices.map((slice) => (
+									<tr key={`${slice.plan}-${slice.interval}`}>
+										<td mix={css({ padding: `${spacing.xs} ${spacing.sm}` })}>
+											{formatPlanLabel(slice.plan)} · {slice.interval}
+										</td>
+										<td
+											mix={css({
+												padding: `${spacing.xs} ${spacing.sm}`,
+												textAlign: 'right',
+												fontVariantNumeric: 'tabular-nums',
+											})}
+										>
+											{formatIntegerNumber(slice.subscribers)}
+										</td>
+										<td
+											mix={css({
+												padding: `${spacing.xs} ${spacing.sm}`,
+												textAlign: 'right',
+												fontVariantNumeric: 'tabular-nums',
+												color: colors.textMuted,
+											})}
+										>
+											{formatUsdFromCents(slice.mrrUsdCents)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					)}
+				</ChartCard>
+				<ChartCard
+					title="Plan sources"
+					sub={
+						signals.overlayStandard > 0
+							? `${formatIntegerNumber(signals.overlayStandard)} effective Standard come from gift or referral overlays.`
+							: 'Manual grant, Stripe subscription, and effective entitlement stay separate.'
+					}
+					span={6}
+				>
+					{renderPlanTable({
+						ariaLabel: 'Users by plan source',
+						rows: [
+							{ label: 'plan', slices: signals.manualPlans },
+							{ label: 'stripePlan', slices: signals.stripePlans },
+							{ label: 'effectivePlan', slices: signals.effectivePlans },
+						],
+					})}
+				</ChartCard>
+
+				<ChartCard
+					title="MCP client mix"
+					sub="First-touch mcp_client_name classified into Cursor, Claude Code, Codex, and other hosts."
+					span={6}
+				>
+					<DonutChart
+						ariaLabel="First-touch MCP clients"
+						centerLabel="connected"
+						emptyText="Nobody has connected an MCP client yet."
+						slices={signals.mcpClients.map((slice, index) => ({
+							label: slice.label,
+							value: slice.count,
+							color:
+								((slice.kind && mcpClientColors[slice.kind]) ||
+									[chartColor.cyan, chartColor.lime, chartColor.fuchsia][
+										index % 3
+									]) ??
+								chartColor.cyan,
+						}))}
+					/>
+				</ChartCard>
+				<ChartCard
+					title="Entitlement ladder"
+					sub={`${formatIntegerNumber(signals.paidEntitlementLadders.legacy)} paid legacy · ${formatIntegerNumber(signals.paidEntitlementLadders.public)} paid public.`}
+					span={6}
+				>
+					<DonutChart
+						ariaLabel="Users by entitlement ladder"
+						centerLabel="users"
+						slices={[
+							{
+								label: 'Public',
+								value: signals.entitlementLadders.public,
+								color: chartColor.blue,
+							},
+							{
+								label: 'Legacy',
+								value: signals.entitlementLadders.legacy,
+								color: chartColor.amber,
+							},
+						]}
+					/>
+				</ChartCard>
+			</div>
+		</>
+	)
+}

--- a/packages/worker/client/routes/admin-insights-launch.tsx
+++ b/packages/worker/client/routes/admin-insights-launch.tsx
@@ -228,7 +228,7 @@ export function renderLaunchSignals(signals: AdminInsightsLaunchSignals) {
 					id="stat-active"
 					label="Active users"
 					value={formatIntegerNumber(signals.activeUsers.hours24)}
-					sub={`${formatIntegerNumber(signals.activeUsers.hours48)} in 48h · ${formatIntegerNumber(signals.activeUsers.days7)} in 7d`}
+					sub={`${formatIntegerNumber(signals.activeUsers.hours48)} in 48h · ${formatIntegerNumber(signals.activeUsers.days7)} in 7d · UTC days from last_active_at`}
 					color={chartColor.blue}
 					sparkValues={[
 						signals.activeUsers.hours24,

--- a/packages/worker/client/routes/admin-insights-sections.tsx
+++ b/packages/worker/client/routes/admin-insights-sections.tsx
@@ -156,7 +156,7 @@ export function renderDynamicWorkerCost(cost: AdminInsightsDynamicWorkerCost) {
 					key: consumer.stableUserId,
 					username: consumer.username,
 					stableUserId: consumer.stableUserId,
-					value: `${formatDynamicWorkerUsd(consumer.estimatedGrossUsd)} (${formatIntegerNumber(consumer.uniqueWorkerDays)})`,
+					value: `${formatDynamicWorkerUsd(consumer.estimatedGrossUsd)} (${formatIntegerNumber(consumer.uniqueWorkerDays)})${consumer.underwater ? ' · underwater' : ''}`,
 				})),
 			})}
 		</div>

--- a/packages/worker/client/routes/admin-insights-shared.ts
+++ b/packages/worker/client/routes/admin-insights-shared.ts
@@ -18,6 +18,7 @@ export const planColors: Record<string, string> = {
 	pro: chartColor.violet,
 	free: chartColor.blue,
 	standard: chartColor.emerald,
+	max: chartColor.rose,
 	none: chartColor.cyan,
 }
 
@@ -81,11 +82,22 @@ export const runtimeDurationMetricLabels: Record<AdminUsageMetric, string> = {
 	durable_object_rows_read: 'Durable Object rows read',
 }
 
+export function formatUsdFromCents(cents: number) {
+	return new Intl.NumberFormat('en-US', {
+		style: 'currency',
+		currency: 'USD',
+		maximumFractionDigits: cents % 100 === 0 ? 0 : 2,
+	}).format(cents / 100)
+}
+
 /** Null when run-derived totals are complete; otherwise a user-facing warning. */
 export function formatRunLogCompletenessWarning(
 	completeness: AdminInsightsRunLogCompleteness,
 ): string | null {
 	if (completeness.complete) return null
+	if (completeness.snapshotUpdatedAt == null) {
+		return 'Workflow and package-activation totals refresh hourly off this page. No snapshot yet.'
+	}
 	return `Workflow and activation totals are partial — loaded RunLog snapshots for ${completeness.usersLoaded} of ${completeness.usersAttempted} users.`
 }
 

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -67,7 +67,7 @@ export function AdminInsightsRoute(handle: Handle) {
 			>
 				<AdminPageHeader
 					title="Admin insights"
-					description="Launch signals, paid mix, and platform activity. Aggregated account metadata only — user content is never shown."
+					description="Launch signals, paid mix, cost vs pay, and platform activity. Aggregated account metadata only — user content is never shown."
 					currentHref={currentHref}
 				/>
 				{status === 'loading' ? (

--- a/packages/worker/client/routes/admin-insights.tsx
+++ b/packages/worker/client/routes/admin-insights.tsx
@@ -67,7 +67,7 @@ export function AdminInsightsRoute(handle: Handle) {
 			>
 				<AdminPageHeader
 					title="Admin insights"
-					description="Platform-wide activity at a glance. Aggregated account metadata only — user content is never shown."
+					description="Launch signals, paid mix, and platform activity. Aggregated account metadata only — user content is never shown."
 					currentHref={currentHref}
 				/>
 				{status === 'loading' ? (

--- a/packages/worker/client/routes/admin-users-detail.tsx
+++ b/packages/worker/client/routes/admin-users-detail.tsx
@@ -34,9 +34,10 @@ import {
 import { describeEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
 import { formatUsageLimit, formatUsagePercent } from './admin-users-shared.ts'
 import {
-	dynamicWorkerCostFootnote,
+	costVsPayFootnote,
 	formatDynamicWorkerUsd,
 } from '#universal/dynamic-worker-cost.ts'
+import { formatUsdFromCents } from './admin-insights-shared.ts'
 import {
 	durableObjectDurationFootnote,
 	formatDurableObjectGbSeconds,
@@ -534,12 +535,25 @@ export function renderAdminUserDetail(props: AdminUserDetailProps) {
 								})}
 							>
 								{formatDynamicWorkerUsd(
-									selectedUsage.dynamicWorkerCost.estimatedGrossUsd,
+									selectedUsage.costVsPay.estimatedGrossUsd,
 								)}{' '}
-								gross this month (
-								{formatIntegerNumber(
-									selectedUsage.dynamicWorkerCost.uniqueWorkerDays,
+								est. cost ·{' '}
+								{formatUsdFromCents(
+									selectedUsage.costVsPay.estimatedPaidUsdCents,
 								)}{' '}
+								list pay ·{' '}
+								<span
+									mix={css({
+										color: selectedUsage.costVsPay.underwater
+											? colors.danger
+											: undefined,
+									})}
+								>
+									{selectedUsage.costVsPay.underwater
+										? 'underwater'
+										: 'above cost'}
+								</span>{' '}
+								({formatIntegerNumber(selectedUsage.costVsPay.uniqueWorkerDays)}{' '}
 								unique worker-days)
 							</p>
 							<p
@@ -549,7 +563,7 @@ export function renderAdminUserDetail(props: AdminUserDetailProps) {
 									fontSize: typography.fontSize.xs,
 								})}
 							>
-								{dynamicWorkerCostFootnote}
+								{costVsPayFootnote}
 							</p>
 						</div>
 						<div mix={css({ display: 'grid', gap: spacing.sm })}>

--- a/packages/worker/migrations/0059-admin-insights-launch-indexes.sql
+++ b/packages/worker/migrations/0059-admin-insights-launch-indexes.sql
@@ -1,0 +1,18 @@
+-- Indexed columns for admin launch-signal aggregations. The insights page
+-- groups paid Stripe prices, first-touch MCP clients, signup/created_at
+-- windows, and last_active_at activity without paging the user table.
+
+CREATE INDEX IF NOT EXISTS idx_users_created_at
+	ON users(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_users_last_active_at
+	ON users(last_active_at)
+	WHERE last_active_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_stripe_plan_price
+	ON users(stripe_plan, stripe_price_id)
+	WHERE stripe_plan IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_mcp_client_name
+	ON users(mcp_client_name)
+	WHERE first_mcp_connected_at IS NOT NULL;

--- a/packages/worker/src/admin/cost-vs-pay.node.test.ts
+++ b/packages/worker/src/admin/cost-vs-pay.node.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from 'vitest'
+import {
+	estimatePaidListMrrUsdCents,
+	rankUnderwaterCostConsumers,
+	toAdminCostVsPay,
+	toAdminCostVsPayConsumer,
+} from './cost-vs-pay.ts'
+import { resolveStripePriceCatalog } from '#worker/billing/stripe-price-catalog.ts'
+
+const catalog = resolveStripePriceCatalog({
+	STRIPE_STANDARD_PRICE_ID: 'price_standard',
+	STRIPE_STANDARD_YEARLY_PRICE_ID: 'price_standard_yearly',
+	STRIPE_PRO_PRICE_ID: 'price_pro',
+	STRIPE_PRO_YEARLY_PRICE_ID: 'price_pro_yearly',
+})
+
+test('estimatePaidListMrrUsdCents uses catalog list MRR and treats overlays as $0', () => {
+	expect(
+		estimatePaidListMrrUsdCents({
+			stripePlan: 'standard',
+			stripePriceId: 'price_standard',
+			catalog,
+		}),
+	).toEqual({ cents: 1_200, source: 'stripe_catalog' })
+	expect(
+		estimatePaidListMrrUsdCents({
+			stripePlan: 'pro',
+			stripePriceId: 'price_pro_yearly',
+			catalog,
+		}),
+	).toEqual({ cents: 4_000, source: 'stripe_catalog' })
+	expect(
+		estimatePaidListMrrUsdCents({
+			stripePlan: null,
+			stripePriceId: 'price_standard',
+			catalog,
+		}),
+	).toEqual({ cents: 0, source: 'none' })
+	expect(
+		estimatePaidListMrrUsdCents({
+			stripePlan: 'standard',
+			stripePriceId: 'price_unknown',
+			catalog,
+		}),
+	).toEqual({ cents: 0, source: 'none' })
+})
+
+test('toAdminCostVsPay flags underwater when gross worker-day cost exceeds list pay', () => {
+	const freeHeavy = toAdminCostVsPay({
+		uniqueWorkerDays: 1_500,
+		stripePlan: null,
+		stripePriceId: null,
+		catalog,
+	})
+	expect(freeHeavy.estimatedGrossUsd).toBe(3)
+	expect(freeHeavy.estimatedPaidUsdCents).toBe(0)
+	expect(freeHeavy.estimatedMarginUsd).toBe(-3)
+	expect(freeHeavy.underwater).toBe(true)
+	expect(freeHeavy.paidSource).toBe('none')
+
+	const paidLight = toAdminCostVsPay({
+		uniqueWorkerDays: 90,
+		stripePlan: 'standard',
+		stripePriceId: 'price_standard',
+		catalog,
+	})
+	expect(paidLight.estimatedGrossUsd).toBe(0.18)
+	expect(paidLight.estimatedPaidUsdCents).toBe(1_200)
+	expect(paidLight.underwater).toBe(false)
+	expect(paidLight.paidSource).toBe('stripe_catalog')
+})
+
+test('rankUnderwaterCostConsumers sorts by deficit and keeps the display bound', () => {
+	const ranked = rankUnderwaterCostConsumers(
+		[
+			toAdminCostVsPayConsumer({
+				stableUserId: 'paid',
+				username: 'paid',
+				uniqueWorkerDays: 90,
+				stripePlan: 'pro',
+				stripePriceId: 'price_pro',
+				catalog,
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'small',
+				username: 'small',
+				uniqueWorkerDays: 100,
+				stripePlan: null,
+				stripePriceId: null,
+				catalog,
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'big',
+				username: 'big',
+				uniqueWorkerDays: 2_000,
+				stripePlan: null,
+				stripePriceId: null,
+				catalog,
+			}),
+		],
+		2,
+	)
+	expect(ranked.map((row) => row.stableUserId)).toEqual(['big', 'small'])
+})

--- a/packages/worker/src/admin/cost-vs-pay.ts
+++ b/packages/worker/src/admin/cost-vs-pay.ts
@@ -1,0 +1,91 @@
+/**
+ * Operator cost vs list-pay estimates. Unique worker-days and stored Stripe
+ * price ids only — no Stripe API and no per-user usage fan-out.
+ */
+
+import { toAdminDynamicWorkerCost } from '#universal/dynamic-worker-cost.ts'
+import {
+	type AdminCostVsPay,
+	type AdminInsightsDynamicWorkerCostConsumer,
+	type AdminPaidSource,
+} from '#universal/loader-data.ts'
+import {
+	monthlyRecurringRevenueUsdCents,
+	type StripePriceCatalogEntry,
+} from '#worker/billing/stripe-price-catalog.ts'
+
+export const adminFleetCostVsPayScanLimit = 25
+export const adminFleetCostVsPayDisplayLimit = 10
+
+export function estimatePaidListMrrUsdCents(input: {
+	stripePlan: string | null | undefined
+	stripePriceId: string | null | undefined
+	catalog: Map<string, StripePriceCatalogEntry>
+}): { cents: number; source: AdminPaidSource } {
+	const plan = input.stripePlan?.trim() ?? ''
+	if (plan !== 'standard' && plan !== 'pro') {
+		return { cents: 0, source: 'none' }
+	}
+	const priceId = input.stripePriceId?.trim() ?? ''
+	if (!priceId) return { cents: 0, source: 'none' }
+	const entry = input.catalog.get(priceId)
+	if (!entry) return { cents: 0, source: 'none' }
+	return {
+		cents: monthlyRecurringRevenueUsdCents(entry),
+		source: 'stripe_catalog',
+	}
+}
+
+export function toAdminCostVsPay(input: {
+	uniqueWorkerDays: number
+	stripePlan: string | null | undefined
+	stripePriceId: string | null | undefined
+	catalog: Map<string, StripePriceCatalogEntry>
+}): AdminCostVsPay {
+	const cost = toAdminDynamicWorkerCost(input.uniqueWorkerDays)
+	const paid = estimatePaidListMrrUsdCents(input)
+	const paidUsd = paid.cents / 100
+	return {
+		...cost,
+		estimatedPaidUsdCents: paid.cents,
+		estimatedMarginUsd: paidUsd - cost.estimatedGrossUsd,
+		underwater: cost.estimatedGrossUsd > paidUsd,
+		paidSource: paid.source,
+	}
+}
+
+export function toAdminCostVsPayConsumer(input: {
+	stableUserId: string
+	username: string
+	uniqueWorkerDays: number
+	stripePlan: string | null | undefined
+	stripePriceId: string | null | undefined
+	catalog: Map<string, StripePriceCatalogEntry>
+}): AdminInsightsDynamicWorkerCostConsumer {
+	const costVsPay = toAdminCostVsPay(input)
+	return {
+		stableUserId: input.stableUserId,
+		username: input.username,
+		uniqueWorkerDays: costVsPay.uniqueWorkerDays,
+		estimatedGrossUsd: costVsPay.estimatedGrossUsd,
+		estimatedPaidUsdCents: costVsPay.estimatedPaidUsdCents,
+		estimatedMarginUsd: costVsPay.estimatedMarginUsd,
+		underwater: costVsPay.underwater,
+		paidSource: costVsPay.paidSource,
+	}
+}
+
+export function rankUnderwaterCostConsumers(
+	consumers: ReadonlyArray<AdminInsightsDynamicWorkerCostConsumer>,
+	limit = adminFleetCostVsPayDisplayLimit,
+) {
+	return consumers
+		.filter((consumer) => consumer.underwater)
+		.toSorted(
+			(left, right) =>
+				right.estimatedGrossUsd -
+				right.estimatedPaidUsdCents / 100 -
+				(left.estimatedGrossUsd - left.estimatedPaidUsdCents / 100),
+		)
+		.slice(0, limit)
+}

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -277,6 +277,22 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 				username: 'cara',
 				uniqueWorkerDays: 90,
 				estimatedGrossUsd: 0.18,
+				estimatedPaidUsdCents: 0,
+				estimatedMarginUsd: -0.18,
+				underwater: true,
+				paidSource: 'none',
+			},
+		],
+		underwaterConsumers: [
+			{
+				stableUserId: 'user-c',
+				username: 'cara',
+				uniqueWorkerDays: 90,
+				estimatedGrossUsd: 0.18,
+				estimatedPaidUsdCents: 0,
+				estimatedMarginUsd: -0.18,
+				underwater: true,
+				paidSource: 'none',
 			},
 		],
 	})

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -12,6 +12,13 @@ import {
 	type PlanName,
 } from '#universal/plans.ts'
 import { observeOnlyUsageEventTypes } from '#universal/usage-event-types.ts'
+import {
+	adminFleetCostVsPayDisplayLimit,
+	adminFleetCostVsPayScanLimit,
+	rankUnderwaterCostConsumers,
+	toAdminCostVsPayConsumer,
+} from '#worker/admin/cost-vs-pay.ts'
+import { resolveStripePriceCatalog } from '#worker/billing/stripe-price-catalog.ts'
 import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
 import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
 import {
@@ -144,7 +151,7 @@ export async function loadFleetUsageInsights(input: {
 		queryTopEventCountConsumers(input.db, currentMonth),
 		queryTopDurationConsumersByMetric(input.db, currentMonth),
 		buildEntitlementPressurePanel(input),
-		queryDynamicWorkerCost(input.db, currentMonth),
+		queryDynamicWorkerCost(input.db, input.env, currentMonth),
 	])
 	return {
 		topRuntimeDurationConsumers,
@@ -341,8 +348,10 @@ async function queryTopEventCountConsumers(
 
 async function queryDynamicWorkerCost(
 	db: D1Database,
+	env: Env,
 	currentMonth: string,
 ): Promise<AdminInsightsDynamicWorkerCost> {
+	const catalog = resolveStripePriceCatalog(env)
 	const [totalRow, consumerRows] = await Promise.all([
 		db
 			.prepare(
@@ -355,7 +364,8 @@ async function queryDynamicWorkerCost(
 			.first<{ unique_worker_days: number }>(),
 		db
 			.prepare(
-				`SELECT u.stable_user_id, u.username, r.event_count
+				`SELECT u.stable_user_id, u.username, u.stripe_plan, u.stripe_price_id,
+					r.event_count
 				 FROM usage_rollups r
 				 INNER JOIN users u ON u.stable_user_id = r.user_id
 				 WHERE r.month = ?
@@ -364,25 +374,30 @@ async function queryDynamicWorkerCost(
 				 ORDER BY r.event_count DESC
 				 LIMIT ?`,
 			)
-			.bind(currentMonth, adminFleetTopConsumersLimit)
+			.bind(currentMonth, adminFleetCostVsPayScanLimit)
 			.all<{
 				stable_user_id: string
 				username: string
+				stripe_plan: string | null
+				stripe_price_id: string | null
 				event_count: number
 			}>(),
 	])
 	const uniqueWorkerDays = Number(totalRow?.unique_worker_days ?? 0)
+	const scanned = (consumerRows.results ?? []).map((row) =>
+		toAdminCostVsPayConsumer({
+			stableUserId: row.stable_user_id,
+			username: row.username,
+			uniqueWorkerDays: Number(row.event_count),
+			stripePlan: row.stripe_plan,
+			stripePriceId: row.stripe_price_id,
+			catalog,
+		}),
+	)
 	return {
 		...toAdminDynamicWorkerCost(uniqueWorkerDays),
-		topConsumers: (consumerRows.results ?? []).map((row) => {
-			const days = Number(row.event_count)
-			return {
-				stableUserId: row.stable_user_id,
-				username: row.username,
-				uniqueWorkerDays: days,
-				estimatedGrossUsd: estimateDynamicWorkerUsd(days),
-			}
-		}),
+		topConsumers: scanned.slice(0, adminFleetCostVsPayDisplayLimit),
+		underwaterConsumers: rankUnderwaterCostConsumers(scanned),
 	}
 }
 

--- a/packages/worker/src/admin/insights-runlog-snapshot.node.test.ts
+++ b/packages/worker/src/admin/insights-runlog-snapshot.node.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { type RunLogAdminInsightsSnapshot } from '#worker/run-records/admin-insights-snapshot.ts'
 import {
 	adminInsightsRunLogConcurrency,
+	adminInsightsRunLogMaxUsersPerTick,
 	adminInsightsRunLogSnapshotKvKey,
 	foldRunLogSnapshots,
 	readAdminInsightsRunLogSnapshot,
@@ -53,7 +54,10 @@ function createUsersDb(
 ) {
 	return {
 		prepare(query: string) {
-			return {
+			const statement = {
+				bind() {
+					return statement
+				},
 				async all<T>() {
 					if (
 						query.includes('stable_user_id') &&
@@ -64,6 +68,7 @@ function createUsersDb(
 					throw new Error(`Unsupported query: ${query}`)
 				},
 			}
+			return statement
 		},
 	} as unknown as D1Database
 }
@@ -144,6 +149,75 @@ test('readAdminInsightsRunLogSnapshot degrades when KV is missing or empty', asy
 			snapshotUpdatedAt: null,
 		},
 	)
+})
+
+test('refreshAdminInsightsRunLogSnapshot throws when BUNDLE_ARTIFACTS_KV is missing', async () => {
+	await expect(
+		refreshAdminInsightsRunLogSnapshot({
+			env: {
+				APP_DB: createUsersDb([
+					{
+						stable_user_id: 'user-a',
+						email_verified_at: '2026-09-01T00:00:00.000Z',
+					},
+				]),
+			} as Env,
+			now: new Date('2026-09-10T18:00:00.000Z'),
+		}),
+	).rejects.toThrow(/BUNDLE_ARTIFACTS_KV is required/)
+})
+
+test('refreshAdminInsightsRunLogSnapshot throws when the KV write fails', async () => {
+	runLogMocks.getAdminInsightsSnapshot.mockResolvedValue(emptySnapshot())
+	const kv = createMemoryKv()
+	kv.put = async () => {
+		throw new Error('kv write failed')
+	}
+	await expect(
+		refreshAdminInsightsRunLogSnapshot({
+			env: {
+				APP_DB: createUsersDb([
+					{
+						stable_user_id: 'user-a',
+						email_verified_at: '2026-09-01T00:00:00.000Z',
+					},
+				]),
+				BUNDLE_ARTIFACTS_KV: kv,
+			} as Env,
+			now: new Date('2026-09-10T18:00:00.000Z'),
+		}),
+	).rejects.toThrow(/kv write failed/)
+})
+
+test('refreshAdminInsightsRunLogSnapshot caps per-tick fanout and marks the snapshot incomplete', async () => {
+	runLogMocks.getAdminInsightsSnapshot.mockReset()
+	runLogMocks.getAdminInsightsSnapshot.mockResolvedValue(emptySnapshot())
+	const kv = createMemoryKv()
+	const users = Array.from(
+		{ length: adminInsightsRunLogMaxUsersPerTick + 1 },
+		(_, index) => ({
+			stable_user_id: `user-${String(index + 1).padStart(4, '0')}`,
+			email_verified_at: '2026-09-01T00:00:00.000Z',
+		}),
+	)
+	const snapshot = await refreshAdminInsightsRunLogSnapshot({
+		env: {
+			APP_DB: createUsersDb(users),
+			BUNDLE_ARTIFACTS_KV: kv,
+		} as Env,
+		now: new Date('2026-09-10T18:00:00.000Z'),
+	})
+
+	expect(snapshot.complete).toBe(false)
+	expect(snapshot.usersAttempted).toBe(adminInsightsRunLogMaxUsersPerTick)
+	expect(runLogMocks.getAdminInsightsSnapshot).toHaveBeenCalledTimes(
+		adminInsightsRunLogMaxUsersPerTick,
+	)
+	const stored = JSON.parse(
+		kv.store.get(adminInsightsRunLogSnapshotKvKey) ?? '{}',
+	) as { complete: boolean; usersAttempted: number }
+	expect(stored.complete).toBe(false)
+	expect(stored.usersAttempted).toBe(adminInsightsRunLogMaxUsersPerTick)
 })
 
 test('foldRunLogSnapshots still reports partial fanout without user content', () => {

--- a/packages/worker/src/admin/insights-runlog-snapshot.node.test.ts
+++ b/packages/worker/src/admin/insights-runlog-snapshot.node.test.ts
@@ -1,0 +1,171 @@
+import { expect, test, vi } from 'vitest'
+import { type RunLogAdminInsightsSnapshot } from '#worker/run-records/admin-insights-snapshot.ts'
+import {
+	adminInsightsRunLogConcurrency,
+	adminInsightsRunLogSnapshotKvKey,
+	foldRunLogSnapshots,
+	readAdminInsightsRunLogSnapshot,
+	refreshAdminInsightsRunLogSnapshot,
+} from './insights-runlog-snapshot.ts'
+
+const runLogMocks = vi.hoisted(() => ({
+	getAdminInsightsSnapshot:
+		vi.fn<
+			(input: {
+				env: Env
+				userId: string
+			}) => Promise<RunLogAdminInsightsSnapshot>
+		>(),
+	inFlight: 0,
+	maxInFlight: 0,
+}))
+
+vi.mock('#worker/run-records/service.ts', () => ({
+	getAdminInsightsSnapshot: (input: { env: Env; userId: string }) =>
+		runLogMocks.getAdminInsightsSnapshot(input),
+}))
+
+function emptySnapshot(): RunLogAdminInsightsSnapshot {
+	return {
+		workflowStatusCounts: [],
+		activationMilestones: [],
+		jobRunCounts: { success: 0, error: 0 },
+	}
+}
+
+function createMemoryKv() {
+	const store = new Map<string, string>()
+	return {
+		store,
+		async get<T>(key: string, type?: 'json' | 'text') {
+			const raw = store.get(key)
+			if (raw == null) return null
+			return type === 'json' ? (JSON.parse(raw) as T) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+	} as unknown as KVNamespace & { store: Map<string, string> }
+}
+
+function createUsersDb(
+	users: Array<{ stable_user_id: string; email_verified_at: string | null }>,
+) {
+	return {
+		prepare(query: string) {
+			return {
+				async all<T>() {
+					if (
+						query.includes('stable_user_id') &&
+						query.includes('deleting_at IS NULL')
+					) {
+						return { results: users as Array<T> }
+					}
+					throw new Error(`Unsupported query: ${query}`)
+				},
+			}
+		},
+	} as unknown as D1Database
+}
+
+test('refreshAdminInsightsRunLogSnapshot writes a content-free KV snapshot and bounds concurrency', async () => {
+	runLogMocks.inFlight = 0
+	runLogMocks.maxInFlight = 0
+	runLogMocks.getAdminInsightsSnapshot.mockImplementation(async (input) => {
+		runLogMocks.inFlight += 1
+		runLogMocks.maxInFlight = Math.max(
+			runLogMocks.maxInFlight,
+			runLogMocks.inFlight,
+		)
+		await Promise.resolve()
+		runLogMocks.inFlight -= 1
+		if (input.userId === 'user-a') {
+			return {
+				workflowStatusCounts: [{ status: 'complete', count: 2 }],
+				jobRunCounts: { success: 3, error: 1 },
+				activationMilestones: [
+					{
+						milestone: 'package_run_succeeded',
+						reachedAt: '2026-09-10T12:00:00.000Z',
+						packageId: 'opaque-pkg',
+					},
+				],
+			}
+		}
+		return emptySnapshot()
+	})
+	const kv = createMemoryKv()
+	const now = new Date('2026-09-10T18:00:00.000Z')
+	const snapshot = await refreshAdminInsightsRunLogSnapshot({
+		env: {
+			APP_DB: createUsersDb([
+				{
+					stable_user_id: 'user-a',
+					email_verified_at: '2026-09-01T00:00:00.000Z',
+				},
+				{
+					stable_user_id: 'user-b',
+					email_verified_at: '2026-09-02T00:00:00.000Z',
+				},
+			]),
+			BUNDLE_ARTIFACTS_KV: kv,
+		} as Env,
+		now,
+	})
+
+	expect(snapshot.workflowRuns).toBe(2)
+	expect(snapshot.jobSuccessRuns).toBe(3)
+	expect(snapshot.packageRunSucceededUsers).toBe(1)
+	expect(snapshot.complete).toBe(true)
+	expect(snapshot.snapshotUpdatedAt).toBe(now.toISOString())
+	expect(runLogMocks.getAdminInsightsSnapshot).toHaveBeenCalledTimes(2)
+	expect(runLogMocks.maxInFlight).toBeLessThanOrEqual(
+		adminInsightsRunLogConcurrency,
+	)
+	expect(kv.store.get(adminInsightsRunLogSnapshotKvKey)).not.toContain(
+		'opaque-pkg',
+	)
+
+	const read = await readAdminInsightsRunLogSnapshot(kv)
+	expect(read.workflowRuns).toBe(2)
+	expect(read.snapshotUpdatedAt).toBe(now.toISOString())
+	expect(read.complete).toBe(true)
+})
+
+test('readAdminInsightsRunLogSnapshot degrades when KV is missing or empty', async () => {
+	expect(await readAdminInsightsRunLogSnapshot(undefined)).toMatchObject({
+		complete: false,
+		snapshotUpdatedAt: null,
+		workflowRuns: 0,
+	})
+	expect(await readAdminInsightsRunLogSnapshot(createMemoryKv())).toMatchObject(
+		{
+			complete: false,
+			snapshotUpdatedAt: null,
+		},
+	)
+})
+
+test('foldRunLogSnapshots still reports partial fanout without user content', () => {
+	const folded = foldRunLogSnapshots([
+		{
+			user: {
+				stable_user_id: 'u1',
+				email_verified_at: '2026-07-01T00:00:00.000Z',
+			},
+			snapshot: emptySnapshot(),
+		},
+		{
+			user: {
+				stable_user_id: 'u2',
+				email_verified_at: null,
+			},
+			snapshot: null,
+		},
+	])
+	expect(folded).toMatchObject({
+		usersAttempted: 2,
+		usersLoaded: 1,
+		complete: false,
+	})
+})

--- a/packages/worker/src/admin/insights-runlog-snapshot.ts
+++ b/packages/worker/src/admin/insights-runlog-snapshot.ts
@@ -1,0 +1,291 @@
+/**
+ * Hourly KV snapshot of RunLog-derived admin insights. The insights page
+ * reads this instead of fanning out per-user Durable Object RPCs.
+ */
+
+import { type RunLogAdminInsightsSnapshot } from '#worker/run-records/admin-insights-snapshot.ts'
+import { getAdminInsightsSnapshot } from '#worker/run-records/service.ts'
+import {
+	type AdminInsightsRunLogCompleteness,
+	type AdminInsightsWorkflowStatus,
+} from '#universal/loader-data.ts'
+
+export const adminInsightsRunLogSnapshotKvKey = 'admin-insights-runlog:v1'
+
+/**
+ * Per-user RunLog point-reads for workflow/activation aggregates. Bound so a
+ * large user table cannot open unbounded DO RPCs on one scheduled tick.
+ */
+export const adminInsightsRunLogConcurrency = 8
+
+const hourMs = 60 * 60 * 1000
+
+type InsightsUserRow = {
+	stable_user_id: string
+	email_verified_at: string | null
+}
+
+export type AggregatedRunLogInsights = AdminInsightsRunLogCompleteness & {
+	workflowStatuses: Array<AdminInsightsWorkflowStatus>
+	workflowRuns: number
+	jobSuccessRuns: number
+	jobErrorRuns: number
+	packageRunSucceededUsers: number
+	packageActivatedUsers: number
+	medianHoursToActivation: number | null
+}
+
+export type AdminInsightsRunLogSnapshot = AggregatedRunLogInsights & {
+	version: 1
+}
+
+export const emptyRunLogInsights: AggregatedRunLogInsights = {
+	usersAttempted: 0,
+	usersLoaded: 0,
+	complete: true,
+	snapshotUpdatedAt: null,
+	workflowStatuses: [],
+	workflowRuns: 0,
+	jobSuccessRuns: 0,
+	jobErrorRuns: 0,
+	packageRunSucceededUsers: 0,
+	packageActivatedUsers: 0,
+	medianHoursToActivation: null,
+}
+
+export function missingRunLogInsights(): AggregatedRunLogInsights {
+	return {
+		...emptyRunLogInsights,
+		complete: false,
+	}
+}
+
+export async function readAdminInsightsRunLogSnapshot(
+	kv: KVNamespace | undefined,
+): Promise<AggregatedRunLogInsights> {
+	if (!kv) return missingRunLogInsights()
+	try {
+		const snapshot = await kv.get<AdminInsightsRunLogSnapshot>(
+			adminInsightsRunLogSnapshotKvKey,
+			'json',
+		)
+		if (!snapshot || snapshot.version !== 1) return missingRunLogInsights()
+		return {
+			usersAttempted: snapshot.usersAttempted,
+			usersLoaded: snapshot.usersLoaded,
+			complete: snapshot.complete,
+			snapshotUpdatedAt: snapshot.snapshotUpdatedAt,
+			workflowStatuses: snapshot.workflowStatuses,
+			workflowRuns: snapshot.workflowRuns,
+			jobSuccessRuns: snapshot.jobSuccessRuns,
+			jobErrorRuns: snapshot.jobErrorRuns,
+			packageRunSucceededUsers: snapshot.packageRunSucceededUsers,
+			packageActivatedUsers: snapshot.packageActivatedUsers,
+			medianHoursToActivation: snapshot.medianHoursToActivation,
+		}
+	} catch (error) {
+		console.warn('admin-insights-run-log-snapshot-read-failed', { error })
+		return missingRunLogInsights()
+	}
+}
+
+export async function refreshAdminInsightsRunLogSnapshot(input: {
+	env: Env
+	now?: Date
+}): Promise<AggregatedRunLogInsights> {
+	const users = await listNonDeletingInsightsUsers(input.env.APP_DB)
+	const aggregated = await aggregateRunLogInsights({
+		env: input.env,
+		users,
+	})
+	const snapshot: AdminInsightsRunLogSnapshot = {
+		version: 1,
+		...aggregated,
+		snapshotUpdatedAt: (input.now ?? new Date()).toISOString(),
+	}
+	if (input.env.BUNDLE_ARTIFACTS_KV) {
+		try {
+			await input.env.BUNDLE_ARTIFACTS_KV.put(
+				adminInsightsRunLogSnapshotKvKey,
+				JSON.stringify(snapshot),
+			)
+		} catch (error) {
+			console.warn('admin-insights-run-log-snapshot-write-failed', { error })
+		}
+	}
+	return {
+		...aggregated,
+		snapshotUpdatedAt: snapshot.snapshotUpdatedAt,
+	}
+}
+
+async function listNonDeletingInsightsUsers(
+	db: D1Database,
+): Promise<Array<InsightsUserRow>> {
+	const rows = await db
+		.prepare(
+			`SELECT stable_user_id, email_verified_at
+			 FROM users
+			 WHERE deleting_at IS NULL
+			   AND stable_user_id IS NOT NULL`,
+		)
+		.all<InsightsUserRow>()
+	return (rows.results ?? []).filter(
+		(row) =>
+			typeof row.stable_user_id === 'string' && row.stable_user_id !== '',
+	)
+}
+
+async function aggregateRunLogInsights(input: {
+	env: Env
+	users: ReadonlyArray<InsightsUserRow>
+}): Promise<AggregatedRunLogInsights> {
+	if (input.users.length === 0) return emptyRunLogInsights
+
+	const snapshots = await mapWithConcurrency(
+		input.users,
+		adminInsightsRunLogConcurrency,
+		async (user) => {
+			try {
+				const snapshot = await getAdminInsightsSnapshot({
+					env: input.env,
+					userId: user.stable_user_id,
+				})
+				return { user, snapshot }
+			} catch (error) {
+				// Missing RUN_LOG or a single-user RPC failure must not take down
+				// the hourly snapshot — degrade run-derived charts for that user only.
+				console.warn('admin-insights-run-log-unavailable', {
+					userId: user.stable_user_id,
+					error,
+				})
+				return { user, snapshot: null }
+			}
+		},
+	)
+
+	return foldRunLogSnapshots(snapshots)
+}
+
+export function foldRunLogSnapshots(
+	entries: ReadonlyArray<{
+		user: InsightsUserRow
+		snapshot: RunLogAdminInsightsSnapshot | null
+	}>,
+): AggregatedRunLogInsights {
+	const usersAttempted = entries.length
+	let usersLoaded = 0
+	const statusCounts = new Map<string, number>()
+	let workflowRuns = 0
+	let jobSuccessRuns = 0
+	let jobErrorRuns = 0
+	let packageRunSucceededUsers = 0
+	let packageActivatedUsers = 0
+	const activationHours: Array<number> = []
+
+	for (const { user, snapshot } of entries) {
+		if (!snapshot) continue
+		usersLoaded += 1
+		for (const row of snapshot.workflowStatusCounts) {
+			const count = Number(row.count) || 0
+			if (count <= 0) continue
+			const status = row.status.trim() || 'unknown'
+			statusCounts.set(status, (statusCounts.get(status) ?? 0) + count)
+			workflowRuns += count
+		}
+		jobSuccessRuns += Math.max(0, Number(snapshot.jobRunCounts.success) || 0)
+		jobErrorRuns += Math.max(0, Number(snapshot.jobRunCounts.error) || 0)
+		let hasRunSucceeded = false
+		let activatedReachedAt: string | null = null
+		for (const milestone of snapshot.activationMilestones) {
+			if (milestone.milestone === 'package_run_succeeded') {
+				hasRunSucceeded = true
+			} else if (milestone.milestone === 'package_activated') {
+				activatedReachedAt = milestone.reachedAt
+			}
+		}
+		if (hasRunSucceeded) packageRunSucceededUsers += 1
+		if (activatedReachedAt != null) {
+			packageActivatedUsers += 1
+			const hours = hoursFromVerifiedToActivation(
+				user.email_verified_at,
+				activatedReachedAt,
+			)
+			if (hours != null) activationHours.push(hours)
+		}
+	}
+
+	activationHours.sort((left, right) => left - right)
+
+	return {
+		usersAttempted,
+		usersLoaded,
+		complete: usersLoaded === usersAttempted,
+		snapshotUpdatedAt: null,
+		workflowStatuses: Array.from(statusCounts.entries())
+			.map(([status, count]) => ({ status, count }))
+			.sort(
+				(left, right) =>
+					right.count - left.count || left.status.localeCompare(right.status),
+			),
+		workflowRuns,
+		jobSuccessRuns,
+		jobErrorRuns,
+		packageRunSucceededUsers,
+		packageActivatedUsers,
+		medianHoursToActivation: medianOf(activationHours),
+	}
+}
+
+/**
+ * Hours from email verification to package activation. Users who activated
+ * before verifying (seeded / admin-created) would skew the median negative, so
+ * they are excluded rather than clamped.
+ */
+export function hoursFromVerifiedToActivation(
+	emailVerifiedAt: string | null | undefined,
+	activatedReachedAt: string,
+): number | null {
+	if (emailVerifiedAt == null || emailVerifiedAt === '') return null
+	const verifiedMs = Date.parse(emailVerifiedAt)
+	const activatedMs = Date.parse(activatedReachedAt)
+	if (!Number.isFinite(verifiedMs) || !Number.isFinite(activatedMs)) return null
+	const hours = (activatedMs - verifiedMs) / hourMs
+	if (!Number.isFinite(hours) || hours < 0) return null
+	return hours
+}
+
+async function mapWithConcurrency<T, R>(
+	items: ReadonlyArray<T>,
+	concurrency: number,
+	mapper: (item: T) => Promise<R>,
+): Promise<Array<R>> {
+	if (items.length === 0) return []
+	const limit = Math.max(1, Math.min(concurrency, items.length))
+	const results: Array<R | undefined> = Array.from({ length: items.length })
+	let nextIndex = 0
+	await Promise.all(
+		Array.from({ length: limit }, async () => {
+			while (nextIndex < items.length) {
+				const index = nextIndex
+				nextIndex += 1
+				const item = items[index]
+				if (item === undefined) return
+				results[index] = await mapper(item)
+			}
+		}),
+	)
+	return results as Array<R>
+}
+
+/** Median of an ascending list. Even-length lists average the middle pair. */
+export function medianOf(sortedValues: Array<number>): number | null {
+	const values = sortedValues.filter((value) => Number.isFinite(value))
+	if (values.length === 0) return null
+	const middle = Math.floor(values.length / 2)
+	if (values.length % 2 === 1) return values[middle] ?? null
+	const lower = values[middle - 1]
+	const upper = values[middle]
+	if (lower == null || upper == null) return null
+	return (lower + upper) / 2
+}

--- a/packages/worker/src/admin/insights-runlog-snapshot.ts
+++ b/packages/worker/src/admin/insights-runlog-snapshot.ts
@@ -13,10 +13,13 @@ import {
 export const adminInsightsRunLogSnapshotKvKey = 'admin-insights-runlog:v1'
 
 /**
- * Per-user RunLog point-reads for workflow/activation aggregates. Bound so a
- * large user table cannot open unbounded DO RPCs on one scheduled tick.
+ * Per-user RunLog point-reads for workflow/activation aggregates. Concurrent
+ * RPCs stay at 8. Each hourly tick also caps how many users it fans out to
+ * so the scheduled invocation cannot exhaust the Worker subrequest budget.
+ * Overflow marks the snapshot incomplete instead of paging across ticks.
  */
 export const adminInsightsRunLogConcurrency = 8
+export const adminInsightsRunLogMaxUsersPerTick = 1_500
 
 const hourMs = 60 * 60 * 1000
 
@@ -93,7 +96,9 @@ export async function refreshAdminInsightsRunLogSnapshot(input: {
 	env: Env
 	now?: Date
 }): Promise<AggregatedRunLogInsights> {
-	const users = await listNonDeletingInsightsUsers(input.env.APP_DB)
+	const { users, truncated } = await listNonDeletingInsightsUsers(
+		input.env.APP_DB,
+	)
 	const aggregated = await aggregateRunLogInsights({
 		env: input.env,
 		users,
@@ -101,39 +106,49 @@ export async function refreshAdminInsightsRunLogSnapshot(input: {
 	const snapshot: AdminInsightsRunLogSnapshot = {
 		version: 1,
 		...aggregated,
+		complete: aggregated.complete && !truncated,
 		snapshotUpdatedAt: (input.now ?? new Date()).toISOString(),
 	}
-	if (input.env.BUNDLE_ARTIFACTS_KV) {
-		try {
-			await input.env.BUNDLE_ARTIFACTS_KV.put(
-				adminInsightsRunLogSnapshotKvKey,
-				JSON.stringify(snapshot),
-			)
-		} catch (error) {
-			console.warn('admin-insights-run-log-snapshot-write-failed', { error })
-		}
+	if (!input.env.BUNDLE_ARTIFACTS_KV) {
+		throw new Error('BUNDLE_ARTIFACTS_KV is required for RunLog snapshots.')
 	}
+	await input.env.BUNDLE_ARTIFACTS_KV.put(
+		adminInsightsRunLogSnapshotKvKey,
+		JSON.stringify(snapshot),
+	)
 	return {
 		...aggregated,
+		complete: snapshot.complete,
 		snapshotUpdatedAt: snapshot.snapshotUpdatedAt,
 	}
 }
 
-async function listNonDeletingInsightsUsers(
-	db: D1Database,
-): Promise<Array<InsightsUserRow>> {
+async function listNonDeletingInsightsUsers(db: D1Database): Promise<{
+	users: Array<InsightsUserRow>
+	truncated: boolean
+}> {
 	const rows = await db
 		.prepare(
 			`SELECT stable_user_id, email_verified_at
 			 FROM users
 			 WHERE deleting_at IS NULL
-			   AND stable_user_id IS NOT NULL`,
+			   AND stable_user_id IS NOT NULL
+			 ORDER BY stable_user_id
+			 LIMIT ?`,
 		)
+		.bind(adminInsightsRunLogMaxUsersPerTick + 1)
 		.all<InsightsUserRow>()
-	return (rows.results ?? []).filter(
+	const eligible = (rows.results ?? []).filter(
 		(row) =>
 			typeof row.stable_user_id === 'string' && row.stable_user_id !== '',
 	)
+	const truncated = eligible.length > adminInsightsRunLogMaxUsersPerTick
+	return {
+		users: truncated
+			? eligible.slice(0, adminInsightsRunLogMaxUsersPerTick)
+			: eligible,
+		truncated,
+	}
 }
 
 async function aggregateRunLogInsights(input: {

--- a/packages/worker/src/admin/launch-signals.node.test.ts
+++ b/packages/worker/src/admin/launch-signals.node.test.ts
@@ -1,0 +1,205 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test } from 'vitest'
+import { applyAllMigrations } from '#worker/test-support/apply-all-migrations.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { platformPublicOpenedDay } from '#universal/platform-open.ts'
+import { loadAdminLaunchSignals } from './launch-signals.ts'
+
+const now = new Date('2026-09-10T18:00:00.000Z')
+
+function createLaunchSignalsDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	applyAllMigrations(sqlite, new URL('../../migrations/', import.meta.url))
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+function insertUser(
+	sqlite: DatabaseSync,
+	row: {
+		username: string
+		stableUserId: string
+		plan?: string
+		stripePlan?: string | null
+		stripePriceId?: string | null
+		entitlementLadder?: string
+		emailVerifiedAt?: string | null
+		firstMcpConnectedAt?: string | null
+		firstSearchAt?: string | null
+		firstExecuteAt?: string | null
+		firstSavedPackageAt?: string | null
+		mcpClientName?: string | null
+		lastActiveAt?: string | null
+		giftExpiresAt?: string | null
+		referralExpiresAt?: string | null
+		createdAt?: string
+		deletingAt?: string | null
+	},
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO users (
+				username, email, password_hash, stable_user_id, plan, stripe_plan,
+				stripe_price_id, entitlement_ladder, email_verified_at,
+				first_mcp_connected_at, first_search_at, first_execute_at,
+				first_saved_package_at, mcp_client_name, last_active_at,
+				second_agent_standard_gift_expires_at, referral_standard_credit_expires_at,
+				created_at, updated_at, deleting_at, account_type
+			) VALUES (?, ?, 'x', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'person')`,
+		)
+		.run(
+			row.username,
+			`${row.username}@example.com`,
+			row.stableUserId,
+			row.plan ?? 'free',
+			row.stripePlan ?? null,
+			row.stripePriceId ?? null,
+			row.entitlementLadder ?? 'public',
+			row.emailVerifiedAt ?? null,
+			row.firstMcpConnectedAt ?? null,
+			row.firstSearchAt ?? null,
+			row.firstExecuteAt ?? null,
+			row.firstSavedPackageAt ?? null,
+			row.mcpClientName ?? null,
+			row.lastActiveAt ?? null,
+			row.giftExpiresAt ?? null,
+			row.referralExpiresAt ?? null,
+			row.createdAt ?? '2026-08-01T00:00:00.000Z',
+			row.createdAt ?? '2026-08-01T00:00:00.000Z',
+			row.deletingAt ?? null,
+		)
+}
+
+test('launch signals aggregate paid MRR, funnels, activity, and overlays without paging users', async () => {
+	const { sqlite, db } = createLaunchSignalsDb()
+	insertUser(sqlite, {
+		username: 'paid-monthly',
+		stableUserId: 'user-paid-monthly',
+		plan: 'free',
+		stripePlan: 'standard',
+		stripePriceId: 'price_standard',
+		emailVerifiedAt: '2026-08-02T00:00:00.000Z',
+		firstMcpConnectedAt: '2026-08-03T00:00:00.000Z',
+		firstSearchAt: '2026-08-03T01:00:00.000Z',
+		firstExecuteAt: '2026-08-03T02:00:00.000Z',
+		firstSavedPackageAt: '2026-08-04T00:00:00.000Z',
+		mcpClientName: 'Cursor',
+		lastActiveAt: '2026-09-10T16:00:00.000Z',
+		entitlementLadder: 'legacy',
+	})
+	insertUser(sqlite, {
+		username: 'paid-yearly',
+		stableUserId: 'user-paid-yearly',
+		plan: 'pro',
+		stripePlan: 'pro',
+		stripePriceId: 'price_pro_yearly',
+		emailVerifiedAt: '2026-09-10T08:00:00.000Z',
+		firstMcpConnectedAt: '2026-09-10T09:00:00.000Z',
+		mcpClientName: 'Claude Code',
+		lastActiveAt: '2026-09-09T12:00:00.000Z',
+		createdAt: '2026-09-10T07:00:00.000Z',
+	})
+	insertUser(sqlite, {
+		username: 'gifted',
+		stableUserId: 'user-gifted',
+		plan: 'free',
+		giftExpiresAt: '2026-09-20T00:00:00.000Z',
+		emailVerifiedAt: '2026-09-10T10:00:00.000Z',
+		lastActiveAt: '2026-09-03T00:00:00.000Z',
+		createdAt: '2026-09-10T10:00:00.000Z',
+	})
+	insertUser(sqlite, {
+		username: 'deleting',
+		stableUserId: 'user-deleting',
+		stripePlan: 'pro',
+		stripePriceId: 'price_pro',
+		deletingAt: '2026-09-10T00:00:00.000Z',
+	})
+	sqlite
+		.prepare(
+			`INSERT INTO platform_feedback (
+				id, submitter_user_id, submitter_username, submitter_email,
+				category, summary, details, status, created_at, updated_at
+			) VALUES
+				('fb-open', 'user-gifted', 'gifted', 'gifted@example.com',
+					'bug', 'Open bug', 'details', 'open', ?, ?),
+				('fb-done', 'user-gifted', 'gifted', 'gifted@example.com',
+					'suggestion', 'Done idea', 'details', 'resolved', ?, ?)`,
+		)
+		.run(
+			now.toISOString(),
+			now.toISOString(),
+			now.toISOString(),
+			now.toISOString(),
+		)
+
+	const signals = await loadAdminLaunchSignals({
+		db,
+		env: {
+			STRIPE_STANDARD_PRICE_ID: 'price_standard',
+			STRIPE_STANDARD_YEARLY_PRICE_ID: 'price_standard_yearly',
+			STRIPE_PRO_PRICE_ID: 'price_pro',
+			STRIPE_PRO_YEARLY_PRICE_ID: 'price_pro_yearly',
+		},
+		now,
+	})
+
+	expect(signals.openedDay).toBe(platformPublicOpenedDay)
+	expect(signals.paidSubscribers).toBe(2)
+	expect(signals.mrrUsdCents).toBe(1_200 + 4_000)
+	expect(signals.paidSlices).toEqual([
+		{
+			plan: 'pro',
+			interval: 'year',
+			subscribers: 1,
+			mrrUsdCents: 4_000,
+		},
+		{
+			plan: 'standard',
+			interval: 'month',
+			subscribers: 1,
+			mrrUsdCents: 1_200,
+		},
+	])
+	expect(signals.manualPlans).toEqual([
+		{ plan: 'free', count: 2 },
+		{ plan: 'pro', count: 1 },
+	])
+	expect(signals.stripePlans).toEqual([
+		{ plan: 'none', count: 1 },
+		{ plan: 'pro', count: 1 },
+		{ plan: 'standard', count: 1 },
+	])
+	expect(signals.effectivePlans).toEqual([
+		{ plan: 'standard', count: 2 },
+		{ plan: 'pro', count: 1 },
+	])
+	expect(signals.overlayStandard).toBe(1)
+	expect(signals.entitlementLadders).toEqual({ public: 2, legacy: 1 })
+	expect(signals.paidEntitlementLadders).toEqual({ public: 1, legacy: 1 })
+	expect(signals.activeUsers).toEqual({
+		hours24: 1,
+		hours48: 2,
+		days7: 2,
+	})
+	expect(signals.activation.overall).toEqual([
+		{ step: 'signed_up', users: 3 },
+		{ step: 'email_verified', users: 3 },
+		{ step: 'first_mcp', users: 2 },
+		{ step: 'first_search', users: 1 },
+		{ step: 'first_execute', users: 1 },
+		{ step: 'first_saved_package', users: 1 },
+	])
+	expect(signals.activation.sinceOpen).toEqual([
+		{ step: 'signed_up', users: 2 },
+		{ step: 'email_verified', users: 2 },
+		{ step: 'first_mcp', users: 1 },
+		{ step: 'first_search', users: 0 },
+		{ step: 'first_execute', users: 0 },
+		{ step: 'first_saved_package', users: 0 },
+	])
+	expect(signals.mcpClients).toEqual([
+		{ kind: 'claude-code', label: 'Claude Code', count: 1 },
+		{ kind: 'cursor', label: 'Cursor', count: 1 },
+	])
+	expect(signals.openPlatformFeedback).toBe(1)
+})

--- a/packages/worker/src/admin/launch-signals.node.test.ts
+++ b/packages/worker/src/admin/launch-signals.node.test.ts
@@ -177,9 +177,9 @@ test('launch signals aggregate paid MRR, funnels, activity, and overlays without
 	expect(signals.entitlementLadders).toEqual({ public: 2, legacy: 1 })
 	expect(signals.paidEntitlementLadders).toEqual({ public: 1, legacy: 1 })
 	expect(signals.activeUsers).toEqual({
-		hours24: 1,
+		hours24: 2,
 		hours48: 2,
-		days7: 2,
+		days7: 3,
 	})
 	expect(signals.activation.overall).toEqual([
 		{ step: 'signed_up', users: 3 },
@@ -202,4 +202,31 @@ test('launch signals aggregate paid MRR, funnels, activity, and overlays without
 		{ kind: 'cursor', label: 'Cursor', count: 1 },
 	])
 	expect(signals.openPlatformFeedback).toBe(1)
+})
+
+test('active windows count last_active_at UTC days, not a rolling ISO-hour cutoff', async () => {
+	const { sqlite, db } = createLaunchSignalsDb()
+	insertUser(sqlite, {
+		username: 'yesterday-early',
+		stableUserId: 'user-yesterday-early',
+		lastActiveAt: '2026-09-10T01:00:00.000Z',
+		createdAt: '2026-09-01T00:00:00.000Z',
+	})
+
+	const signals = await loadAdminLaunchSignals({
+		db,
+		env: {
+			STRIPE_STANDARD_PRICE_ID: 'price_standard',
+			STRIPE_STANDARD_YEARLY_PRICE_ID: 'price_standard_yearly',
+			STRIPE_PRO_PRICE_ID: 'price_pro',
+			STRIPE_PRO_YEARLY_PRICE_ID: 'price_pro_yearly',
+		},
+		now: new Date('2026-09-11T02:00:00.000Z'),
+	})
+
+	expect(signals.activeUsers).toEqual({
+		hours24: 1,
+		hours48: 1,
+		days7: 1,
+	})
 })

--- a/packages/worker/src/admin/launch-signals.ts
+++ b/packages/worker/src/admin/launch-signals.ts
@@ -3,6 +3,7 @@
  * GROUP BY — the page never pages users or fans out per-account reads.
  */
 
+import { utcDayKey } from '@kody-internal/shared/date-keys.ts'
 import { classifyMcpClientName } from '#universal/connected-mcp-agents.ts'
 import {
 	type AdminInsightsLaunchFunnelStep,
@@ -103,9 +104,14 @@ export async function loadAdminLaunchSignals(input: {
 	now: Date
 }): Promise<AdminInsightsLaunchSignals> {
 	const nowIso = input.now.toISOString()
-	const active24h = new Date(input.now.getTime() - dayMs).toISOString()
-	const active48h = new Date(input.now.getTime() - 2 * dayMs).toISOString()
-	const active7d = new Date(input.now.getTime() - 7 * dayMs).toISOString()
+	// last_active_at is a UTC-day stamp (first activity that day). Rolling
+	// hour cutoffs drop users whose stamp is earlier the same calendar day
+	// they were last actually active. Compare date() to UTC day keys so 24h
+	// includes yesterday, 48h the day before that, and 7d the last 8 days
+	// inclusive of today.
+	const active24hDay = utcDayKey(new Date(input.now.getTime() - dayMs))
+	const active48hDay = utcDayKey(new Date(input.now.getTime() - 2 * dayMs))
+	const active7dDay = utcDayKey(new Date(input.now.getTime() - 7 * dayMs))
 	const catalog = resolveStripePriceCatalog(input.env)
 
 	const [totals, paidRows, effectiveRows, clientRows, openFeedback] =
@@ -125,9 +131,9 @@ export async function loadAdminLaunchSignals(input: {
 						SUM(CASE WHEN created_at >= ? AND first_search_at IS NOT NULL THEN 1 ELSE 0 END) AS first_search_since_open,
 						SUM(CASE WHEN created_at >= ? AND first_execute_at IS NOT NULL THEN 1 ELSE 0 END) AS first_execute_since_open,
 						SUM(CASE WHEN created_at >= ? AND first_saved_package_at IS NOT NULL THEN 1 ELSE 0 END) AS first_saved_package_since_open,
-						SUM(CASE WHEN last_active_at >= ? THEN 1 ELSE 0 END) AS active_24h,
-						SUM(CASE WHEN last_active_at >= ? THEN 1 ELSE 0 END) AS active_48h,
-						SUM(CASE WHEN last_active_at >= ? THEN 1 ELSE 0 END) AS active_7d,
+						SUM(CASE WHEN date(last_active_at) >= date(?) THEN 1 ELSE 0 END) AS active_24h,
+						SUM(CASE WHEN date(last_active_at) >= date(?) THEN 1 ELSE 0 END) AS active_48h,
+						SUM(CASE WHEN date(last_active_at) >= date(?) THEN 1 ELSE 0 END) AS active_7d,
 						SUM(CASE WHEN plan = 'free' OR plan IS NULL THEN 1 ELSE 0 END) AS manual_free,
 						SUM(CASE WHEN plan = 'standard' THEN 1 ELSE 0 END) AS manual_standard,
 						SUM(CASE WHEN plan = 'pro' THEN 1 ELSE 0 END) AS manual_pro,
@@ -156,9 +162,9 @@ export async function loadAdminLaunchSignals(input: {
 					platformPublicOpenedDay,
 					platformPublicOpenedDay,
 					platformPublicOpenedDay,
-					active24h,
-					active48h,
-					active7d,
+					active24hDay,
+					active48hDay,
+					active7dDay,
 					nowIso,
 					nowIso,
 				)

--- a/packages/worker/src/admin/launch-signals.ts
+++ b/packages/worker/src/admin/launch-signals.ts
@@ -1,0 +1,370 @@
+/**
+ * D1-only launch signals for `/admin/insights`. Every query is a COUNT or
+ * GROUP BY — the page never pages users or fans out per-account reads.
+ */
+
+import { classifyMcpClientName } from '#universal/connected-mcp-agents.ts'
+import {
+	type AdminInsightsLaunchFunnelStep,
+	type AdminInsightsLaunchSignals,
+	type AdminInsightsMcpClientSlice,
+	type AdminInsightsPaidSlice,
+	type AdminInsightsPlanSlice,
+} from '#universal/loader-data.ts'
+import {
+	platformPublicOpenedAt,
+	platformPublicOpenedDay,
+} from '#universal/platform-open.ts'
+import {
+	monthlyRecurringRevenueUsdCents,
+	resolveStripePriceCatalog,
+} from '#worker/billing/stripe-price-catalog.ts'
+import { type BillingEnv } from '#worker/billing/billing-config.ts'
+
+const dayMs = 24 * 60 * 60 * 1000
+const launchFunnelSteps = [
+	'signed_up',
+	'email_verified',
+	'first_mcp',
+	'first_search',
+	'first_execute',
+	'first_saved_package',
+] as const satisfies ReadonlyArray<AdminInsightsLaunchFunnelStep['step']>
+
+type CountRow = { n: number }
+type NamedCountRow = { name: string; n: number }
+type PaidPriceRow = {
+	stripe_plan: string
+	stripe_price_id: string
+	n: number
+}
+type LaunchTotalsRow = {
+	signed_up: number
+	verified: number
+	first_mcp: number
+	first_search: number
+	first_execute: number
+	first_saved_package: number
+	signed_up_since_open: number
+	verified_since_open: number
+	first_mcp_since_open: number
+	first_search_since_open: number
+	first_execute_since_open: number
+	first_saved_package_since_open: number
+	active_24h: number
+	active_48h: number
+	active_7d: number
+	manual_free: number
+	manual_standard: number
+	manual_pro: number
+	manual_max: number
+	stripe_none: number
+	stripe_standard: number
+	stripe_pro: number
+	ladder_public: number
+	ladder_legacy: number
+	ladder_legacy_paid: number
+	overlay_standard: number
+}
+
+function toCount(value: number | null | undefined) {
+	return Number(value ?? 0)
+}
+
+function funnelSteps(counts: {
+	signed_up: number
+	email_verified: number
+	first_mcp: number
+	first_search: number
+	first_execute: number
+	first_saved_package: number
+}): Array<AdminInsightsLaunchFunnelStep> {
+	return launchFunnelSteps.map((step) => ({
+		step,
+		users: counts[step],
+	}))
+}
+
+function planSlices(
+	counts: Record<string, number>,
+): Array<AdminInsightsPlanSlice> {
+	return Object.entries(counts)
+		.filter(([, count]) => count > 0)
+		.map(([plan, count]) => ({ plan, count }))
+		.sort(
+			(left, right) =>
+				right.count - left.count || left.plan.localeCompare(right.plan),
+		)
+}
+
+export async function loadAdminLaunchSignals(input: {
+	db: D1Database
+	env: BillingEnv
+	now: Date
+}): Promise<AdminInsightsLaunchSignals> {
+	const nowIso = input.now.toISOString()
+	const active24h = new Date(input.now.getTime() - dayMs).toISOString()
+	const active48h = new Date(input.now.getTime() - 2 * dayMs).toISOString()
+	const active7d = new Date(input.now.getTime() - 7 * dayMs).toISOString()
+	const catalog = resolveStripePriceCatalog(input.env)
+
+	const [totals, paidRows, effectiveRows, clientRows, openFeedback] =
+		await Promise.all([
+			input.db
+				.prepare(
+					`SELECT
+						COUNT(*) AS signed_up,
+						SUM(CASE WHEN email_verified_at IS NOT NULL THEN 1 ELSE 0 END) AS verified,
+						SUM(CASE WHEN first_mcp_connected_at IS NOT NULL THEN 1 ELSE 0 END) AS first_mcp,
+						SUM(CASE WHEN first_search_at IS NOT NULL THEN 1 ELSE 0 END) AS first_search,
+						SUM(CASE WHEN first_execute_at IS NOT NULL THEN 1 ELSE 0 END) AS first_execute,
+						SUM(CASE WHEN first_saved_package_at IS NOT NULL THEN 1 ELSE 0 END) AS first_saved_package,
+						SUM(CASE WHEN created_at >= ? THEN 1 ELSE 0 END) AS signed_up_since_open,
+						SUM(CASE WHEN created_at >= ? AND email_verified_at IS NOT NULL THEN 1 ELSE 0 END) AS verified_since_open,
+						SUM(CASE WHEN created_at >= ? AND first_mcp_connected_at IS NOT NULL THEN 1 ELSE 0 END) AS first_mcp_since_open,
+						SUM(CASE WHEN created_at >= ? AND first_search_at IS NOT NULL THEN 1 ELSE 0 END) AS first_search_since_open,
+						SUM(CASE WHEN created_at >= ? AND first_execute_at IS NOT NULL THEN 1 ELSE 0 END) AS first_execute_since_open,
+						SUM(CASE WHEN created_at >= ? AND first_saved_package_at IS NOT NULL THEN 1 ELSE 0 END) AS first_saved_package_since_open,
+						SUM(CASE WHEN last_active_at >= ? THEN 1 ELSE 0 END) AS active_24h,
+						SUM(CASE WHEN last_active_at >= ? THEN 1 ELSE 0 END) AS active_48h,
+						SUM(CASE WHEN last_active_at >= ? THEN 1 ELSE 0 END) AS active_7d,
+						SUM(CASE WHEN plan = 'free' OR plan IS NULL THEN 1 ELSE 0 END) AS manual_free,
+						SUM(CASE WHEN plan = 'standard' THEN 1 ELSE 0 END) AS manual_standard,
+						SUM(CASE WHEN plan = 'pro' THEN 1 ELSE 0 END) AS manual_pro,
+						SUM(CASE WHEN plan = 'max' THEN 1 ELSE 0 END) AS manual_max,
+						SUM(CASE WHEN stripe_plan IS NULL OR stripe_plan = '' THEN 1 ELSE 0 END) AS stripe_none,
+						SUM(CASE WHEN stripe_plan = 'standard' THEN 1 ELSE 0 END) AS stripe_standard,
+						SUM(CASE WHEN stripe_plan = 'pro' THEN 1 ELSE 0 END) AS stripe_pro,
+						SUM(CASE WHEN COALESCE(entitlement_ladder, 'public') = 'public' THEN 1 ELSE 0 END) AS ladder_public,
+						SUM(CASE WHEN COALESCE(entitlement_ladder, 'public') = 'legacy' THEN 1 ELSE 0 END) AS ladder_legacy,
+						SUM(CASE WHEN COALESCE(entitlement_ladder, 'public') = 'legacy' AND stripe_plan IN ('standard', 'pro') THEN 1 ELSE 0 END) AS ladder_legacy_paid,
+						SUM(CASE
+							WHEN (plan IS NULL OR plan = 'free')
+								AND (stripe_plan IS NULL OR stripe_plan NOT IN ('standard', 'pro'))
+								AND (
+									(second_agent_standard_gift_expires_at IS NOT NULL AND second_agent_standard_gift_expires_at > ?)
+									OR (referral_standard_credit_expires_at IS NOT NULL AND referral_standard_credit_expires_at > ?)
+								)
+							THEN 1 ELSE 0 END) AS overlay_standard
+					 FROM users
+					 WHERE deleting_at IS NULL`,
+				)
+				.bind(
+					platformPublicOpenedDay,
+					platformPublicOpenedDay,
+					platformPublicOpenedDay,
+					platformPublicOpenedDay,
+					platformPublicOpenedDay,
+					platformPublicOpenedDay,
+					active24h,
+					active48h,
+					active7d,
+					nowIso,
+					nowIso,
+				)
+				.first<LaunchTotalsRow>(),
+			input.db
+				.prepare(
+					`SELECT COALESCE(stripe_plan, '') AS stripe_plan,
+						COALESCE(stripe_price_id, '') AS stripe_price_id,
+						COUNT(*) AS n
+					 FROM users
+					 WHERE deleting_at IS NULL
+						AND stripe_plan IN ('standard', 'pro')
+					 GROUP BY 1, 2`,
+				)
+				.all<PaidPriceRow>(),
+			input.db
+				.prepare(
+					`SELECT
+						CASE
+							WHEN plan = 'max' THEN 'max'
+							WHEN plan = 'pro' OR stripe_plan = 'pro' THEN 'pro'
+							WHEN plan = 'standard' OR stripe_plan = 'standard' THEN 'standard'
+							WHEN (
+								(second_agent_standard_gift_expires_at IS NOT NULL AND second_agent_standard_gift_expires_at > ?)
+								OR (referral_standard_credit_expires_at IS NOT NULL AND referral_standard_credit_expires_at > ?)
+							) THEN 'standard'
+							ELSE COALESCE(plan, 'free')
+						END AS name,
+						COUNT(*) AS n
+					 FROM users
+					 WHERE deleting_at IS NULL
+					 GROUP BY 1`,
+				)
+				.bind(nowIso, nowIso)
+				.all<NamedCountRow>(),
+			input.db
+				.prepare(
+					`SELECT COALESCE(mcp_client_name, '') AS name, COUNT(*) AS n
+					 FROM users
+					 WHERE deleting_at IS NULL
+						AND first_mcp_connected_at IS NOT NULL
+					 GROUP BY 1`,
+				)
+				.all<NamedCountRow>(),
+			input.db
+				.prepare(
+					`SELECT COUNT(*) AS n
+					 FROM platform_feedback
+					 WHERE status = 'open'`,
+				)
+				.first<CountRow>(),
+		])
+
+	const paid = foldPaidSlices(paidRows.results ?? [], catalog)
+	const ladderLegacy = toCount(totals?.ladder_legacy)
+	const ladderPublic = toCount(totals?.ladder_public)
+
+	return {
+		openedAt: platformPublicOpenedAt,
+		openedDay: platformPublicOpenedDay,
+		mrrUsdCents: paid.mrrUsdCents,
+		paidSubscribers: paid.paidSubscribers,
+		unpricedPaidSubscribers: paid.unpricedPaidSubscribers,
+		paidSlices: paid.slices,
+		manualPlans: planSlices({
+			free: toCount(totals?.manual_free),
+			standard: toCount(totals?.manual_standard),
+			pro: toCount(totals?.manual_pro),
+			max: toCount(totals?.manual_max),
+		}),
+		stripePlans: planSlices({
+			none: toCount(totals?.stripe_none),
+			standard: toCount(totals?.stripe_standard),
+			pro: toCount(totals?.stripe_pro),
+		}),
+		effectivePlans: (effectiveRows.results ?? [])
+			.map((row): AdminInsightsPlanSlice => ({
+				plan: row.name || 'free',
+				count: toCount(row.n),
+			}))
+			.filter((slice) => slice.count > 0)
+			.sort(
+				(left, right) =>
+					right.count - left.count || left.plan.localeCompare(right.plan),
+			),
+		overlayStandard: toCount(totals?.overlay_standard),
+		entitlementLadders: {
+			public: ladderPublic,
+			legacy: ladderLegacy,
+		},
+		paidEntitlementLadders: {
+			legacy: toCount(totals?.ladder_legacy_paid),
+			public: Math.max(
+				0,
+				toCount(totals?.stripe_standard) +
+					toCount(totals?.stripe_pro) -
+					toCount(totals?.ladder_legacy_paid),
+			),
+		},
+		activeUsers: {
+			hours24: toCount(totals?.active_24h),
+			hours48: toCount(totals?.active_48h),
+			days7: toCount(totals?.active_7d),
+		},
+		activation: {
+			overall: funnelSteps({
+				signed_up: toCount(totals?.signed_up),
+				email_verified: toCount(totals?.verified),
+				first_mcp: toCount(totals?.first_mcp),
+				first_search: toCount(totals?.first_search),
+				first_execute: toCount(totals?.first_execute),
+				first_saved_package: toCount(totals?.first_saved_package),
+			}),
+			sinceOpen: funnelSteps({
+				signed_up: toCount(totals?.signed_up_since_open),
+				email_verified: toCount(totals?.verified_since_open),
+				first_mcp: toCount(totals?.first_mcp_since_open),
+				first_search: toCount(totals?.first_search_since_open),
+				first_execute: toCount(totals?.first_execute_since_open),
+				first_saved_package: toCount(totals?.first_saved_package_since_open),
+			}),
+		},
+		mcpClients: foldMcpClients(clientRows.results ?? []),
+		openPlatformFeedback: toCount(openFeedback?.n),
+	}
+}
+
+function foldPaidSlices(
+	rows: ReadonlyArray<PaidPriceRow>,
+	catalog: ReturnType<typeof resolveStripePriceCatalog>,
+): {
+	slices: Array<AdminInsightsPaidSlice>
+	mrrUsdCents: number
+	paidSubscribers: number
+	unpricedPaidSubscribers: number
+} {
+	const byKey = new Map<string, AdminInsightsPaidSlice>()
+	let paidSubscribers = 0
+	let unpricedPaidSubscribers = 0
+	let mrrUsdCents = 0
+
+	for (const row of rows) {
+		const subscribers = toCount(row.n)
+		if (subscribers <= 0) continue
+		const plan = row.stripe_plan === 'pro' ? 'pro' : 'standard'
+		const entry = catalog.get(row.stripe_price_id)
+		const interval = entry?.interval ?? 'unknown'
+		const sliceMrr = entry
+			? monthlyRecurringRevenueUsdCents(entry) * subscribers
+			: 0
+		if (!entry) unpricedPaidSubscribers += subscribers
+		paidSubscribers += subscribers
+		mrrUsdCents += sliceMrr
+		const key = `${plan}:${interval}`
+		const current = byKey.get(key) ?? {
+			plan,
+			interval,
+			subscribers: 0,
+			mrrUsdCents: 0,
+		}
+		current.subscribers += subscribers
+		current.mrrUsdCents += sliceMrr
+		byKey.set(key, current)
+	}
+
+	const slices = Array.from(byKey.values()).sort((left, right) => {
+		if (left.plan !== right.plan) return left.plan.localeCompare(right.plan)
+		return intervalRank(left.interval) - intervalRank(right.interval)
+	})
+	return { slices, mrrUsdCents, paidSubscribers, unpricedPaidSubscribers }
+}
+
+function intervalRank(interval: AdminInsightsPaidSlice['interval']) {
+	switch (interval) {
+		case 'month':
+			return 0
+		case 'year':
+			return 1
+		case 'unknown':
+			return 2
+		default: {
+			const exhaustive: never = interval
+			throw new Error(`Unknown billing interval: ${String(exhaustive)}`)
+		}
+	}
+}
+
+function foldMcpClients(
+	rows: ReadonlyArray<NamedCountRow>,
+): Array<AdminInsightsMcpClientSlice> {
+	const byLabel = new Map<string, AdminInsightsMcpClientSlice>()
+	for (const row of rows) {
+		const count = toCount(row.n)
+		if (count <= 0) continue
+		const classified = classifyMcpClientName(row.name || null)
+		const key = classified.kind ?? `other:${classified.label}`
+		const current = byLabel.get(key) ?? {
+			kind: classified.kind,
+			label: classified.label,
+			count: 0,
+		}
+		current.count += count
+		byLabel.set(key, current)
+	}
+	return Array.from(byLabel.values()).sort(
+		(left, right) =>
+			right.count - left.count || left.label.localeCompare(right.label),
+	)
+}

--- a/packages/worker/src/admin/user-usage-data.node.test.ts
+++ b/packages/worker/src/admin/user-usage-data.node.test.ts
@@ -85,6 +85,7 @@ type UserRow = {
 	email: string
 	plan: string
 	stripe_plan?: string | null
+	stripe_price_id?: string | null
 	stable_user_id: string
 }
 
@@ -145,7 +146,7 @@ function createAdminUserUsageTestDb(input: {
 				async first<T>() {
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, plan, stripe_plan, entitlement_ladder, stable_user_id from users where stable_user_id = ?',
+							'select id, username, email, plan, stripe_plan, stripe_price_id, entitlement_ladder, stable_user_id from users where stable_user_id = ?',
 						)
 					) {
 						return (users.find((user) => user.stable_user_id === params[0]) ??
@@ -267,6 +268,16 @@ test('loadAdminUserUsageData returns null for unknown users and zeroed usage for
 		usdPerUniqueDay: 0.002,
 		includedPerAccountMonth: 1000,
 	})
+	expect(data?.costVsPay).toEqual({
+		uniqueWorkerDays: 0,
+		estimatedGrossUsd: 0,
+		usdPerUniqueDay: 0.002,
+		includedPerAccountMonth: 1000,
+		estimatedPaidUsdCents: 0,
+		estimatedMarginUsd: 0,
+		underwater: false,
+		paidSource: 'none',
+	})
 	expect(data?.durableObjectDuration).toEqual({
 		gbSeconds: 0,
 		durationMs: 0,
@@ -312,7 +323,52 @@ test('loadAdminUserUsageData estimates Dynamic Worker cost from unique worker-da
 		usdPerUniqueDay: 0.002,
 		includedPerAccountMonth: 1000,
 	})
+	expect(data?.costVsPay.underwater).toBe(true)
+	expect(data?.costVsPay.estimatedPaidUsdCents).toBe(0)
 	expect(data?.durableObjectDuration.rpcCount).toBe(0)
+})
+
+test('loadAdminUserUsageData compares catalog list MRR to estimated cost', async () => {
+	const email = 'dw-paid@example.com'
+	const usageUserId = await createStableUserIdFromEmail(email)
+	const db = createAdminUserUsageTestDb({
+		users: [
+			{
+				id: 31,
+				username: 'dwpaid',
+				email,
+				plan: 'free',
+				stripe_plan: 'standard',
+				stripe_price_id: 'price_standard',
+				stable_user_id: usageUserId,
+			},
+		],
+		usageRollups: [
+			usageRow({
+				user_id: usageUserId,
+				metric: 'dynamic_worker_day',
+				month: '2026-07',
+				event_count: 90,
+			}),
+		],
+		resourceCounts: { [usageUserId]: {} },
+	})
+
+	const data = await loadAdminUserUsageData(
+		withUserMeter({
+			APP_DB: db,
+			STRIPE_STANDARD_PRICE_ID: 'price_standard',
+		}) as Env,
+		usageUserId,
+		new Date('2026-07-05T12:00:00.000Z'),
+	)
+
+	expect(data?.costVsPay.uniqueWorkerDays).toBe(90)
+	expect(data?.costVsPay.estimatedGrossUsd).toBeCloseTo(0.18)
+	expect(data?.costVsPay.estimatedPaidUsdCents).toBe(1_200)
+	expect(data?.costVsPay.estimatedMarginUsd).toBeCloseTo(11.82)
+	expect(data?.costVsPay.underwater).toBe(false)
+	expect(data?.costVsPay.paidSource).toBe('stripe_catalog')
 })
 
 test('loadAdminUserUsageData converts Durable Object RPC duration to observe-only GB-s', async () => {

--- a/packages/worker/src/admin/user-usage-data.ts
+++ b/packages/worker/src/admin/user-usage-data.ts
@@ -1,13 +1,5 @@
 import { cachified, type Cache } from '@epic-web/cachified'
 import { utcDayKey, utcMonthKey } from '@kody-internal/shared/date-keys.ts'
-import {
-	parseEntitlementLadder,
-	parseStoredPlanName,
-	resolveEffectivePlan,
-} from '#universal/plans.ts'
-import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
-import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
-import { resolveUserStableId } from '#worker/user-id.ts'
 import { toAdminDynamicWorkerCost } from '#universal/dynamic-worker-cost.ts'
 import { toAdminDurableObjectDuration } from '#universal/durable-object-duration.ts'
 import {
@@ -16,6 +8,16 @@ import {
 	type AdminUsageRollup,
 	type AdminUserUsageLoaderData,
 } from '#universal/loader-data.ts'
+import {
+	parseEntitlementLadder,
+	parseStoredPlanName,
+	resolveEffectivePlan,
+} from '#universal/plans.ts'
+import { toAdminCostVsPay } from '#worker/admin/cost-vs-pay.ts'
+import { readAdminEntitlementConsumption } from '#worker/admin/entitlement-consumption.ts'
+import { resolveStripePriceCatalog } from '#worker/billing/stripe-price-catalog.ts'
+import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
+import { resolveUserStableId } from '#worker/user-id.ts'
 
 export const adminUsageMetrics = [
 	'execute',
@@ -44,6 +46,7 @@ type AdminUserUsageUserRow = {
 	email: string
 	plan: string
 	stripe_plan: string | null
+	stripe_price_id: string | null
 	entitlement_ladder: string | null
 	stable_user_id: string
 }
@@ -71,7 +74,7 @@ export async function loadAdminUserUsageData(
 	now: Date = new Date(),
 ): Promise<AdminUserUsageLoaderData | null> {
 	const row = await env.APP_DB.prepare(
-		`SELECT id, username, email, plan, stripe_plan, entitlement_ladder, stable_user_id FROM users WHERE stable_user_id = ?`,
+		`SELECT id, username, email, plan, stripe_plan, stripe_price_id, entitlement_ladder, stable_user_id FROM users WHERE stable_user_id = ?`,
 	)
 		.bind(stableUserId)
 		.first<AdminUserUsageUserRow>()
@@ -117,6 +120,12 @@ export async function loadAdminUserUsageData(
 	const durableObjectUsage = currentMonthUsage.find(
 		(row) => row.metric === 'durable_object_gb_seconds',
 	)
+	const costVsPay = toAdminCostVsPay({
+		uniqueWorkerDays,
+		stripePlan: row.stripe_plan,
+		stripePriceId: row.stripe_price_id,
+		catalog: resolveStripePriceCatalog(env),
+	})
 
 	return {
 		ok: true,
@@ -134,6 +143,7 @@ export async function loadAdminUserUsageData(
 			durationMs: durableObjectUsage?.totalDurationMs ?? 0,
 			rpcCount: durableObjectUsage?.eventCount ?? 0,
 		}),
+		costVsPay,
 	}
 }
 

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -45,6 +45,7 @@ const fleetUsageMocks = vi.hoisted(() => ({
 			usdPerUniqueDay: 0.002,
 			includedPerAccountMonth: 1000,
 			topConsumers: [],
+			underwaterConsumers: [],
 		},
 	})),
 	loadFleetPackageErrorRateSnapshot: vi.fn(async () => null),
@@ -538,6 +539,7 @@ test('loadAdminInsightsData assembles the dashboard payload from D1 plus the Run
 		usdPerUniqueDay: 0.002,
 		includedPerAccountMonth: 1000,
 		topConsumers: [],
+		underwaterConsumers: [],
 	})
 })
 

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -1,8 +1,16 @@
 import { expect, test, vi } from 'vitest'
 import { consoleWarn } from '#worker/test-support/console-spies.ts'
 import { type RunLogAdminInsightsSnapshot } from '#worker/run-records/admin-insights-snapshot.ts'
+import { type AdminInsightsLaunchSignals } from '#universal/loader-data.ts'
 import {
-	adminInsightsRunLogConcurrency,
+	platformPublicOpenedAt,
+	platformPublicOpenedDay,
+} from '#universal/platform-open.ts'
+import {
+	adminInsightsRunLogSnapshotKvKey,
+	type AggregatedRunLogInsights,
+} from '#worker/admin/insights-runlog-snapshot.ts'
+import {
 	buildAuthDays,
 	buildEmailDays,
 	buildEmailDeliveryDays,
@@ -21,16 +29,8 @@ import {
 
 const now = new Date('2026-07-08T12:00:00.000Z')
 
-const runLogMocks = vi.hoisted(() => ({
-	getAdminInsightsSnapshot:
-		vi.fn<
-			(input: {
-				env: Env
-				userId: string
-			}) => Promise<RunLogAdminInsightsSnapshot>
-		>(),
-	inFlight: 0,
-	maxInFlight: 0,
+const launchSignalMocks = vi.hoisted(() => ({
+	loadAdminLaunchSignals: vi.fn(async () => emptyLaunchSignals()),
 }))
 
 const fleetUsageMocks = vi.hoisted(() => ({
@@ -50,6 +50,10 @@ const fleetUsageMocks = vi.hoisted(() => ({
 	loadFleetPackageErrorRateSnapshot: vi.fn(async () => null),
 }))
 
+vi.mock('#worker/admin/launch-signals.ts', () => ({
+	loadAdminLaunchSignals: launchSignalMocks.loadAdminLaunchSignals,
+}))
+
 vi.mock('#worker/admin/fleet-usage-insights.ts', () => ({
 	loadFleetUsageInsights: fleetUsageMocks.loadFleetUsageInsights,
 }))
@@ -59,10 +63,90 @@ vi.mock('#worker/usage/fleet-package-error-rate.ts', () => ({
 		fleetUsageMocks.loadFleetPackageErrorRateSnapshot,
 }))
 
-vi.mock('#worker/run-records/service.ts', () => ({
-	getAdminInsightsSnapshot: (input: { env: Env; userId: string }) =>
-		runLogMocks.getAdminInsightsSnapshot(input),
-}))
+function emptyLaunchSignals(): AdminInsightsLaunchSignals {
+	return {
+		openedAt: platformPublicOpenedAt,
+		openedDay: platformPublicOpenedDay,
+		mrrUsdCents: 0,
+		paidSubscribers: 0,
+		unpricedPaidSubscribers: 0,
+		paidSlices: [],
+		manualPlans: [],
+		stripePlans: [],
+		effectivePlans: [],
+		overlayStandard: 0,
+		entitlementLadders: { public: 0, legacy: 0 },
+		paidEntitlementLadders: { public: 0, legacy: 0 },
+		activeUsers: { hours24: 0, hours48: 0, days7: 0 },
+		activation: {
+			overall: [
+				{ step: 'signed_up', users: 0 },
+				{ step: 'email_verified', users: 0 },
+				{ step: 'first_mcp', users: 0 },
+				{ step: 'first_search', users: 0 },
+				{ step: 'first_execute', users: 0 },
+				{ step: 'first_saved_package', users: 0 },
+			],
+			sinceOpen: [
+				{ step: 'signed_up', users: 0 },
+				{ step: 'email_verified', users: 0 },
+				{ step: 'first_mcp', users: 0 },
+				{ step: 'first_search', users: 0 },
+				{ step: 'first_execute', users: 0 },
+				{ step: 'first_saved_package', users: 0 },
+			],
+		},
+		mcpClients: [],
+		openPlatformFeedback: 0,
+	}
+}
+
+function createMemoryKv(snapshot?: AggregatedRunLogInsights) {
+	const store = new Map<string, string>()
+	if (snapshot) {
+		store.set(
+			adminInsightsRunLogSnapshotKvKey,
+			JSON.stringify({ version: 1, ...snapshot }),
+		)
+	}
+	return {
+		async get<T>(key: string, type?: 'json' | 'text') {
+			const raw = store.get(key)
+			if (raw == null) return null
+			return type === 'json' ? (JSON.parse(raw) as T) : raw
+		},
+		async put(key: string, value: string) {
+			store.set(key, value)
+		},
+	} as unknown as KVNamespace
+}
+
+function emptySnapshot(): RunLogAdminInsightsSnapshot {
+	return {
+		workflowStatusCounts: [],
+		activationMilestones: [],
+		jobRunCounts: { success: 0, error: 0 },
+	}
+}
+
+function runLogSnapshot(
+	overrides: Partial<AggregatedRunLogInsights> = {},
+): AggregatedRunLogInsights {
+	return {
+		usersAttempted: 0,
+		usersLoaded: 0,
+		complete: true,
+		snapshotUpdatedAt: '2026-07-08T11:00:00.000Z',
+		workflowStatuses: [],
+		workflowRuns: 0,
+		jobSuccessRuns: 0,
+		jobErrorRuns: 0,
+		packageRunSucceededUsers: 0,
+		packageActivatedUsers: 0,
+		medianHoursToActivation: null,
+		...overrides,
+	}
+}
 
 test('admin insights date helpers bucket, zero-fill, and fold correctly', () => {
 	// 2026-07-08 is a Wednesday; 2026-07-06 is the Monday before.
@@ -194,33 +278,7 @@ function normalizeQuery(query: string) {
 	return query.replace(/\s+/g, ' ').trim().toLowerCase()
 }
 
-const defaultInsightsUsers = [
-	{
-		stable_user_id: 'user-a',
-		email_verified_at: '2026-07-01T00:00:00.000Z',
-	},
-	{
-		stable_user_id: 'user-b',
-		email_verified_at: '2026-07-02T00:00:00.000Z',
-	},
-]
-
-function emptySnapshot(): RunLogAdminInsightsSnapshot {
-	return {
-		workflowStatusCounts: [],
-		activationMilestones: [],
-		jobRunCounts: { success: 0, error: 0 },
-	}
-}
-
-function createInsightsTestDb(
-	overrides: {
-		insightsUsers?: Array<{
-			stable_user_id: string
-			email_verified_at: string | null
-		}>
-	} = {},
-) {
+function createInsightsTestDb() {
 	const seenQueries: Array<string> = []
 	const db = {
 		prepare(query: string) {
@@ -277,17 +335,6 @@ function createInsightsTestDb(
 					throw new Error(`Unsupported first query: ${query}`)
 				},
 				async all<T>() {
-					if (
-						normalizedQuery.includes(
-							'select stable_user_id, email_verified_at',
-						) &&
-						normalizedQuery.includes('deleting_at is null')
-					) {
-						return {
-							results: (overrides.insightsUsers ??
-								defaultInsightsUsers) as Array<T>,
-						}
-					}
 					if (
 						normalizedQuery.includes('from users') &&
 						normalizedQuery.includes('group by day')
@@ -366,63 +413,9 @@ function createInsightsTestDb(
 	return db
 }
 
-function stubSnapshotsByUser(
-	byUser: Record<string, RunLogAdminInsightsSnapshot | Error>,
-) {
-	runLogMocks.inFlight = 0
-	runLogMocks.maxInFlight = 0
-	runLogMocks.getAdminInsightsSnapshot.mockImplementation(
-		async (input: { userId: string }) => {
-			runLogMocks.inFlight += 1
-			runLogMocks.maxInFlight = Math.max(
-				runLogMocks.maxInFlight,
-				runLogMocks.inFlight,
-			)
-			await Promise.resolve()
-			runLogMocks.inFlight -= 1
-			const result = byUser[input.userId]
-			if (result instanceof Error) throw result
-			if (!result) throw new Error(`Unexpected snapshot user ${input.userId}`)
-			return result
-		},
-	)
-}
-
-test('loadAdminInsightsData assembles the dashboard payload from D1 plus RunLog snapshots', async () => {
+test('loadAdminInsightsData assembles the dashboard payload from D1 plus the RunLog snapshot', async () => {
 	consoleWarn.mockImplementation(() => {})
 	consoleWarn.mockClear()
-	stubSnapshotsByUser({
-		'user-a': {
-			workflowStatusCounts: [
-				{ status: 'complete', count: 5 },
-				{ status: 'errored', count: 1 },
-			],
-			jobRunCounts: { success: 12, error: 2 },
-			activationMilestones: [
-				{
-					milestone: 'package_run_succeeded',
-					reachedAt: '2026-07-02T12:00:00.000Z',
-					packageId: 'pkg-a',
-				},
-				{
-					milestone: 'package_activated',
-					reachedAt: '2026-07-02T12:00:00.000Z',
-					packageId: 'pkg-a',
-				},
-			],
-		},
-		'user-b': {
-			workflowStatusCounts: [{ status: 'complete', count: 3 }],
-			jobRunCounts: { success: 8, error: 0 },
-			activationMilestones: [
-				{
-					milestone: 'package_run_succeeded',
-					reachedAt: '2026-07-03T00:00:00.000Z',
-					packageId: 'pkg-b',
-				},
-			],
-		},
-	})
 	const db = createInsightsTestDb()
 	const data = await loadAdminInsightsData(
 		{
@@ -430,6 +423,23 @@ test('loadAdminInsightsData assembles the dashboard payload from D1 plus RunLog 
 			AUDIT_DB: db,
 			EMAIL_EVENTS: {} as AnalyticsEngineDataset,
 			WRANGLER_IS_LOCAL_DEV: 'true',
+			BUNDLE_ARTIFACTS_KV: createMemoryKv(
+				runLogSnapshot({
+					usersAttempted: 2,
+					usersLoaded: 2,
+					complete: true,
+					workflowStatuses: [
+						{ status: 'complete', count: 8 },
+						{ status: 'errored', count: 1 },
+					],
+					workflowRuns: 9,
+					jobSuccessRuns: 20,
+					jobErrorRuns: 2,
+					packageRunSucceededUsers: 2,
+					packageActivatedUsers: 1,
+					medianHoursToActivation: 36,
+				}),
+			),
 		} as Env,
 		now,
 	)
@@ -519,7 +529,9 @@ test('loadAdminInsightsData assembles the dashboard payload from D1 plus RunLog 
 		usersAttempted: 2,
 		usersLoaded: 2,
 		complete: true,
+		snapshotUpdatedAt: '2026-07-08T11:00:00.000Z',
 	})
+	expect(data.launchSignals.openedDay).toBe(platformPublicOpenedDay)
 	expect(data.dynamicWorkerCost).toEqual({
 		uniqueWorkerDays: 0,
 		estimatedGrossUsd: 0,
@@ -527,10 +539,6 @@ test('loadAdminInsightsData assembles the dashboard payload from D1 plus RunLog 
 		includedPerAccountMonth: 1000,
 		topConsumers: [],
 	})
-	expect(runLogMocks.getAdminInsightsSnapshot).toHaveBeenCalledTimes(2)
-	expect(runLogMocks.maxInFlight).toBeLessThanOrEqual(
-		adminInsightsRunLogConcurrency,
-	)
 })
 
 test('multi-user RunLog aggregation sums workflow statuses and milestone users', () => {
@@ -601,111 +609,7 @@ test('multi-user RunLog aggregation sums workflow statuses and milestone users',
 	expect(folded.complete).toBe(false)
 })
 
-test('loadAdminInsightsData enumerates only non-deleting users for RunLog reads', async () => {
-	consoleWarn.mockImplementation(() => {})
-	stubSnapshotsByUser({
-		'user-live': emptySnapshot(),
-	})
-	const db = createInsightsTestDb({
-		insightsUsers: [
-			{
-				stable_user_id: 'user-live',
-				email_verified_at: '2026-07-01T00:00:00.000Z',
-			},
-		],
-	})
-	await loadAdminInsightsData(
-		{
-			APP_DB: db,
-			AUDIT_DB: db,
-			WRANGLER_IS_LOCAL_DEV: 'true',
-		} as Env,
-		now,
-	)
-
-	const userListQuery = db.seenQueries.find((query) =>
-		normalizeQuery(query).includes('deleting_at is null'),
-	)
-	expect(userListQuery).toBeTruthy()
-	expect(normalizeQuery(userListQuery ?? '')).toContain('deleting_at is null')
-	expect(runLogMocks.getAdminInsightsSnapshot).toHaveBeenCalledTimes(1)
-	expect(runLogMocks.getAdminInsightsSnapshot).toHaveBeenCalledWith(
-		expect.objectContaining({ userId: 'user-live' }),
-	)
-	expect(runLogMocks.getAdminInsightsSnapshot).not.toHaveBeenCalledWith(
-		expect.objectContaining({ userId: 'user-deleting' }),
-	)
-})
-
-test('activation latency uses package_activated reachedAt against D1 email_verified_at', async () => {
-	consoleWarn.mockImplementation(() => {})
-	stubSnapshotsByUser({
-		'user-a': {
-			workflowStatusCounts: [],
-			jobRunCounts: { success: 0, error: 0 },
-			activationMilestones: [
-				{
-					milestone: 'package_activated',
-					reachedAt: '2026-07-03T00:00:00.000Z',
-					packageId: 'pkg-a',
-				},
-			],
-		},
-		'user-b': {
-			workflowStatusCounts: [],
-			jobRunCounts: { success: 0, error: 0 },
-			activationMilestones: [
-				{
-					milestone: 'package_activated',
-					// Before verification — excluded from latency, still counts as activated.
-					reachedAt: '2026-07-01T00:00:00.000Z',
-					packageId: 'pkg-b',
-				},
-			],
-		},
-		'user-c': {
-			workflowStatusCounts: [],
-			jobRunCounts: { success: 0, error: 0 },
-			activationMilestones: [
-				{
-					milestone: 'package_activated',
-					reachedAt: '2026-07-05T00:00:00.000Z',
-					packageId: 'pkg-c',
-				},
-			],
-		},
-	})
-	const db = createInsightsTestDb({
-		insightsUsers: [
-			{
-				stable_user_id: 'user-a',
-				email_verified_at: '2026-07-01T00:00:00.000Z',
-			},
-			{
-				stable_user_id: 'user-b',
-				email_verified_at: '2026-07-02T00:00:00.000Z',
-			},
-			{
-				stable_user_id: 'user-c',
-				email_verified_at: null,
-			},
-		],
-	})
-	const data = await loadAdminInsightsData(
-		{
-			APP_DB: db,
-			AUDIT_DB: db,
-			WRANGLER_IS_LOCAL_DEV: 'true',
-		} as Env,
-		now,
-	)
-
-	expect(data.activation.steps.at(-1)).toEqual({
-		step: 'package_activated',
-		users: 3,
-	})
-	// Only user-a contributes: 48 hours. user-b negative; user-c unverified.
-	expect(data.activation.medianHoursToActivation).toBe(48)
+test('activation latency helper excludes unverified and pre-verify activations', () => {
 	expect(
 		hoursFromVerifiedToActivation(
 			'2026-07-01T00:00:00.000Z',
@@ -723,13 +627,9 @@ test('activation latency uses package_activated reachedAt against D1 email_verif
 	).toBeNull()
 })
 
-test('degraded RunLog snapshots warn and zero run-derived charts without failing the page', async () => {
+test('a missing RunLog snapshot zeros run-derived charts without failing the page', async () => {
 	consoleWarn.mockImplementation(() => {})
 	consoleWarn.mockClear()
-	stubSnapshotsByUser({
-		'user-a': new Error('RUN_LOG Durable Object binding is not configured.'),
-		'user-b': new Error('rpc failed'),
-	})
 	const db = createInsightsTestDb()
 	const data = await loadAdminInsightsData(
 		{
@@ -764,61 +664,34 @@ test('degraded RunLog snapshots warn and zero run-derived charts without failing
 		unknown: 4,
 	})
 	expect(data.runLogCompleteness).toEqual({
-		usersAttempted: 2,
+		usersAttempted: 0,
 		usersLoaded: 0,
 		complete: false,
+		snapshotUpdatedAt: null,
 	})
-	expect(consoleWarn).toHaveBeenCalledWith(
-		'admin-insights-run-log-unavailable',
-		expect.objectContaining({
-			userId: 'user-a',
-			error: expect.any(Error),
-		}),
-	)
-	expect(consoleWarn).toHaveBeenCalledWith(
-		'admin-insights-run-log-unavailable',
-		expect.objectContaining({
-			userId: 'user-b',
-			error: expect.any(Error),
-		}),
-	)
 })
 
-test('admin insights uses content-free getAdminInsightsSnapshot point reads only', async () => {
+test('admin insights RunLog snapshot stays content-free', async () => {
 	consoleWarn.mockImplementation(() => {})
-	const snapshot: RunLogAdminInsightsSnapshot = {
-		workflowStatusCounts: [{ status: 'complete', count: 1 }],
-		jobRunCounts: { success: 2, error: 1 },
-		activationMilestones: [
-			{
-				milestone: 'package_run_succeeded',
-				reachedAt: '2026-07-02T00:00:00.000Z',
-				packageId: 'opaque-pkg',
-			},
-		],
-	}
-	stubSnapshotsByUser({
-		'user-a': snapshot,
-		'user-b': emptySnapshot(),
-	})
 	const db = createInsightsTestDb()
 	const data = await loadAdminInsightsData(
 		{
 			APP_DB: db,
 			AUDIT_DB: db,
 			WRANGLER_IS_LOCAL_DEV: 'true',
+			BUNDLE_ARTIFACTS_KV: createMemoryKv(
+				runLogSnapshot({
+					workflowStatuses: [{ status: 'complete', count: 1 }],
+					workflowRuns: 1,
+					jobSuccessRuns: 2,
+					jobErrorRuns: 1,
+					packageRunSucceededUsers: 1,
+				}),
+			),
 		} as Env,
 		now,
 	)
 
-	expect(runLogMocks.getAdminInsightsSnapshot).toHaveBeenCalledTimes(2)
-	for (const call of runLogMocks.getAdminInsightsSnapshot.mock.calls) {
-		expect(Object.keys(call[0] ?? {})).toEqual(
-			expect.arrayContaining(['env', 'userId']),
-		)
-		expect(call[0]).not.toHaveProperty('includeContent')
-		expect(call[0]).not.toHaveProperty('includeLogs')
-	}
 	const serialized = JSON.stringify(data)
 	expect(serialized).not.toContain('opaque-pkg')
 	expect(serialized).not.toMatch(/workflowName|lastError|errorMessage/)
@@ -836,10 +709,6 @@ test('admin insights uses content-free getAdminInsightsSnapshot point reads only
 
 test('admin insights surfaces the fleet package error-rate snapshot', async () => {
 	consoleWarn.mockImplementation(() => {})
-	stubSnapshotsByUser({
-		'user-a': emptySnapshot(),
-		'user-b': emptySnapshot(),
-	})
 	fleetUsageMocks.loadFleetPackageErrorRateSnapshot.mockResolvedValueOnce({
 		version: 1,
 		updatedAt: '2026-08-22T19:32:00.000Z',
@@ -928,10 +797,6 @@ test('admin insights surfaces the fleet package error-rate snapshot', async () =
 test('loadAdminInsightsData warns when EMAIL_EVENTS binding is missing', async () => {
 	consoleWarn.mockImplementation(() => {})
 	consoleWarn.mockClear()
-	stubSnapshotsByUser({
-		'user-a': emptySnapshot(),
-		'user-b': emptySnapshot(),
-	})
 	const db = createInsightsTestDb()
 	const data = await loadAdminInsightsData(
 		{ APP_DB: db, AUDIT_DB: db } as Env,
@@ -950,10 +815,6 @@ test('loadAdminInsightsData warns when EMAIL_EVENTS binding is missing', async (
 })
 
 test('admin insights reads email reporting from Analytics Engine and degrades when it is unavailable', async () => {
-	stubSnapshotsByUser({
-		'user-a': emptySnapshot(),
-		'user-b': emptySnapshot(),
-	})
 	const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
 		Response.json({
 			data: [
@@ -1050,15 +911,15 @@ test('foldRunLogSnapshots reports complete fanout when every snapshot loads', ()
 	})
 })
 
-test('loadAdminInsightsData treats a zero-user fleet as complete run-log fanout', async () => {
+test('loadAdminInsightsData treats an empty complete snapshot as finished RunLog totals', async () => {
 	consoleWarn.mockImplementation(() => {})
-	stubSnapshotsByUser({})
-	const db = createInsightsTestDb({ insightsUsers: [] })
+	const db = createInsightsTestDb()
 	const data = await loadAdminInsightsData(
 		{
 			APP_DB: db,
 			AUDIT_DB: db,
 			WRANGLER_IS_LOCAL_DEV: 'true',
+			BUNDLE_ARTIFACTS_KV: createMemoryKv(runLogSnapshot()),
 		} as Env,
 		now,
 	)
@@ -1067,22 +928,25 @@ test('loadAdminInsightsData treats a zero-user fleet as complete run-log fanout'
 		usersAttempted: 0,
 		usersLoaded: 0,
 		complete: true,
+		snapshotUpdatedAt: '2026-07-08T11:00:00.000Z',
 	})
-	expect(runLogMocks.getAdminInsightsSnapshot).not.toHaveBeenCalled()
 })
 
 test('loadAdminInsightsData JSON exposes runLogCompleteness without user content', async () => {
 	consoleWarn.mockImplementation(() => {})
-	stubSnapshotsByUser({
-		'user-a': emptySnapshot(),
-		'user-b': new Error('rpc failed'),
-	})
 	const db = createInsightsTestDb()
 	const data = await loadAdminInsightsData(
 		{
 			APP_DB: db,
 			AUDIT_DB: db,
 			WRANGLER_IS_LOCAL_DEV: 'true',
+			BUNDLE_ARTIFACTS_KV: createMemoryKv(
+				runLogSnapshot({
+					usersAttempted: 2,
+					usersLoaded: 1,
+					complete: false,
+				}),
+			),
 		} as Env,
 		now,
 	)
@@ -1092,9 +956,11 @@ test('loadAdminInsightsData JSON exposes runLogCompleteness without user content
 		usersAttempted: 2,
 		usersLoaded: 1,
 		complete: false,
+		snapshotUpdatedAt: '2026-07-08T11:00:00.000Z',
 	})
 	expect(Object.keys(parsed.runLogCompleteness).sort()).toEqual([
 		'complete',
+		'snapshotUpdatedAt',
 		'usersAttempted',
 		'usersLoaded',
 	])

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -6,10 +6,13 @@ import {
 } from '@kody-internal/shared/date-keys.ts'
 import { createKvCachifiedCache } from '#worker/kv-cachified.ts'
 import { jobsData } from '#worker/jobs/jobs-data.ts'
+import { loadAdminLaunchSignals } from '#worker/admin/launch-signals.ts'
+import {
+	readAdminInsightsRunLogSnapshot,
+	type AggregatedRunLogInsights,
+} from '#worker/admin/insights-runlog-snapshot.ts'
 import { adminUsageMetrics } from '#worker/admin/user-usage-data.ts'
 import { loadFleetUsageInsights } from '#worker/admin/fleet-usage-insights.ts'
-import { type RunLogAdminInsightsSnapshot } from '#worker/run-records/admin-insights-snapshot.ts'
-import { getAdminInsightsSnapshot } from '#worker/run-records/service.ts'
 import { queryAnalyticsEngineSql } from '#worker/usage/aggregate-rollups.ts'
 import { loadFleetPackageErrorRateSnapshot } from '#worker/usage/fleet-package-error-rate.ts'
 import {
@@ -24,11 +27,9 @@ import {
 	type AdminInsightsLoaderData,
 	type AdminInsightsPackageErrorRate,
 	type AdminInsightsPlanSlice,
-	type AdminInsightsRunLogCompleteness,
 	type AdminInsightsSignupWeek,
 	type AdminInsightsTotals,
 	type AdminInsightsUsageMonth,
-	type AdminInsightsWorkflowStatus,
 	type AdminUsageMetric,
 } from '#universal/loader-data.ts'
 
@@ -36,11 +37,12 @@ export const adminInsightsSignupWeeks = 12
 export const adminInsightsUsageMonths = 12
 export const adminInsightsActivityDays = 28
 
-/**
- * Per-user RunLog point-reads for workflow/activation aggregates. Bound so a
- * large user table cannot open unbounded DO RPCs on one admin page load.
- */
-export const adminInsightsRunLogConcurrency = 8
+export {
+	adminInsightsRunLogConcurrency,
+	foldRunLogSnapshots,
+	hoursFromVerifiedToActivation,
+	medianOf,
+} from '#worker/admin/insights-runlog-snapshot.ts'
 
 /**
  * The dashboard is a platform-wide read model over many tables, so a short
@@ -50,7 +52,6 @@ export const adminInsightsRunLogConcurrency = 8
 const insightsCacheTtlMs = 5 * 60 * 1000
 
 const dayMs = 24 * 60 * 60 * 1000
-const hourMs = 60 * 60 * 1000
 
 type CountRow = { n: number }
 type DayCountRow = { day: string; n: number }
@@ -73,26 +74,6 @@ type AuthDayRow = { day: string; result: string; n: number }
 type AuthCategoryRow = { category: string; n: number }
 type HeatmapRow = { day: string; hour: string; n: number }
 type ForkActorRow = { actor: string | null; n: number }
-type InsightsUserRow = {
-	stable_user_id: string
-	email_verified_at: string | null
-}
-
-type AggregatedRunLogInsights = AdminInsightsRunLogCompleteness & {
-	workflowStatuses: Array<AdminInsightsWorkflowStatus>
-	workflowRuns: number
-	jobSuccessRuns: number
-	jobErrorRuns: number
-	packageRunSucceededUsers: number
-	packageActivatedUsers: number
-	medianHoursToActivation: number | null
-}
-
-const completeRunLogInsights: AdminInsightsRunLogCompleteness = {
-	usersAttempted: 0,
-	usersLoaded: 0,
-	complete: true,
-}
 
 export async function loadAdminInsightsData(
 	env: Env,
@@ -105,7 +86,7 @@ export async function loadAdminInsightsData(
 		: null
 	if (!cache) return await queryAdminInsights(env, now)
 	return await cachified({
-		key: 'admin-insights:v8',
+		key: 'admin-insights:v9',
 		cache,
 		ttl: insightsCacheTtlMs,
 		getFreshValue: () => queryAdminInsights(env, now),
@@ -146,7 +127,8 @@ async function queryAdminInsights(
 		authCategoryRows,
 		heatmapRows,
 		activationBase,
-		insightsUsers,
+		launchSignals,
+		runLogInsights,
 	] = await Promise.all([
 		queryTotals(db),
 		jobsData(env).getJobInsights(),
@@ -213,13 +195,9 @@ async function queryAdminInsights(
 			.bind(dayCutoff)
 			.all<HeatmapRow>(),
 		queryActivationBase(db),
-		listNonDeletingInsightsUsers(db),
+		loadAdminLaunchSignals({ db, env, now }),
+		readAdminInsightsRunLogSnapshot(env.BUNDLE_ARTIFACTS_KV),
 	])
-
-	const runLogInsights = await aggregateRunLogInsights({
-		env,
-		users: insightsUsers,
-	})
 
 	const [fleetUsage, packageErrorRateSnapshot] = await Promise.all([
 		loadFleetUsageInsights({ db, env, now }),
@@ -282,10 +260,12 @@ async function queryAdminInsights(
 		workflowStatuses: runLogInsights.workflowStatuses,
 		jobHealth,
 		activation: mergeActivation(activationBase, runLogInsights),
+		launchSignals,
 		runLogCompleteness: {
 			usersAttempted: runLogInsights.usersAttempted,
 			usersLoaded: runLogInsights.usersLoaded,
 			complete: runLogInsights.complete,
+			snapshotUpdatedAt: runLogInsights.snapshotUpdatedAt,
 		},
 		topRuntimeDurationConsumers: fleetUsage.topRuntimeDurationConsumers,
 		topEventCountConsumers: fleetUsage.topEventCountConsumers,
@@ -485,7 +465,12 @@ async function queryActivationBase(db: D1Database): Promise<{
 
 function mergeActivation(
 	base: Awaited<ReturnType<typeof queryActivationBase>>,
-	runLog: AggregatedRunLogInsights,
+	runLog: Pick<
+		AggregatedRunLogInsights,
+		| 'packageRunSucceededUsers'
+		| 'packageActivatedUsers'
+		| 'medianHoursToActivation'
+	>,
 ): AdminInsightsActivation {
 	return {
 		steps: [
@@ -502,186 +487,6 @@ function mergeActivation(
 		forksByActor: base.forksByActor,
 		medianHoursToActivation: runLog.medianHoursToActivation,
 	}
-}
-
-async function listNonDeletingInsightsUsers(
-	db: D1Database,
-): Promise<Array<InsightsUserRow>> {
-	const rows = await db
-		.prepare(
-			`SELECT stable_user_id, email_verified_at
-			 FROM users
-			 WHERE deleting_at IS NULL
-			   AND stable_user_id IS NOT NULL`,
-		)
-		.all<InsightsUserRow>()
-	return (rows.results ?? []).filter(
-		(row) =>
-			typeof row.stable_user_id === 'string' && row.stable_user_id !== '',
-	)
-}
-
-async function aggregateRunLogInsights(input: {
-	env: Env
-	users: ReadonlyArray<InsightsUserRow>
-}): Promise<AggregatedRunLogInsights> {
-	const empty: AggregatedRunLogInsights = {
-		...completeRunLogInsights,
-		workflowStatuses: [],
-		workflowRuns: 0,
-		jobSuccessRuns: 0,
-		jobErrorRuns: 0,
-		packageRunSucceededUsers: 0,
-		packageActivatedUsers: 0,
-		medianHoursToActivation: null,
-	}
-	if (input.users.length === 0) return empty
-
-	const snapshots = await mapWithConcurrency(
-		input.users,
-		adminInsightsRunLogConcurrency,
-		async (user) => {
-			try {
-				const snapshot = await getAdminInsightsSnapshot({
-					env: input.env,
-					userId: user.stable_user_id,
-				})
-				return { user, snapshot }
-			} catch (error) {
-				// Missing RUN_LOG or a single-user RPC failure must not take down
-				// the admin page — degrade run-derived charts for that user only.
-				console.warn('admin-insights-run-log-unavailable', {
-					userId: user.stable_user_id,
-					error,
-				})
-				return { user, snapshot: null }
-			}
-		},
-	)
-
-	return foldRunLogSnapshots(snapshots)
-}
-
-export function foldRunLogSnapshots(
-	entries: ReadonlyArray<{
-		user: InsightsUserRow
-		snapshot: RunLogAdminInsightsSnapshot | null
-	}>,
-): AggregatedRunLogInsights {
-	const usersAttempted = entries.length
-	let usersLoaded = 0
-	const statusCounts = new Map<string, number>()
-	let workflowRuns = 0
-	let jobSuccessRuns = 0
-	let jobErrorRuns = 0
-	let packageRunSucceededUsers = 0
-	let packageActivatedUsers = 0
-	const activationHours: Array<number> = []
-
-	for (const { user, snapshot } of entries) {
-		if (!snapshot) continue
-		usersLoaded += 1
-		for (const row of snapshot.workflowStatusCounts) {
-			const count = Number(row.count) || 0
-			if (count <= 0) continue
-			const status = row.status.trim() || 'unknown'
-			statusCounts.set(status, (statusCounts.get(status) ?? 0) + count)
-			workflowRuns += count
-		}
-		jobSuccessRuns += Math.max(0, Number(snapshot.jobRunCounts.success) || 0)
-		jobErrorRuns += Math.max(0, Number(snapshot.jobRunCounts.error) || 0)
-		let hasRunSucceeded = false
-		let activatedReachedAt: string | null = null
-		for (const milestone of snapshot.activationMilestones) {
-			if (milestone.milestone === 'package_run_succeeded') {
-				hasRunSucceeded = true
-			} else if (milestone.milestone === 'package_activated') {
-				activatedReachedAt = milestone.reachedAt
-			}
-		}
-		if (hasRunSucceeded) packageRunSucceededUsers += 1
-		if (activatedReachedAt != null) {
-			packageActivatedUsers += 1
-			const hours = hoursFromVerifiedToActivation(
-				user.email_verified_at,
-				activatedReachedAt,
-			)
-			if (hours != null) activationHours.push(hours)
-		}
-	}
-
-	activationHours.sort((left, right) => left - right)
-
-	return {
-		usersAttempted,
-		usersLoaded,
-		complete: usersLoaded === usersAttempted,
-		workflowStatuses: Array.from(statusCounts.entries())
-			.map(([status, count]) => ({ status, count }))
-			.sort(
-				(left, right) =>
-					right.count - left.count || left.status.localeCompare(right.status),
-			),
-		workflowRuns,
-		jobSuccessRuns,
-		jobErrorRuns,
-		packageRunSucceededUsers,
-		packageActivatedUsers,
-		medianHoursToActivation: medianOf(activationHours),
-	}
-}
-
-/**
- * Hours from email verification to package activation. Users who activated
- * before verifying (seeded / admin-created) would skew the median negative, so
- * they are excluded rather than clamped.
- */
-export function hoursFromVerifiedToActivation(
-	emailVerifiedAt: string | null | undefined,
-	activatedReachedAt: string,
-): number | null {
-	if (emailVerifiedAt == null || emailVerifiedAt === '') return null
-	const verifiedMs = Date.parse(emailVerifiedAt)
-	const activatedMs = Date.parse(activatedReachedAt)
-	if (!Number.isFinite(verifiedMs) || !Number.isFinite(activatedMs)) return null
-	const hours = (activatedMs - verifiedMs) / hourMs
-	if (!Number.isFinite(hours) || hours < 0) return null
-	return hours
-}
-
-async function mapWithConcurrency<T, R>(
-	items: ReadonlyArray<T>,
-	concurrency: number,
-	mapper: (item: T) => Promise<R>,
-): Promise<Array<R>> {
-	if (items.length === 0) return []
-	const limit = Math.max(1, Math.min(concurrency, items.length))
-	const results: Array<R | undefined> = Array.from({ length: items.length })
-	let nextIndex = 0
-	await Promise.all(
-		Array.from({ length: limit }, async () => {
-			while (nextIndex < items.length) {
-				const index = nextIndex
-				nextIndex += 1
-				const item = items[index]
-				if (item === undefined) return
-				results[index] = await mapper(item)
-			}
-		}),
-	)
-	return results as Array<R>
-}
-
-/** Median of an ascending list. Even-length lists average the middle pair. */
-export function medianOf(sortedValues: Array<number>): number | null {
-	const values = sortedValues.filter((value) => Number.isFinite(value))
-	if (values.length === 0) return null
-	const middle = Math.floor(values.length / 2)
-	if (values.length % 2 === 1) return values[middle] ?? null
-	const lower = values[middle - 1]
-	const upper = values[middle]
-	if (lower == null || upper == null) return null
-	return (lower + upper) / 2
 }
 
 async function queryTotals(

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -86,7 +86,7 @@ export async function loadAdminInsightsData(
 		: null
 	if (!cache) return await queryAdminInsights(env, now)
 	return await cachified({
-		key: 'admin-insights:v9',
+		key: 'admin-insights:v10',
 		cache,
 		ttl: insightsCacheTtlMs,
 		getFreshValue: () => queryAdminInsights(env, now),

--- a/packages/worker/src/billing/billing-config.ts
+++ b/packages/worker/src/billing/billing-config.ts
@@ -6,7 +6,7 @@ import {
 } from '#universal/plans.ts'
 import { type StripeSubscription } from './stripe-client.ts'
 
-type BillingEnv = {
+export type BillingEnv = {
 	STRIPE_SECRET_KEY?: string
 	STRIPE_STANDARD_PRICE_ID?: string
 	STRIPE_STANDARD_YEARLY_PRICE_ID?: string
@@ -57,8 +57,10 @@ export function subscriptionHasPrice(
  * standard/pro so existing subscriptions do not drop to free.
  * Standard $5 (`price_1Tv3W2…`) has one customer through 2026-09-08.
  */
-const retiredStandardPriceIds = ['price_1Tv3W2LAQpAnsYszSr4PGBkE'] as const
-const retiredProPriceIds = [
+export const retiredStandardPriceIds = [
+	'price_1Tv3W2LAQpAnsYszSr4PGBkE',
+] as const
+export const retiredProPriceIds = [
 	'price_1U1AISLAQpAnsYszIQvRJNhl',
 	'price_1U3sg6LAQpAnsYszlVpEIFGx',
 	'price_1U3sg7LAQpAnsYszpozAEFUi',

--- a/packages/worker/src/billing/stripe-price-catalog.node.test.ts
+++ b/packages/worker/src/billing/stripe-price-catalog.node.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest'
+import {
+	retiredProPriceIds,
+	retiredStandardPriceIds,
+} from './billing-config.ts'
+import {
+	monthlyRecurringRevenueUsdCents,
+	resolveStripePriceCatalog,
+} from './stripe-price-catalog.ts'
+
+test('resolveStripePriceCatalog maps public and retired prices to monthly-equivalent MRR', () => {
+	const catalog = resolveStripePriceCatalog({
+		STRIPE_STANDARD_PRICE_ID: 'price_standard',
+		STRIPE_STANDARD_YEARLY_PRICE_ID: 'price_standard_yearly',
+		STRIPE_PRO_PRICE_ID: 'price_pro',
+		STRIPE_PRO_YEARLY_PRICE_ID: 'price_pro_yearly',
+	})
+
+	expect(monthlyRecurringRevenueUsdCents(catalog.get('price_standard')!)).toBe(
+		1_200,
+	)
+	expect(
+		monthlyRecurringRevenueUsdCents(catalog.get('price_standard_yearly')!),
+	).toBe(1_000)
+	expect(monthlyRecurringRevenueUsdCents(catalog.get('price_pro')!)).toBe(4_900)
+	expect(
+		monthlyRecurringRevenueUsdCents(catalog.get('price_pro_yearly')!),
+	).toBe(4_000)
+	expect(
+		monthlyRecurringRevenueUsdCents(catalog.get(retiredStandardPriceIds[0])!),
+	).toBe(500)
+	expect(
+		monthlyRecurringRevenueUsdCents(catalog.get(retiredProPriceIds[0])!),
+	).toBe(2_000)
+	expect(
+		monthlyRecurringRevenueUsdCents(catalog.get(retiredProPriceIds[1])!),
+	).toBe(2_900)
+	expect(
+		monthlyRecurringRevenueUsdCents(catalog.get(retiredProPriceIds[2])!),
+	).toBe(2_400)
+	expect(catalog.has('price_unknown')).toBe(false)
+})

--- a/packages/worker/src/billing/stripe-price-catalog.ts
+++ b/packages/worker/src/billing/stripe-price-catalog.ts
@@ -1,0 +1,120 @@
+/**
+ * Known Stripe list prices for admin MRR. Checkout amounts live here so
+ * insights can turn `users.stripe_price_id` into monthly-equivalent revenue
+ * without calling Stripe on the request path.
+ */
+
+import {
+	getProPriceId,
+	getProYearlyPriceId,
+	getStandardPriceId,
+	getStandardYearlyPriceId,
+	retiredProPriceIds,
+	retiredStandardPriceIds,
+	type BillingInterval,
+	type BillingEnv,
+	type PurchasablePlan,
+} from './billing-config.ts'
+
+export type StripePriceCatalogEntry = {
+	priceId: string
+	plan: PurchasablePlan
+	interval: BillingInterval
+	/** Recurring list price in USD cents for `interval`. */
+	amountUsdCents: number
+}
+
+const publicStandardMonthlyUsdCents = 1_200
+const publicStandardYearlyUsdCents = 12_000
+const publicProMonthlyUsdCents = 4_900
+const publicProYearlyUsdCents = 48_000
+
+const retiredPriceCatalog: ReadonlyArray<StripePriceCatalogEntry> = [
+	{
+		priceId: retiredStandardPriceIds[0],
+		plan: 'standard',
+		interval: 'month',
+		amountUsdCents: 500,
+	},
+	{
+		priceId: retiredProPriceIds[0],
+		plan: 'pro',
+		interval: 'month',
+		amountUsdCents: 2_000,
+	},
+	{
+		priceId: retiredProPriceIds[1],
+		plan: 'pro',
+		interval: 'month',
+		amountUsdCents: 2_900,
+	},
+	{
+		priceId: retiredProPriceIds[2],
+		plan: 'pro',
+		interval: 'year',
+		amountUsdCents: 28_800,
+	},
+]
+
+export function monthlyRecurringRevenueUsdCents(
+	entry: StripePriceCatalogEntry,
+): number {
+	switch (entry.interval) {
+		case 'month':
+			return entry.amountUsdCents
+		case 'year':
+			return Math.round(entry.amountUsdCents / 12)
+		default: {
+			const exhaustive: never = entry.interval
+			throw new Error(`Unknown billing interval: ${String(exhaustive)}`)
+		}
+	}
+}
+
+function addCatalogEntry(
+	byPriceId: Map<string, StripePriceCatalogEntry>,
+	entry: StripePriceCatalogEntry,
+) {
+	const priceId = entry.priceId.trim()
+	if (!priceId) return
+	byPriceId.set(priceId, { ...entry, priceId })
+}
+
+/**
+ * Map configured plus retired Standard/Pro price ids to list price and
+ * interval. Unknown ids (metadata-only grants) are absent so MRR can skip
+ * them instead of inventing a number.
+ */
+export function resolveStripePriceCatalog(
+	env: BillingEnv,
+): Map<string, StripePriceCatalogEntry> {
+	const byPriceId = new Map<string, StripePriceCatalogEntry>()
+	for (const entry of retiredPriceCatalog) {
+		addCatalogEntry(byPriceId, entry)
+	}
+	addCatalogEntry(byPriceId, {
+		priceId: getStandardPriceId(env) ?? '',
+		plan: 'standard',
+		interval: 'month',
+		amountUsdCents: publicStandardMonthlyUsdCents,
+	})
+	addCatalogEntry(byPriceId, {
+		priceId: getStandardYearlyPriceId(env) ?? '',
+		plan: 'standard',
+		interval: 'year',
+		amountUsdCents: publicStandardYearlyUsdCents,
+	})
+	addCatalogEntry(byPriceId, {
+		priceId: getProPriceId(env) ?? '',
+		plan: 'pro',
+		interval: 'month',
+		amountUsdCents: publicProMonthlyUsdCents,
+	})
+	addCatalogEntry(byPriceId, {
+		priceId: getProYearlyPriceId(env) ?? '',
+		plan: 'pro',
+		interval: 'year',
+		amountUsdCents: publicProYearlyUsdCents,
+	})
+	return byPriceId
+}

--- a/packages/worker/src/index.workers.test.ts
+++ b/packages/worker/src/index.workers.test.ts
@@ -20,6 +20,15 @@ const mocks = vi.hoisted(() => ({
 		count: 0,
 	})),
 	aggregateUsageRollups: vi.fn(async () => ({ skipped: true })),
+	refreshAdminInsightsRunLogSnapshot: vi.fn(async () => ({
+		complete: true,
+		snapshotUpdatedAt: '2026-09-10T00:00:00.000Z',
+		usersWithRunLog: 0,
+		usersMissingRunLog: 0,
+		runs: 0,
+		medianRunDurationMs: null,
+		hours: [],
+	})),
 	backfillStorageBucketEstimates: vi.fn(async () => ({
 		scanned: 0,
 		updated: 0,
@@ -63,6 +72,10 @@ vi.mock('#app/auth-denial-alerts.ts', () => ({
 
 vi.mock('#worker/usage/aggregate-rollups.ts', () => ({
 	aggregateUsageRollups: mocks.aggregateUsageRollups,
+}))
+
+vi.mock('#worker/admin/insights-runlog-snapshot.ts', () => ({
+	refreshAdminInsightsRunLogSnapshot: mocks.refreshAdminInsightsRunLogSnapshot,
 }))
 
 vi.mock('#worker/storage-buckets/estimate-backfill.ts', () => ({
@@ -123,6 +136,9 @@ test('platform lanes execute with their expected inputs and jobs-owned lanes are
 		expect.objectContaining({ blobs: env.EMAIL_BLOBS }),
 	)
 	expect(mocks.aggregateUsageRollups).toHaveBeenCalledWith(env, scheduledAt)
+	expect(mocks.refreshAdminInsightsRunLogSnapshot).toHaveBeenCalledWith(
+		expect.objectContaining({ now: scheduledAt }),
+	)
 	expect(mocks.checkAuthDenialBurstAndNotify).toHaveBeenCalledWith(
 		expect.objectContaining({ now: scheduledAt }),
 	)

--- a/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-capabilities.node.test.ts
@@ -236,7 +236,7 @@ function createAdminCapabilityTestDb(input: {
 					}
 					if (
 						normalizedQuery.includes(
-							'select id, username, email, plan, stripe_plan, entitlement_ladder, stable_user_id from users where stable_user_id = ?',
+							'select id, username, email, plan, stripe_plan, stripe_price_id, entitlement_ladder, stable_user_id from users where stable_user_id = ?',
 						)
 					) {
 						const user = users.find((row) => row.stable_user_id === params[0])

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
@@ -99,6 +99,16 @@ const outputSchema = z.object({
 				usdPerUniqueDay: z.number().nonnegative(),
 				includedPerAccountMonth: z.number().int().nonnegative(),
 			}),
+			costVsPay: z.object({
+				uniqueWorkerDays: z.number().int().nonnegative(),
+				estimatedGrossUsd: z.number().nonnegative(),
+				usdPerUniqueDay: z.number().nonnegative(),
+				includedPerAccountMonth: z.number().int().nonnegative(),
+				estimatedPaidUsdCents: z.number().int().nonnegative(),
+				estimatedMarginUsd: z.number(),
+				underwater: z.boolean(),
+				paidSource: z.enum(['stripe_catalog', 'none']),
+			}),
 			durableObjectDuration: z.object({
 				gbSeconds: z.number().nonnegative(),
 				durationMs: z.number().nonnegative(),
@@ -115,7 +125,7 @@ export const adminUserUsageCapability = defineDomainCapability(
 		...adminCapabilityAccess,
 		name: 'adminUserUsage',
 		description:
-			'Read usage rollups, entitlement counters, plan-limit consumption, estimated Cloudflare Dynamic Worker cost, and observe-only Durable Object duration (GB-s) for one user account by stable user id, email, or username. Admin-only; never returns user content.',
+			'Read usage rollups, entitlement counters, plan-limit consumption, estimated Cloudflare Dynamic Worker cost vs catalog list MRR, and observe-only Durable Object duration (GB-s) for one user account by stable user id, email, or username. Admin-only; never returns user content.',
 		keywords: [
 			'admin',
 			'usage',

--- a/packages/worker/src/scheduled/scheduled-lanes.ts
+++ b/packages/worker/src/scheduled/scheduled-lanes.ts
@@ -23,6 +23,7 @@ import { jobsData } from '#worker/jobs/jobs-data.ts'
 import { reconcileArtifactsPushes } from '#worker/jobs/reconcile-artifacts-pushes.ts'
 import { cleanupRepoSessionBranches } from '#worker/repo/repo-session-cleanup.ts'
 import { backfillStorageBucketEstimates } from '#worker/storage-buckets/estimate-backfill.ts'
+import { refreshAdminInsightsRunLogSnapshot } from '#worker/admin/insights-runlog-snapshot.ts'
 import { aggregateUsageRollups } from '#worker/usage/aggregate-rollups.ts'
 import { runComputeOverageBilling } from '#worker/billing/compute-overage-invoices.ts'
 
@@ -129,7 +130,18 @@ export async function runScheduledLane(input: {
 					reason: 'query_failed',
 				}
 			}
-			return { ...result, fleetPackageErrorRate }
+			let runLogSnapshot: { status: 'ok' | 'failed' }
+			try {
+				await refreshAdminInsightsRunLogSnapshot({
+					env: input.env,
+					now: input.scheduledAt,
+				})
+				runLogSnapshot = { status: 'ok' }
+			} catch (error) {
+				console.warn('admin-insights-run-log-snapshot-lane-failed', error)
+				runLogSnapshot = { status: 'failed' }
+			}
+			return { ...result, fleetPackageErrorRate, runLogSnapshot }
 		}
 		case 'compute_overage_billing':
 			return runComputeOverageBilling({

--- a/packages/worker/universal/connected-mcp-agents.node.test.ts
+++ b/packages/worker/universal/connected-mcp-agents.node.test.ts
@@ -6,6 +6,7 @@ import {
 	type ConnectedMcpAgent,
 	connectedAgentConnectionLabel,
 	connectedAgentIconName,
+	classifyMcpClientName,
 	countUniqueOAuthClientIds,
 	groupConnectedAgents,
 	hasSecondConnectedMcpClient,
@@ -77,6 +78,19 @@ test('inbound labels prefer a known kind, then clientName, then hostname, then a
 			clientName: 'Claude Code',
 		}),
 	).toEqual({ kind: 'claude-code', label: 'Claude Code' })
+
+	expect(classifyMcpClientName('Cursor')).toEqual({
+		kind: 'cursor',
+		label: 'Cursor',
+	})
+	expect(classifyMcpClientName('Claude Code')).toEqual({
+		kind: 'claude-code',
+		label: 'Claude Code',
+	})
+	expect(classifyMcpClientName(null)).toEqual({
+		kind: null,
+		label: 'Unknown',
+	})
 
 	expect(
 		labelInboundMcpClient({

--- a/packages/worker/universal/connected-mcp-agents.ts
+++ b/packages/worker/universal/connected-mcp-agents.ts
@@ -254,6 +254,19 @@ export function labelInboundMcpClient(
 	return { kind: null, label: truncateClientIdLabel(clientId) }
 }
 
+export function classifyMcpClientName(clientName: string | null): {
+	kind: McpClientKind | null
+	label: string
+} {
+	const kind = kindFromClientName(clientName)
+	if (kind) {
+		return { kind, label: mcpClientById(kind).label }
+	}
+	const trimmed = clientName?.trim() || ''
+	if (trimmed) return { kind: null, label: trimmed }
+	return { kind: null, label: 'Unknown' }
+}
+
 function kindFromClientName(clientName: string | null): McpClientKind | null {
 	if (!clientName) return null
 	const normalized = clientName.toLowerCase()

--- a/packages/worker/universal/dynamic-worker-cost.ts
+++ b/packages/worker/universal/dynamic-worker-cost.ts
@@ -79,3 +79,6 @@ export function formatDynamicWorkerUsd(amount: number): string {
 
 export const dynamicWorkerCostFootnote =
 	'Gross estimate: unique Dynamic Worker ids × $0.002 per UTC day. Cloudflare includes 1,000 unique worker-days per account per month, so this is not a net bill share.'
+
+export const costVsPayFootnote =
+	'Cost is a Cloudflare list-rate estimate on unique Dynamic Worker days only (gross, not a net bill share). Paid is catalog list MRR from stored stripe_price_id. Gift, referral, and manual-only access count as $0. Not invoice-perfect: no tax, coupons, overage invoices, email, or storage.'

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -669,6 +669,55 @@ export type AdminInsightsPlanSlice = {
 	count: number
 }
 
+export type AdminInsightsLaunchFunnelStep = {
+	step:
+		| 'signed_up'
+		| 'email_verified'
+		| 'first_mcp'
+		| 'first_search'
+		| 'first_execute'
+		| 'first_saved_package'
+	users: number
+}
+
+export type AdminInsightsPaidSlice = {
+	plan: 'standard' | 'pro'
+	interval: 'month' | 'year' | 'unknown'
+	subscribers: number
+	/** Monthly-equivalent list revenue in USD cents. Zero when the price is unknown. */
+	mrrUsdCents: number
+}
+
+export type AdminInsightsMcpClientSlice = {
+	kind: string | null
+	label: string
+	count: number
+}
+
+export type AdminInsightsLaunchSignals = {
+	openedAt: string
+	openedDay: string
+	mrrUsdCents: number
+	/** Paid Stripe Standard/Pro rows. Gift/referral overlays are not included. */
+	paidSubscribers: number
+	unpricedPaidSubscribers: number
+	paidSlices: Array<AdminInsightsPaidSlice>
+	manualPlans: Array<AdminInsightsPlanSlice>
+	stripePlans: Array<AdminInsightsPlanSlice>
+	effectivePlans: Array<AdminInsightsPlanSlice>
+	/** Effective Standard from an active gift or referral while manual+Stripe stay free. */
+	overlayStandard: number
+	entitlementLadders: { public: number; legacy: number }
+	paidEntitlementLadders: { public: number; legacy: number }
+	activeUsers: { hours24: number; hours48: number; days7: number }
+	activation: {
+		overall: Array<AdminInsightsLaunchFunnelStep>
+		sinceOpen: Array<AdminInsightsLaunchFunnelStep>
+	}
+	mcpClients: Array<AdminInsightsMcpClientSlice>
+	openPlatformFeedback: number
+}
+
 export type AdminInsightsWorkflowStatus = {
 	status: string
 	count: number
@@ -711,11 +760,13 @@ export type AdminInsightsActivation = {
 	medianHoursToActivation: number | null
 }
 
-/** Content-free fanout status for per-user RunLog snapshot reads. */
+/** Content-free status for the hourly RunLog snapshot that insights reads. */
 export type AdminInsightsRunLogCompleteness = {
 	usersAttempted: number
 	usersLoaded: number
 	complete: boolean
+	/** When the hourly snapshot was written. Null until the first refresh. */
+	snapshotUpdatedAt: string | null
 }
 
 export type AdminInsightsDurationConsumer = {
@@ -829,6 +880,7 @@ export type AdminInsightsLoaderData = {
 	workflowStatuses: Array<AdminInsightsWorkflowStatus>
 	jobHealth: AdminInsightsJobHealth
 	activation: AdminInsightsActivation
+	launchSignals: AdminInsightsLaunchSignals
 	runLogCompleteness: AdminInsightsRunLogCompleteness
 	topRuntimeDurationConsumers: Array<AdminInsightsDurationConsumer>
 	topEventCountConsumers: Array<AdminInsightsEventCountConsumer>

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -592,6 +592,20 @@ export type AdminUserUsageLoaderData = {
 	warnings: Array<AdminUsageEntitlementConsumption>
 	dynamicWorkerCost: AdminDynamicWorkerCost
 	durableObjectDuration: AdminDurableObjectDuration
+	costVsPay: AdminCostVsPay
+}
+
+export type AdminPaidSource = 'stripe_catalog' | 'none'
+
+/**
+ * Operator estimate: gross unique-worker-day cost vs catalog list MRR.
+ * Not an invoice and not a net Cloudflare bill share.
+ */
+export type AdminCostVsPay = AdminDynamicWorkerCost & {
+	estimatedPaidUsdCents: number
+	estimatedMarginUsd: number
+	underwater: boolean
+	paidSource: AdminPaidSource
 }
 
 export type AdminInsightsTotals = {
@@ -795,15 +809,20 @@ type AdminDurableObjectDuration = {
 	memoryGb: number
 }
 
-type AdminInsightsDynamicWorkerCostConsumer = {
+export type AdminInsightsDynamicWorkerCostConsumer = {
 	stableUserId: string
 	username: string
 	uniqueWorkerDays: number
 	estimatedGrossUsd: number
+	estimatedPaidUsdCents: number
+	estimatedMarginUsd: number
+	underwater: boolean
+	paidSource: AdminPaidSource
 }
 
 export type AdminInsightsDynamicWorkerCost = AdminDynamicWorkerCost & {
 	topConsumers: Array<AdminInsightsDynamicWorkerCostConsumer>
+	underwaterConsumers: Array<AdminInsightsDynamicWorkerCostConsumer>
 }
 
 export type AdminInsightsMetricDurationConsumers = {

--- a/packages/worker/universal/platform-open.ts
+++ b/packages/worker/universal/platform-open.ts
@@ -1,0 +1,11 @@
+/**
+ * Public launch of kody.codes. Admin launch-cohort filters use this
+ * instant; it is not a stored setting.
+ */
+export const platformPublicOpenedAt = '2026-09-10T00:00:00.000Z'
+
+/** UTC calendar day of {@link platformPublicOpenedAt}, for D1 prefix filters. */
+export const platformPublicOpenedDay = platformPublicOpenedAt.slice(
+	0,
+	'YYYY-MM-DD'.length,
+)

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -235,6 +235,10 @@
 		{
 			"filename": "0058-drop-invites.sql",
 			"sha256": "0ae9a24f67abb537a08403fe01f0c3ac745bd973c4cfc2e049df9af708120d6b"
+		},
+		{
+			"filename": "0059-admin-insights-launch-indexes.sql",
+			"sha256": "be5d99a7d97f0d7a304ac3154f619294dc08a3b2edbda1fbafc000ff414b2bb6"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give `/admin/insights` the post-launch signals Kent needed on 2026-09-10 (MRR, plan sources, activation, activity, MCP mix, entitlement ladder, open feedback) plus cost-vs-pay, and make the page fast enough to use as a product dashboard.

## Why

The first launch-day look at the admin dashboard was missing paid mix, activation, and who is underwater on cost vs list pay. The existing RunLog path also fanned out per-user Durable Object reads on every request. This ships the missing signals and the speed work together.

## Summary

- **Launch signals** from indexed D1 `COUNT` / `GROUP BY` only (no user paging, no Stripe on the request path, no N+1 `adminUserUsage`):
  - Rough MRR from active `stripe_plan` + `stripe_price_id` (public catalog + retired prices). Overlays do not inflate paid MRR.
  - Plan sources split: manual `plan`, `stripePlan`, and `effectivePlan` (gift/referral Standard overlays called out separately).
  - Activation funnel overall and since public open (`2026-09-10`): signup → verified → first MCP → search → execute → saved package.
  - Active users 24h / 48h / 7d from `last_active_at` as **UTC-day stamps** (not rolling ISO-hour cutoffs).
  - New-since-open cohort.
  - MCP client mix (Cursor, Claude Code, Codex, and others).
  - Entitlement ladder public vs legacy.
  - Open platform feedback count.
- **Cost vs pay** (operator estimate, not invoice-perfect):
  - Insights card: highest unique-worker-day cost this month, plus the underwater subset (cost > catalog list MRR).
  - Per-user usage panel: est. cost, list pay, and underwater/above-cost.
  - Paid is catalog list MRR from stored `stripe_price_id`. Free / overlay / unknown price = $0. One bounded `usage_rollups` scan (25 rows), no Stripe, no N+1.
- **Entitlement pressure** stays the existing bounded `usage_rollups` sweep (top ~15), not a full-user scan.
- **RunLog off the request path:** hourly `usage_aggregation` writes KV `admin-insights-runlog:v1`. The page reads that snapshot. Missing KV or a failed `put` fails the scheduled tick. Per-tick fanout is capped at 1500 users (overflow marks the snapshot incomplete; durable multi-tick pagination is a follow-up).
- **Indexes only** in `0059-admin-insights-launch-indexes.sql` (`created_at`, `last_active_at`, `stripe_plan`+`stripe_price_id`, `mcp_client_name`). Not a heavy schema change.

## Testing

- `npm run test:node` — 3045 passed (push hook on `3ce71263`).
- `npm run test:workers` — 344 passed.
- `npm run test:push` — green before each push.
- Review-fix coverage: UTC-day active windows, KV write failures throw, 1500-user snapshot cap.
- Preview `https://kody-pr-2240.kody-a99.workers.dev` health SHA is the merge of `3ce71263`. Seed user is not admin: `GET /admin`, `/admin/insights`, `/admin/insights.json`, `/admin/users` all 403 as expected.
- Local origin on this Cloud Agent VM failed to bind D1/KV/DO (`Missing APP_DB`). Insights UI must be checked as a real admin.

## How to verify in admin

1. Sign in as an admin and open `/admin/insights`.
2. Confirm the launch cards: Rough MRR, Active users, New since open, Open feedback.
3. Confirm launch + since-open funnels, paid Standard/Pro monthly vs yearly, plan-source table, MCP mix, and entitlement ladder.
4. Confirm **Cost vs pay**: highest-cost users and underwater users, with links to `/admin/users/:id`.
5. Open a user detail pane and confirm the usage panel shows est. cost, list pay, and underwater/above-cost.
6. Confirm RunLog-derived cards use the hourly snapshot (warning copy when the snapshot is missing or incomplete).
7. Reload should feel snappy: launch numbers are D1 aggregates + 5-minute insights KV cache, not a live user scan.

## System changes

Medium risk (`extends`). Additive D1 indexes only — not a heavy schema change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `dba5cc84` · **Head:** `3ce71263`

**Classification:** extends — `/admin/insights` adds launch-signal aggregates, cost-vs-pay, and moves RunLog fanout off the request path. Indexes are additive only.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — launch-signal cards, cost-vs-pay, plan/MCP/ladder charts on `/admin/insights` and per-user cost |
| `billing` | auth | extends — Stripe price catalog used for rough MRR and paid-vs-cost (no Stripe API on the page) |
| `d1-app-db` | storage | extends — `0059` indexes on `users` for launch-signal `COUNT` / `GROUP BY` |
| `email-reporting` | storage | extends — insights loader reads launch aggregates + RunLog KV instead of live DO RPCs |
| `rbac` | auth | extends — `adminUserUsage` returns estimated cost vs list pay |
| `scheduled-cron` | surfaces | extends — `usage_aggregation` writes `admin-insights-runlog:v1`, fails the tick on KV write errors, and caps fanout at 1500 users |

Unmatched new modules: `packages/worker/src/admin/launch-signals.ts`, `insights-runlog-snapshot.ts`, and `cost-vs-pay.ts`.

### Change flow

Admin insights now answers launch and cost-vs-pay questions from indexed D1 rollups and an hourly RunLog snapshot.

```mermaid
sequenceDiagram
	actor admin as Admin
	participant appUi as app-ui
	participant emailReporting as email-reporting
	participant d1AppDb as d1-app-db
	participant billing as billing
	participant scheduledCron as scheduled-cron
	admin->>appUi: GET /admin/insights
	appUi->>emailReporting: loadAdminInsightsData
	emailReporting->>d1AppDb: COUNT and GROUP BY launch signals
	emailReporting->>d1AppDb: bounded usage_rollups cost vs pay
	emailReporting->>billing: map stripe_price_id to catalog MRR
	emailReporting->>emailReporting: read KV admin-insights-runlog:v1
	emailReporting-->>appUi: launch cards, cost vs pay, snapshot RunLog
	scheduledCron->>d1AppDb: hourly usage_aggregation user list
	scheduledCron->>scheduledCron: cap RunLog DO fanout at 1500 users
	scheduledCron->>emailReporting: write KV admin-insights-runlog:v1 or fail the tick
```

### Before / after

| Request path | Before | After |
| --- | --- | --- |
| Paid / MRR | Missing or mixed with `effectivePlan` | `stripe_plan` + catalog MRR, overlays separate |
| Cost vs pay | Gross Dynamic Worker cost only | Cost, list pay, and underwater on insights + user detail |
| Activation | Package RunLog only, live DO fanout | Stamp funnel (D1) + hourly RunLog snapshot |
| Activity | Rolling ISO-hour cutoffs on a UTC-day stamp | UTC-day windows from `last_active_at` |
| Activity / MCP / feedback | Missing | Indexed counts on the same page |
| RunLog snapshot write | Missing KV or put failure still reported ok | Scheduled lane fails, page keeps last good snapshot |

### Invariants

Per-user isolation is unchanged. This surface is admin-only and reads platform-wide aggregates, not another user's private assistant state from the request path.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edb1872f-1d14-41ba-b460-c045055110af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edb1872f-1d14-41ba-b460-c045055110af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cost-versus-pay analysis to Admin Insights, including estimated costs, paid amounts, margins, and underwater accounts.
  - Added cost-versus-pay details to individual admin user pages.
  - Added clearer launch metrics, including launch-period activation and active-user windows.

- **Performance**
  - Admin Insights now uses hourly aggregated activity snapshots for faster, more reliable loading.

- **Documentation**
  - Documented launch signals, cost-versus-pay reporting, and updated Admin Insights architecture guidance.

- **Bug Fixes**
  - Improved handling of missing or incomplete activity snapshots and unknown MCP client names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->