### PR TITLE
Retarget admin Cost vs pay into real risk buckets

### DIFF
--- a/.agents/skills/control-kody/references/features/admin.md
+++ b/.agents/skills/control-kody/references/features/admin.md
@@ -11,9 +11,10 @@ Operator tools. Seed and preview users are **not** admin.
 `/admin/system-email`). `/admin/insights` shows launch MRR, paid mix, the
 stamp-based activation funnel (overall and since 2026-09-10), active-user
 windows, MCP client mix, entitlement ladders, open platform feedback, and
-estimated Dynamic Worker cost vs catalog list pay (underwater users).
-`/admin/users/:stableUserId` shows the same cost-vs-pay estimate for one
-account.
+estimated Dynamic Worker cost vs catalog list pay, with a Risk panel for
+paid-underwater accounts, unpaid users approaching the included-bucket alert,
+and missing catalog price ids. `/admin/users/:stableUserId` shows the same
+cost-vs-pay estimate for one account.
 
 ## Drive it
 

--- a/.agents/skills/control-kody/references/features/admin.md
+++ b/.agents/skills/control-kody/references/features/admin.md
@@ -12,9 +12,12 @@ Operator tools. Seed and preview users are **not** admin.
 stamp-based activation funnel (overall and since 2026-09-10), active-user
 windows, MCP client mix, entitlement ladders, open platform feedback, and
 estimated Dynamic Worker cost vs catalog list pay, with a Risk panel for
-paid-underwater accounts, unpaid users approaching the included-bucket alert,
-and missing catalog price ids. `/admin/users/:stableUserId` shows the same
-cost-vs-pay estimate for one account.
+catalog-paid accounts over list MRR, unpaid users at
+≥$1 / 500 unique days
+(50% of the $2 included-bucket alert), and Standard/Pro
+rows whose `stripe_price_id` is missing or not in the catalog.
+`/admin/users/:stableUserId` shows the same cost-vs-pay estimate for one
+account.
 
 ## Drive it
 

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -547,10 +547,12 @@ WHERE timestamp > NOW() - INTERVAL '1' HOUR
   consumers (bounded scan) and a Risk panel: catalog-paid accounts over list
   MRR, unpaid accounts at ≥$1 / 500 unique days (50% of the $2 / 1,000
   unique-day included-bucket alert), and Standard/Pro rows whose
-  `stripe_price_id` is missing or not in the catalog. Free pennies and
-  max/operator accounts are not tagged underwater. The 5-minute insights KV
-  cache (`admin-insights:v11`) covers the assembled page; RunLog-derived charts
-  come from the hourly RunLog KV snapshot.
+  `stripe_price_id` is missing or not in the catalog. Free pennies, max, and
+  `kentcdodds` are not tagged. Admin-role accounts stay out of the unpaid
+  near-allotment warn bucket; catalog-paid admins over list MRR still appear as
+  paid underwater. The 5-minute insights KV cache (`admin-insights:v11`) covers
+  the assembled page; RunLog-derived charts come from the hourly RunLog KV
+  snapshot.
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emits `fleet.entitlement.crossed` to admin-owned packages

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -544,9 +544,12 @@ WHERE timestamp > NOW() - INTERVAL '1' HOUR
   or pages the user table. `plan`, `stripe_plan`, and overlay-aware
   `effectivePlan` stay separate so gift/referral Standard does not look like
   paid MRR. Cost-vs-pay ranks the current month's top unique-worker-day
-  consumers (bounded scan) against that same catalog list MRR. The 5-minute
-  insights KV cache (`admin-insights:v10`) covers the assembled page; RunLog-
-  derived charts come from the hourly RunLog KV snapshot.
+  consumers (bounded scan) and a Risk panel: catalog-paid accounts over list
+  MRR, unpaid accounts approaching the $2 / 1,000 unique-day included-bucket
+  alert, and paid-looking Standard/Pro rows with a missing catalog price id.
+  Free pennies and max/operator accounts are not tagged underwater. The 5-minute
+  insights KV cache (`admin-insights:v11`) covers the assembled page;
+  RunLog-derived charts come from the hourly RunLog KV snapshot.
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emits `fleet.entitlement.crossed` to admin-owned packages

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -545,11 +545,12 @@ WHERE timestamp > NOW() - INTERVAL '1' HOUR
   `effectivePlan` stay separate so gift/referral Standard does not look like
   paid MRR. Cost-vs-pay ranks the current month's top unique-worker-day
   consumers (bounded scan) and a Risk panel: catalog-paid accounts over list
-  MRR, unpaid accounts approaching the $2 / 1,000 unique-day included-bucket
-  alert, and paid-looking Standard/Pro rows with a missing catalog price id.
-  Free pennies and max/operator accounts are not tagged underwater. The 5-minute
-  insights KV cache (`admin-insights:v11`) covers the assembled page;
-  RunLog-derived charts come from the hourly RunLog KV snapshot.
+  MRR, unpaid accounts at ≥$1 / 500 unique days (50% of the $2 / 1,000
+  unique-day included-bucket alert), and Standard/Pro rows whose
+  `stripe_price_id` is missing or not in the catalog. Free pennies and
+  max/operator accounts are not tagged underwater. The 5-minute insights KV
+  cache (`admin-insights:v11`) covers the assembled page; RunLog-derived charts
+  come from the hourly RunLog KV snapshot.
 - **Proactive alerts** (`usage_entitlement_alert` scheduled lane in
   `packages/worker/src/app/usage-entitlement-alerts.ts`): hourly sweep of the
   same ~15-user bound. Emits `fleet.entitlement.crossed` to admin-owned packages

--- a/packages/worker/client/routes/admin-insights-cost.tsx
+++ b/packages/worker/client/routes/admin-insights-cost.tsx
@@ -6,20 +6,80 @@ import {
 	formatDynamicWorkerUsd,
 } from '#universal/dynamic-worker-cost.ts'
 import {
+	type AdminCostRiskKind,
 	type AdminInsightsDynamicWorkerCost,
 	type AdminInsightsDynamicWorkerCostConsumer,
 } from '#universal/loader-data.ts'
 import {
 	adminUserDetailHref,
+	formatAdminCostRiskLabel,
 	formatUsdFromCents,
 } from './admin-insights-shared.ts'
 import { ChartCard } from './admin-insights-sections.tsx'
+
+const riskBucketOrder = [
+	'paid_underwater',
+	'free_near_allotment',
+	'missing_price_id',
+] as const satisfies ReadonlyArray<Exclude<AdminCostRiskKind, 'none'>>
+
+const riskBucketCopy: Record<
+	(typeof riskBucketOrder)[number],
+	{ title: string; emptyText: string }
+> = {
+	paid_underwater: {
+		title: 'Paid underwater',
+		emptyText: 'No catalog-paid accounts are over list MRR this month.',
+	},
+	free_near_allotment: {
+		title: 'Unpaid near included allotment',
+		emptyText:
+			'No unpaid accounts are approaching the $2 included-bucket alert.',
+	},
+	missing_price_id: {
+		title: 'Paid unknown / missing price id',
+		emptyText: 'No paid-looking plans are missing a catalog price id.',
+	},
+}
+
+function riskInk(risk: AdminCostRiskKind) {
+	switch (risk) {
+		case 'paid_underwater':
+			return colors.danger
+		case 'free_near_allotment':
+			return colors.warningText
+		case 'missing_price_id':
+			return colors.textMuted
+		case 'none':
+			return colors.textMuted
+		default: {
+			const exhaustive: never = risk
+			throw new Error(`Unknown cost risk: ${String(exhaustive)}`)
+		}
+	}
+}
 
 function formatMarginUsd(amount: number) {
 	const formatted = formatDynamicWorkerUsd(Math.abs(amount))
 	if (amount > 0) return `+${formatted}`
 	if (amount < 0) return `−${formatted}`
 	return formatted
+}
+
+function renderRiskBadge(row: AdminInsightsDynamicWorkerCostConsumer) {
+	const label = formatAdminCostRiskLabel(row.risk, row.estimatedGrossUsd)
+	if (!label) return null
+	return (
+		<span
+			mix={css({
+				marginLeft: spacing.xs,
+				color: riskInk(row.risk),
+				fontSize: typography.fontSize.xs,
+			})}
+		>
+			{label}
+		</span>
+	)
 }
 
 function renderCostVsPayTable(input: {
@@ -99,17 +159,7 @@ function renderCostVsPayTable(input: {
 							>
 								{row.username}
 							</a>
-							{row.underwater ? (
-								<span
-									mix={css({
-										marginLeft: spacing.xs,
-										color: colors.danger,
-										fontSize: typography.fontSize.xs,
-									})}
-								>
-									underwater
-								</span>
-							) : null}
+							{renderRiskBadge(row)}
 						</td>
 						<td
 							mix={css({
@@ -138,7 +188,10 @@ function renderCostVsPayTable(input: {
 							mix={css({
 								padding: `${spacing.xs} ${spacing.sm}`,
 								textAlign: 'right',
-								color: row.underwater ? colors.danger : colors.textMuted,
+								color:
+									row.risk === 'paid_underwater'
+										? colors.danger
+										: colors.textMuted,
 								fontVariantNumeric: 'tabular-nums',
 							})}
 						>
@@ -151,11 +204,50 @@ function renderCostVsPayTable(input: {
 	)
 }
 
+function renderRiskBuckets(
+	consumers: Array<AdminInsightsDynamicWorkerCostConsumer>,
+) {
+	const hasRisk = consumers.some((row) => row.risk !== 'none')
+	if (!hasRisk) {
+		return (
+			<p mix={css({ margin: 0, color: colors.textMuted })}>
+				No scanned users are past a cost-risk threshold this month.
+			</p>
+		)
+	}
+	return (
+		<div mix={css({ display: 'grid', gap: spacing.md })}>
+			{riskBucketOrder.map((bucket) => {
+				const rows = consumers.filter((row) => row.risk === bucket)
+				return (
+					<div key={bucket} mix={css({ display: 'grid', gap: spacing.xs })}>
+						<h4
+							mix={css({
+								margin: 0,
+								fontSize: typography.fontSize.sm,
+								fontWeight: typography.fontWeight.semibold,
+								color: riskInk(bucket),
+							})}
+						>
+							{riskBucketCopy[bucket].title}
+						</h4>
+						{renderCostVsPayTable({
+							ariaLabel: riskBucketCopy[bucket].title,
+							emptyText: riskBucketCopy[bucket].emptyText,
+							rows,
+						})}
+					</div>
+				)
+			})}
+		</div>
+	)
+}
+
 export function renderCostVsPay(cost: AdminInsightsDynamicWorkerCost) {
 	return (
 		<ChartCard
 			title="Cost vs pay"
-			sub={`${costVsPayFootnote} Top unique-worker-day users this month, then the underwater subset.`}
+			sub={`${costVsPayFootnote} Highest unique-worker-day users this month, then risk ranked within each bucket.`}
 			span={12}
 		>
 			<div
@@ -190,13 +282,9 @@ export function renderCostVsPay(cost: AdminInsightsDynamicWorkerCost) {
 							fontSize: typography.fontSize.base,
 						})}
 					>
-						Underwater
+						Risk
 					</h3>
-					{renderCostVsPayTable({
-						ariaLabel: 'Users whose estimated cost exceeds catalog list pay',
-						emptyText: 'No scanned users are underwater this month.',
-						rows: cost.underwaterConsumers,
-					})}
+					{renderRiskBuckets(cost.riskConsumers)}
 				</div>
 			</div>
 		</ChartCard>

--- a/packages/worker/client/routes/admin-insights-cost.tsx
+++ b/packages/worker/client/routes/admin-insights-cost.tsx
@@ -34,11 +34,12 @@ const riskBucketCopy: Record<
 	free_near_allotment: {
 		title: 'Unpaid near included allotment',
 		emptyText:
-			'No unpaid accounts are approaching the $2 included-bucket alert.',
+			'No unpaid accounts are at ≥$1 / 500 unique days (50% of the $2 included-bucket alert).',
 	},
 	missing_price_id: {
 		title: 'Paid unknown / missing price id',
-		emptyText: 'No paid-looking plans are missing a catalog price id.',
+		emptyText:
+			'No Standard/Pro stripe_plan rows are missing a catalog price id.',
 	},
 }
 

--- a/packages/worker/client/routes/admin-insights-sections.tsx
+++ b/packages/worker/client/routes/admin-insights-sections.tsx
@@ -22,11 +22,22 @@ import {
 } from '#universal/loader-data.ts'
 import {
 	adminUserDetailHref,
+	formatAdminCostRiskLabel,
 	formatDurationHours,
 	formatPlanLabel,
 	formatPressurePercent,
 	runtimeDurationMetricLabels,
 } from './admin-insights-shared.ts'
+
+function formatAdminCostRiskSuffix(
+	consumer: AdminInsightsDynamicWorkerCost['topConsumers'][number],
+) {
+	const label = formatAdminCostRiskLabel(
+		consumer.risk,
+		consumer.estimatedGrossUsd,
+	)
+	return label ? ` · ${label}` : ''
+}
 
 function renderConsumerTable(input: {
 	ariaLabel: string
@@ -156,7 +167,7 @@ export function renderDynamicWorkerCost(cost: AdminInsightsDynamicWorkerCost) {
 					key: consumer.stableUserId,
 					username: consumer.username,
 					stableUserId: consumer.stableUserId,
-					value: `${formatDynamicWorkerUsd(consumer.estimatedGrossUsd)} (${formatIntegerNumber(consumer.uniqueWorkerDays)})${consumer.underwater ? ' · underwater' : ''}`,
+					value: `${formatDynamicWorkerUsd(consumer.estimatedGrossUsd)} (${formatIntegerNumber(consumer.uniqueWorkerDays)})${formatAdminCostRiskSuffix(consumer)}`,
 				})),
 			})}
 		</div>

--- a/packages/worker/client/routes/admin-insights-shared.ts
+++ b/packages/worker/client/routes/admin-insights-shared.ts
@@ -1,7 +1,10 @@
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { chartColor } from '#client/charts/chart-theme.ts'
 import { monthShortNames } from '#client/charts/usage-metric-series.ts'
-import { fleetDynamicWorkerCostAlertUsd } from '#universal/dynamic-worker-cost.ts'
+import {
+	adminCostRiskNoneStatus,
+	fleetDynamicWorkerCostAlertUsd,
+} from '#universal/dynamic-worker-cost.ts'
 import {
 	type AdminCostRiskKind,
 	type AdminInsightsLoaderData,
@@ -114,6 +117,17 @@ export function formatAdminCostRiskLabel(
 			throw new Error(`Unknown cost risk: ${String(exhaustive)}`)
 		}
 	}
+}
+
+export function formatAdminCostRiskStatus(input: {
+	risk: AdminCostRiskKind
+	estimatedGrossUsd: number
+	estimatedPaidUsdCents: number
+}) {
+	return (
+		formatAdminCostRiskLabel(input.risk, input.estimatedGrossUsd) ??
+		adminCostRiskNoneStatus(input)
+	)
 }
 
 /** Null when run-derived totals are complete; otherwise a user-facing warning. */

--- a/packages/worker/client/routes/admin-insights-shared.ts
+++ b/packages/worker/client/routes/admin-insights-shared.ts
@@ -1,7 +1,9 @@
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { chartColor } from '#client/charts/chart-theme.ts'
 import { monthShortNames } from '#client/charts/usage-metric-series.ts'
+import { fleetDynamicWorkerCostAlertUsd } from '#universal/dynamic-worker-cost.ts'
 import {
+	type AdminCostRiskKind,
 	type AdminInsightsLoaderData,
 	type AdminInsightsRunLogCompleteness,
 	type AdminUsageMetric,
@@ -88,6 +90,30 @@ export function formatUsdFromCents(cents: number) {
 		currency: 'USD',
 		maximumFractionDigits: cents % 100 === 0 ? 0 : 2,
 	}).format(cents / 100)
+}
+
+export function formatAdminCostRiskLabel(
+	risk: AdminCostRiskKind,
+	estimatedGrossUsd = 0,
+): string | null {
+	switch (risk) {
+		case 'none':
+			return null
+		case 'paid_underwater':
+			return 'paid underwater'
+		case 'free_near_allotment': {
+			const freeAlertUsd = fleetDynamicWorkerCostAlertUsd('free') ?? 2
+			return estimatedGrossUsd >= freeAlertUsd
+				? 'past included allotment'
+				: 'near included allotment'
+		}
+		case 'missing_price_id':
+			return 'paid unknown'
+		default: {
+			const exhaustive: never = risk
+			throw new Error(`Unknown cost risk: ${String(exhaustive)}`)
+		}
+	}
 }
 
 /** Null when run-derived totals are complete; otherwise a user-facing warning. */

--- a/packages/worker/client/routes/admin-users-detail.tsx
+++ b/packages/worker/client/routes/admin-users-detail.tsx
@@ -38,7 +38,7 @@ import {
 	formatDynamicWorkerUsd,
 } from '#universal/dynamic-worker-cost.ts'
 import {
-	formatAdminCostRiskLabel,
+	formatAdminCostRiskStatus,
 	formatUsdFromCents,
 } from './admin-insights-shared.ts'
 import {
@@ -555,13 +555,13 @@ export function renderAdminUserDetail(props: AdminUserDetailProps) {
 													: colors.textMuted,
 									})}
 								>
-									{formatAdminCostRiskLabel(
-										selectedUsage.costVsPay.risk,
-										selectedUsage.costVsPay.estimatedGrossUsd,
-									) ??
-										(selectedUsage.costVsPay.estimatedPaidUsdCents > 0
-											? 'above cost'
-											: 'within included allotment')}
+									{formatAdminCostRiskStatus({
+										risk: selectedUsage.costVsPay.risk,
+										estimatedGrossUsd:
+											selectedUsage.costVsPay.estimatedGrossUsd,
+										estimatedPaidUsdCents:
+											selectedUsage.costVsPay.estimatedPaidUsdCents,
+									})}
 								</span>{' '}
 								({formatIntegerNumber(selectedUsage.costVsPay.uniqueWorkerDays)}{' '}
 								unique worker-days)

--- a/packages/worker/client/routes/admin-users-detail.tsx
+++ b/packages/worker/client/routes/admin-users-detail.tsx
@@ -37,7 +37,10 @@ import {
 	costVsPayFootnote,
 	formatDynamicWorkerUsd,
 } from '#universal/dynamic-worker-cost.ts'
-import { formatUsdFromCents } from './admin-insights-shared.ts'
+import {
+	formatAdminCostRiskLabel,
+	formatUsdFromCents,
+} from './admin-insights-shared.ts'
 import {
 	durableObjectDurationFootnote,
 	formatDurableObjectGbSeconds,
@@ -544,14 +547,21 @@ export function renderAdminUserDetail(props: AdminUserDetailProps) {
 								list pay ·{' '}
 								<span
 									mix={css({
-										color: selectedUsage.costVsPay.underwater
-											? colors.danger
-											: undefined,
+										color:
+											selectedUsage.costVsPay.risk === 'paid_underwater'
+												? colors.danger
+												: selectedUsage.costVsPay.risk === 'free_near_allotment'
+													? colors.warningText
+													: colors.textMuted,
 									})}
 								>
-									{selectedUsage.costVsPay.underwater
-										? 'underwater'
-										: 'above cost'}
+									{formatAdminCostRiskLabel(
+										selectedUsage.costVsPay.risk,
+										selectedUsage.costVsPay.estimatedGrossUsd,
+									) ??
+										(selectedUsage.costVsPay.estimatedPaidUsdCents > 0
+											? 'above cost'
+											: 'within included allotment')}
 								</span>{' '}
 								({formatIntegerNumber(selectedUsage.costVsPay.uniqueWorkerDays)}{' '}
 								unique worker-days)

--- a/packages/worker/src/admin/cost-vs-pay.node.test.ts
+++ b/packages/worker/src/admin/cost-vs-pay.node.test.ts
@@ -173,6 +173,17 @@ test('toAdminCostVsPay buckets real risk instead of every unpaid penny', () => {
 			username: 'kentcdodds',
 		}),
 	).toBe('none')
+	expect(
+		classifyAdminCostRisk({
+			estimatedGrossUsd: 4,
+			estimatedPaidUsdCents: 0,
+			paidSource: 'none',
+			stripePlan: null,
+			manualPlan: 'free',
+			username: 'ops-admin',
+			isOperator: true,
+		}),
+	).toBe('none')
 })
 
 test('rankRiskCostConsumers ranks within buckets and drops pennies and operator noise', () => {

--- a/packages/worker/src/admin/cost-vs-pay.node.test.ts
+++ b/packages/worker/src/admin/cost-vs-pay.node.test.ts
@@ -164,6 +164,9 @@ test('toAdminCostVsPay buckets real risk instead of every unpaid penny', () => {
 		isOperatorCostNoise({ username: 'kentcdodds', manualPlan: 'free' }),
 	).toBe(true)
 	expect(
+		isOperatorCostNoise({ username: 'ops-admin', manualPlan: 'free' }),
+	).toBe(false)
+	expect(
 		classifyAdminCostRisk({
 			estimatedGrossUsd: 4,
 			estimatedPaidUsdCents: 0,
@@ -182,6 +185,29 @@ test('toAdminCostVsPay buckets real risk instead of every unpaid penny', () => {
 			manualPlan: 'free',
 			username: 'ops-admin',
 			isOperator: true,
+		}),
+	).toBe('none')
+
+	const paidOperatorUnderwater = toAdminCostVsPay({
+		uniqueWorkerDays: 7_000,
+		stripePlan: 'standard',
+		stripePriceId: 'price_standard',
+		catalog,
+		manualPlan: 'free',
+		username: 'ops-admin',
+		isOperator: true,
+	})
+	expect(paidOperatorUnderwater.risk).toBe('paid_underwater')
+	expect(paidOperatorUnderwater.underwater).toBe(true)
+
+	expect(
+		classifyAdminCostRisk({
+			estimatedGrossUsd: 14,
+			estimatedPaidUsdCents: 1_200,
+			paidSource: 'stripe_catalog',
+			stripePlan: 'standard',
+			manualPlan: 'free',
+			username: 'kentcdodds',
 		}),
 	).toBe('none')
 })
@@ -249,17 +275,38 @@ test('rankRiskCostConsumers ranks within buckets and drops pennies and operator 
 				catalog,
 				manualPlan: 'max',
 			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'paid-admin-deficit',
+				username: 'ops-admin',
+				uniqueWorkerDays: 7_000,
+				stripePlan: 'standard',
+				stripePriceId: 'price_standard',
+				catalog,
+				isOperator: true,
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'unpaid-admin-heavy',
+				username: 'ops-admin-free',
+				uniqueWorkerDays: 1_200,
+				stripePlan: null,
+				stripePriceId: null,
+				catalog,
+				manualPlan: 'free',
+				isOperator: true,
+			}),
 		],
 		10,
 	)
 	expect(ranked.map((row) => row.stableUserId)).toEqual([
 		'paid-big-deficit',
+		'paid-admin-deficit',
 		'paid-small-deficit',
 		'free-past',
 		'free-near',
 		'missing-price',
 	])
 	expect(ranked.map((row) => row.risk)).toEqual([
+		'paid_underwater',
 		'paid_underwater',
 		'paid_underwater',
 		'free_near_allotment',

--- a/packages/worker/src/admin/cost-vs-pay.node.test.ts
+++ b/packages/worker/src/admin/cost-vs-pay.node.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest'
 import {
+	classifyAdminCostRisk,
 	estimatePaidListMrrUsdCents,
-	rankUnderwaterCostConsumers,
+	isOperatorCostNoise,
+	rankRiskCostConsumers,
 	toAdminCostVsPay,
 	toAdminCostVsPayConsumer,
 } from './cost-vs-pay.ts'
@@ -45,60 +47,212 @@ test('estimatePaidListMrrUsdCents uses catalog list MRR and treats overlays as $
 	).toEqual({ cents: 0, source: 'none' })
 })
 
-test('toAdminCostVsPay flags underwater when gross worker-day cost exceeds list pay', () => {
-	const freeHeavy = toAdminCostVsPay({
+test('toAdminCostVsPay buckets real risk instead of every unpaid penny', () => {
+	const freePennies = toAdminCostVsPay({
+		uniqueWorkerDays: 90,
+		stripePlan: null,
+		stripePriceId: null,
+		catalog,
+		manualPlan: 'free',
+		username: 'cara',
+	})
+	expect(freePennies.estimatedGrossUsd).toBe(0.18)
+	expect(freePennies.estimatedPaidUsdCents).toBe(0)
+	expect(freePennies.underwater).toBe(false)
+	expect(freePennies.risk).toBe('none')
+	expect(freePennies.paidSource).toBe('none')
+
+	const freeNearAllotment = toAdminCostVsPay({
+		uniqueWorkerDays: 500,
+		stripePlan: null,
+		stripePriceId: null,
+		catalog,
+		manualPlan: 'free',
+		username: 'climber',
+	})
+	expect(freeNearAllotment.estimatedGrossUsd).toBe(1)
+	expect(freeNearAllotment.underwater).toBe(false)
+	expect(freeNearAllotment.risk).toBe('free_near_allotment')
+
+	const freePastAllotment = toAdminCostVsPay({
 		uniqueWorkerDays: 1_500,
 		stripePlan: null,
 		stripePriceId: null,
 		catalog,
+		manualPlan: 'free',
+		username: 'heavy',
 	})
-	expect(freeHeavy.estimatedGrossUsd).toBe(3)
-	expect(freeHeavy.estimatedPaidUsdCents).toBe(0)
-	expect(freeHeavy.estimatedMarginUsd).toBe(-3)
-	expect(freeHeavy.underwater).toBe(true)
-	expect(freeHeavy.paidSource).toBe('none')
+	expect(freePastAllotment.estimatedGrossUsd).toBe(3)
+	expect(freePastAllotment.underwater).toBe(false)
+	expect(freePastAllotment.risk).toBe('free_near_allotment')
 
 	const paidLight = toAdminCostVsPay({
 		uniqueWorkerDays: 90,
 		stripePlan: 'standard',
 		stripePriceId: 'price_standard',
 		catalog,
+		manualPlan: 'free',
+		username: 'paid-light',
 	})
 	expect(paidLight.estimatedGrossUsd).toBe(0.18)
 	expect(paidLight.estimatedPaidUsdCents).toBe(1_200)
 	expect(paidLight.underwater).toBe(false)
+	expect(paidLight.risk).toBe('none')
 	expect(paidLight.paidSource).toBe('stripe_catalog')
+
+	const paidUnderwater = toAdminCostVsPay({
+		uniqueWorkerDays: 7_000,
+		stripePlan: 'standard',
+		stripePriceId: 'price_standard',
+		catalog,
+		manualPlan: 'free',
+		username: 'paid-heavy',
+	})
+	expect(paidUnderwater.estimatedGrossUsd).toBe(14)
+	expect(paidUnderwater.estimatedPaidUsdCents).toBe(1_200)
+	expect(paidUnderwater.underwater).toBe(true)
+	expect(paidUnderwater.risk).toBe('paid_underwater')
+
+	const missingPriceId = toAdminCostVsPay({
+		uniqueWorkerDays: 481,
+		stripePlan: 'standard',
+		stripePriceId: null,
+		catalog,
+		manualPlan: 'free',
+		username: 'maciek',
+	})
+	expect(missingPriceId.estimatedGrossUsd).toBe(0.962)
+	expect(missingPriceId.estimatedPaidUsdCents).toBe(0)
+	expect(missingPriceId.underwater).toBe(false)
+	expect(missingPriceId.risk).toBe('missing_price_id')
+	expect(missingPriceId.paidSource).toBe('none')
+
+	const giftStandardPennies = toAdminCostVsPay({
+		uniqueWorkerDays: 481,
+		stripePlan: null,
+		stripePriceId: null,
+		catalog,
+		manualPlan: 'standard',
+		username: 'gifted',
+	})
+	expect(giftStandardPennies.risk).toBe('none')
+	expect(giftStandardPennies.underwater).toBe(false)
+
+	const giftStandardNearAllotment = toAdminCostVsPay({
+		uniqueWorkerDays: 600,
+		stripePlan: null,
+		stripePriceId: null,
+		catalog,
+		manualPlan: 'standard',
+		username: 'gifted-heavy',
+	})
+	expect(giftStandardNearAllotment.risk).toBe('free_near_allotment')
+	expect(giftStandardNearAllotment.underwater).toBe(false)
+
+	const maxOperator = toAdminCostVsPay({
+		uniqueWorkerDays: 20_000,
+		stripePlan: null,
+		stripePriceId: null,
+		catalog,
+		manualPlan: 'max',
+		username: 'kentcdodds',
+	})
+	expect(maxOperator.estimatedGrossUsd).toBe(40)
+	expect(maxOperator.underwater).toBe(false)
+	expect(maxOperator.risk).toBe('none')
+	expect(
+		isOperatorCostNoise({ username: 'kentcdodds', manualPlan: 'free' }),
+	).toBe(true)
+	expect(
+		classifyAdminCostRisk({
+			estimatedGrossUsd: 4,
+			estimatedPaidUsdCents: 0,
+			paidSource: 'none',
+			stripePlan: null,
+			manualPlan: 'free',
+			username: 'kentcdodds',
+		}),
+	).toBe('none')
 })
 
-test('rankUnderwaterCostConsumers sorts by deficit and keeps the display bound', () => {
-	const ranked = rankUnderwaterCostConsumers(
+test('rankRiskCostConsumers ranks within buckets and drops pennies and operator noise', () => {
+	const ranked = rankRiskCostConsumers(
 		[
 			toAdminCostVsPayConsumer({
-				stableUserId: 'paid',
-				username: 'paid',
+				stableUserId: 'paid-small-deficit',
+				username: 'paid-small-deficit',
+				uniqueWorkerDays: 6_100,
+				stripePlan: 'standard',
+				stripePriceId: 'price_standard',
+				catalog,
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'paid-big-deficit',
+				username: 'paid-big-deficit',
+				uniqueWorkerDays: 8_000,
+				stripePlan: 'standard',
+				stripePriceId: 'price_standard',
+				catalog,
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'free-pennies',
+				username: 'free-pennies',
 				uniqueWorkerDays: 90,
-				stripePlan: 'pro',
-				stripePriceId: 'price_pro',
-				catalog,
-			}),
-			toAdminCostVsPayConsumer({
-				stableUserId: 'small',
-				username: 'small',
-				uniqueWorkerDays: 100,
 				stripePlan: null,
 				stripePriceId: null,
 				catalog,
+				manualPlan: 'free',
 			}),
 			toAdminCostVsPayConsumer({
-				stableUserId: 'big',
-				username: 'big',
-				uniqueWorkerDays: 2_000,
+				stableUserId: 'free-near',
+				username: 'free-near',
+				uniqueWorkerDays: 600,
 				stripePlan: null,
 				stripePriceId: null,
 				catalog,
+				manualPlan: 'free',
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'free-past',
+				username: 'free-past',
+				uniqueWorkerDays: 1_200,
+				stripePlan: null,
+				stripePriceId: null,
+				catalog,
+				manualPlan: 'free',
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'missing-price',
+				username: 'maciek',
+				uniqueWorkerDays: 481,
+				stripePlan: 'standard',
+				stripePriceId: 'price_unknown',
+				catalog,
+			}),
+			toAdminCostVsPayConsumer({
+				stableUserId: 'operator',
+				username: 'kentcdodds',
+				uniqueWorkerDays: 20_000,
+				stripePlan: null,
+				stripePriceId: null,
+				catalog,
+				manualPlan: 'max',
 			}),
 		],
-		2,
+		10,
 	)
-	expect(ranked.map((row) => row.stableUserId)).toEqual(['big', 'small'])
+	expect(ranked.map((row) => row.stableUserId)).toEqual([
+		'paid-big-deficit',
+		'paid-small-deficit',
+		'free-past',
+		'free-near',
+		'missing-price',
+	])
+	expect(ranked.map((row) => row.risk)).toEqual([
+		'paid_underwater',
+		'paid_underwater',
+		'free_near_allotment',
+		'free_near_allotment',
+		'missing_price_id',
+	])
 })

--- a/packages/worker/src/admin/cost-vs-pay.ts
+++ b/packages/worker/src/admin/cost-vs-pay.ts
@@ -1,14 +1,23 @@
 /**
  * Operator cost vs list-pay estimates. Unique worker-days and stored Stripe
  * price ids only — no Stripe API and no per-user usage fan-out.
+ *
+ * Risk is not "any unpaid usage." Free/gift/max/referral/manual-only count as
+ * $0 paid, so pennies of Dynamic Worker usage used to look underwater. The
+ * risk buckets below match what operators should actually look at.
  */
 
-import { toAdminDynamicWorkerCost } from '#universal/dynamic-worker-cost.ts'
 import {
+	fleetDynamicWorkerCostAlertUsd,
+	toAdminDynamicWorkerCost,
+} from '#universal/dynamic-worker-cost.ts'
+import {
+	type AdminCostRiskKind,
 	type AdminCostVsPay,
 	type AdminInsightsDynamicWorkerCostConsumer,
 	type AdminPaidSource,
 } from '#universal/loader-data.ts'
+import { parsePlanName, parseStripePlanName } from '#universal/plans.ts'
 import {
 	monthlyRecurringRevenueUsdCents,
 	type StripePriceCatalogEntry,
@@ -16,6 +25,22 @@ import {
 
 export const adminFleetCostVsPayScanLimit = 25
 export const adminFleetCostVsPayDisplayLimit = 10
+
+/**
+ * Unpaid accounts enter the warn bucket at this fraction of the Free fleet
+ * alert ($2 / 1,000 unique days). Half ($1 / 500 days) is "climbing toward"
+ * the included allotment without tagging every $0.01 user.
+ */
+export const freeNearAllotmentAlertFraction = 0.5
+
+const operatorNoiseUsernames = new Set(['kentcdodds'])
+
+const riskBucketPriority: Record<AdminCostRiskKind, number> = {
+	paid_underwater: 0,
+	free_near_allotment: 1,
+	missing_price_id: 2,
+	none: 3,
+}
 
 export function estimatePaidListMrrUsdCents(input: {
 	stripePlan: string | null | undefined
@@ -36,21 +61,73 @@ export function estimatePaidListMrrUsdCents(input: {
 	}
 }
 
+export function isOperatorCostNoise(input: {
+	username?: string | null | undefined
+	manualPlan?: string | null | undefined
+}): boolean {
+	const username = input.username?.trim().toLowerCase()
+	if (username && operatorNoiseUsernames.has(username)) return true
+	return parsePlanName(input.manualPlan) === 'max'
+}
+
+export function classifyAdminCostRisk(input: {
+	estimatedGrossUsd: number
+	estimatedPaidUsdCents: number
+	paidSource: AdminPaidSource
+	stripePlan: string | null | undefined
+	manualPlan?: string | null | undefined
+	username?: string | null | undefined
+}): AdminCostRiskKind {
+	if (isOperatorCostNoise(input)) return 'none'
+
+	if (input.paidSource === 'stripe_catalog') {
+		return input.estimatedGrossUsd > input.estimatedPaidUsdCents / 100
+			? 'paid_underwater'
+			: 'none'
+	}
+
+	const stripePlan = parseStripePlanName(input.stripePlan)
+	if (stripePlan === 'standard' || stripePlan === 'pro') {
+		return 'missing_price_id'
+	}
+
+	const freeAlertUsd = fleetDynamicWorkerCostAlertUsd('free')
+	if (
+		freeAlertUsd != null &&
+		input.estimatedGrossUsd >= freeAlertUsd * freeNearAllotmentAlertFraction
+	) {
+		return 'free_near_allotment'
+	}
+
+	return 'none'
+}
+
 export function toAdminCostVsPay(input: {
 	uniqueWorkerDays: number
 	stripePlan: string | null | undefined
 	stripePriceId: string | null | undefined
 	catalog: Map<string, StripePriceCatalogEntry>
+	manualPlan?: string | null | undefined
+	username?: string | null | undefined
 }): AdminCostVsPay {
 	const cost = toAdminDynamicWorkerCost(input.uniqueWorkerDays)
 	const paid = estimatePaidListMrrUsdCents(input)
 	const paidUsd = paid.cents / 100
+	const risk = classifyAdminCostRisk({
+		estimatedGrossUsd: cost.estimatedGrossUsd,
+		estimatedPaidUsdCents: paid.cents,
+		paidSource: paid.source,
+		stripePlan: input.stripePlan,
+		manualPlan: input.manualPlan,
+		username: input.username,
+	})
 	return {
 		...cost,
 		estimatedPaidUsdCents: paid.cents,
 		estimatedMarginUsd: paidUsd - cost.estimatedGrossUsd,
-		underwater: cost.estimatedGrossUsd > paidUsd,
+		underwater: risk === 'paid_underwater',
 		paidSource: paid.source,
+		risk,
 	}
 }
 
@@ -61,6 +138,7 @@ export function toAdminCostVsPayConsumer(input: {
 	stripePlan: string | null | undefined
 	stripePriceId: string | null | undefined
 	catalog: Map<string, StripePriceCatalogEntry>
+	manualPlan?: string | null | undefined
 }): AdminInsightsDynamicWorkerCostConsumer {
 	const costVsPay = toAdminCostVsPay(input)
 	return {
@@ -72,20 +150,45 @@ export function toAdminCostVsPayConsumer(input: {
 		estimatedMarginUsd: costVsPay.estimatedMarginUsd,
 		underwater: costVsPay.underwater,
 		paidSource: costVsPay.paidSource,
+		risk: costVsPay.risk,
 	}
 }
 
-export function rankUnderwaterCostConsumers(
+function adminCostRiskScore(
+	consumer: Pick<
+		AdminInsightsDynamicWorkerCostConsumer,
+		'risk' | 'estimatedGrossUsd' | 'estimatedPaidUsdCents'
+	>,
+): number {
+	switch (consumer.risk) {
+		case 'paid_underwater':
+			return consumer.estimatedGrossUsd - consumer.estimatedPaidUsdCents / 100
+		case 'free_near_allotment': {
+			const freeAlertUsd = fleetDynamicWorkerCostAlertUsd('free') ?? 0
+			return freeAlertUsd > 0 ? consumer.estimatedGrossUsd / freeAlertUsd : 0
+		}
+		case 'missing_price_id':
+			return consumer.estimatedGrossUsd
+		case 'none':
+			return 0
+		default: {
+			const exhaustive: never = consumer.risk
+			throw new Error(`Unknown cost risk: ${String(exhaustive)}`)
+		}
+	}
+}
+
+export function rankRiskCostConsumers(
 	consumers: ReadonlyArray<AdminInsightsDynamicWorkerCostConsumer>,
 	limit = adminFleetCostVsPayDisplayLimit,
 ) {
 	return consumers
-		.filter((consumer) => consumer.underwater)
-		.toSorted(
-			(left, right) =>
-				right.estimatedGrossUsd -
-				right.estimatedPaidUsdCents / 100 -
-				(left.estimatedGrossUsd - left.estimatedPaidUsdCents / 100),
-		)
+		.filter((consumer) => consumer.risk !== 'none')
+		.toSorted((left, right) => {
+			const bucket =
+				riskBucketPriority[left.risk] - riskBucketPriority[right.risk]
+			if (bucket !== 0) return bucket
+			return adminCostRiskScore(right) - adminCostRiskScore(left)
+		})
 		.slice(0, limit)
 }

--- a/packages/worker/src/admin/cost-vs-pay.ts
+++ b/packages/worker/src/admin/cost-vs-pay.ts
@@ -9,6 +9,7 @@
 
 import {
 	fleetDynamicWorkerCostAlertUsd,
+	fleetFreeDynamicWorkerNearAllotmentFraction,
 	toAdminDynamicWorkerCost,
 } from '#universal/dynamic-worker-cost.ts'
 import {
@@ -25,13 +26,6 @@ import {
 
 export const adminFleetCostVsPayScanLimit = 25
 export const adminFleetCostVsPayDisplayLimit = 10
-
-/**
- * Unpaid accounts enter the warn bucket at this fraction of the Free fleet
- * alert ($2 / 1,000 unique days). Half ($1 / 500 days) is "climbing toward"
- * the included allotment without tagging every $0.01 user.
- */
-export const freeNearAllotmentAlertFraction = 0.5
 
 const operatorNoiseUsernames = new Set(['kentcdodds'])
 
@@ -64,7 +58,9 @@ export function estimatePaidListMrrUsdCents(input: {
 export function isOperatorCostNoise(input: {
 	username?: string | null | undefined
 	manualPlan?: string | null | undefined
+	isOperator?: boolean
 }): boolean {
+	if (input.isOperator) return true
 	const username = input.username?.trim().toLowerCase()
 	if (username && operatorNoiseUsernames.has(username)) return true
 	return parsePlanName(input.manualPlan) === 'max'
@@ -77,6 +73,7 @@ export function classifyAdminCostRisk(input: {
 	stripePlan: string | null | undefined
 	manualPlan?: string | null | undefined
 	username?: string | null | undefined
+	isOperator?: boolean
 }): AdminCostRiskKind {
 	if (isOperatorCostNoise(input)) return 'none'
 
@@ -94,7 +91,8 @@ export function classifyAdminCostRisk(input: {
 	const freeAlertUsd = fleetDynamicWorkerCostAlertUsd('free')
 	if (
 		freeAlertUsd != null &&
-		input.estimatedGrossUsd >= freeAlertUsd * freeNearAllotmentAlertFraction
+		input.estimatedGrossUsd >=
+			freeAlertUsd * fleetFreeDynamicWorkerNearAllotmentFraction
 	) {
 		return 'free_near_allotment'
 	}
@@ -109,6 +107,7 @@ export function toAdminCostVsPay(input: {
 	catalog: Map<string, StripePriceCatalogEntry>
 	manualPlan?: string | null | undefined
 	username?: string | null | undefined
+	isOperator?: boolean
 }): AdminCostVsPay {
 	const cost = toAdminDynamicWorkerCost(input.uniqueWorkerDays)
 	const paid = estimatePaidListMrrUsdCents(input)
@@ -120,6 +119,7 @@ export function toAdminCostVsPay(input: {
 		stripePlan: input.stripePlan,
 		manualPlan: input.manualPlan,
 		username: input.username,
+		isOperator: input.isOperator,
 	})
 	return {
 		...cost,
@@ -139,6 +139,7 @@ export function toAdminCostVsPayConsumer(input: {
 	stripePriceId: string | null | undefined
 	catalog: Map<string, StripePriceCatalogEntry>
 	manualPlan?: string | null | undefined
+	isOperator?: boolean
 }): AdminInsightsDynamicWorkerCostConsumer {
 	const costVsPay = toAdminCostVsPay(input)
 	return {

--- a/packages/worker/src/admin/cost-vs-pay.ts
+++ b/packages/worker/src/admin/cost-vs-pay.ts
@@ -58,9 +58,7 @@ export function estimatePaidListMrrUsdCents(input: {
 export function isOperatorCostNoise(input: {
 	username?: string | null | undefined
 	manualPlan?: string | null | undefined
-	isOperator?: boolean
 }): boolean {
-	if (input.isOperator) return true
 	const username = input.username?.trim().toLowerCase()
 	if (username && operatorNoiseUsernames.has(username)) return true
 	return parsePlanName(input.manualPlan) === 'max'
@@ -87,6 +85,10 @@ export function classifyAdminCostRisk(input: {
 	if (stripePlan === 'standard' || stripePlan === 'pro') {
 		return 'missing_price_id'
 	}
+
+	// Admin-role dogfooding stays out of the unpaid warn bucket. Catalog-paid
+	// admins over list MRR still count as paid_underwater above.
+	if (input.isOperator) return 'none'
 
 	const freeAlertUsd = fleetDynamicWorkerCostAlertUsd('free')
 	if (

--- a/packages/worker/src/admin/fleet-usage-insights.node.test.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.node.test.ts
@@ -96,6 +96,7 @@ function createFleetDb(input: {
 					}
 					if (
 						normalized.includes('u.plan') &&
+						normalized.includes('entitlement_ladder') &&
 						normalized.includes('event_count')
 					) {
 						return {
@@ -279,22 +280,12 @@ test('loadFleetUsageInsights returns bounded consumer rankings and pressure pane
 				estimatedGrossUsd: 0.18,
 				estimatedPaidUsdCents: 0,
 				estimatedMarginUsd: -0.18,
-				underwater: true,
+				underwater: false,
 				paidSource: 'none',
+				risk: 'none',
 			},
 		],
-		underwaterConsumers: [
-			{
-				stableUserId: 'user-c',
-				username: 'cara',
-				uniqueWorkerDays: 90,
-				estimatedGrossUsd: 0.18,
-				estimatedPaidUsdCents: 0,
-				estimatedMarginUsd: -0.18,
-				underwater: true,
-				paidSource: 'none',
-			},
-		],
+		riskConsumers: [],
 	})
 })
 

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -352,7 +352,7 @@ async function queryDynamicWorkerCost(
 	currentMonth: string,
 ): Promise<AdminInsightsDynamicWorkerCost> {
 	const catalog = resolveStripePriceCatalog(env)
-	const [totalRow, consumerRows] = await Promise.all([
+	const [totalRow, consumerRows, adminUserIds] = await Promise.all([
 		db
 			.prepare(
 				`SELECT COALESCE(SUM(event_count), 0) AS unique_worker_days
@@ -383,6 +383,7 @@ async function queryDynamicWorkerCost(
 				stripe_price_id: string | null
 				event_count: number
 			}>(),
+		listAdminStableUserIds(db),
 	])
 	const uniqueWorkerDays = Number(totalRow?.unique_worker_days ?? 0)
 	const scanned = (consumerRows.results ?? []).map((row) =>
@@ -394,6 +395,7 @@ async function queryDynamicWorkerCost(
 			stripePriceId: row.stripe_price_id,
 			catalog,
 			manualPlan: row.plan,
+			isOperator: adminUserIds.has(row.stable_user_id),
 		}),
 	)
 	return {

--- a/packages/worker/src/admin/fleet-usage-insights.ts
+++ b/packages/worker/src/admin/fleet-usage-insights.ts
@@ -15,7 +15,7 @@ import { observeOnlyUsageEventTypes } from '#universal/usage-event-types.ts'
 import {
 	adminFleetCostVsPayDisplayLimit,
 	adminFleetCostVsPayScanLimit,
-	rankUnderwaterCostConsumers,
+	rankRiskCostConsumers,
 	toAdminCostVsPayConsumer,
 } from '#worker/admin/cost-vs-pay.ts'
 import { resolveStripePriceCatalog } from '#worker/billing/stripe-price-catalog.ts'
@@ -364,8 +364,8 @@ async function queryDynamicWorkerCost(
 			.first<{ unique_worker_days: number }>(),
 		db
 			.prepare(
-				`SELECT u.stable_user_id, u.username, u.stripe_plan, u.stripe_price_id,
-					r.event_count
+				`SELECT u.stable_user_id, u.username, u.plan, u.stripe_plan,
+					u.stripe_price_id, r.event_count
 				 FROM usage_rollups r
 				 INNER JOIN users u ON u.stable_user_id = r.user_id
 				 WHERE r.month = ?
@@ -378,6 +378,7 @@ async function queryDynamicWorkerCost(
 			.all<{
 				stable_user_id: string
 				username: string
+				plan: string
 				stripe_plan: string | null
 				stripe_price_id: string | null
 				event_count: number
@@ -392,12 +393,13 @@ async function queryDynamicWorkerCost(
 			stripePlan: row.stripe_plan,
 			stripePriceId: row.stripe_price_id,
 			catalog,
+			manualPlan: row.plan,
 		}),
 	)
 	return {
 		...toAdminDynamicWorkerCost(uniqueWorkerDays),
 		topConsumers: scanned.slice(0, adminFleetCostVsPayDisplayLimit),
-		underwaterConsumers: rankUnderwaterCostConsumers(scanned),
+		riskConsumers: rankRiskCostConsumers(scanned),
 	}
 }
 

--- a/packages/worker/src/admin/user-usage-data.node.test.ts
+++ b/packages/worker/src/admin/user-usage-data.node.test.ts
@@ -277,6 +277,7 @@ test('loadAdminUserUsageData returns null for unknown users and zeroed usage for
 		estimatedMarginUsd: 0,
 		underwater: false,
 		paidSource: 'none',
+		risk: 'none',
 	})
 	expect(data?.durableObjectDuration).toEqual({
 		gbSeconds: 0,
@@ -323,8 +324,9 @@ test('loadAdminUserUsageData estimates Dynamic Worker cost from unique worker-da
 		usdPerUniqueDay: 0.002,
 		includedPerAccountMonth: 1000,
 	})
-	expect(data?.costVsPay.underwater).toBe(true)
+	expect(data?.costVsPay.underwater).toBe(false)
 	expect(data?.costVsPay.estimatedPaidUsdCents).toBe(0)
+	expect(data?.costVsPay.risk).toBe('none')
 	expect(data?.durableObjectDuration.rpcCount).toBe(0)
 })
 
@@ -369,6 +371,7 @@ test('loadAdminUserUsageData compares catalog list MRR to estimated cost', async
 	expect(data?.costVsPay.estimatedMarginUsd).toBeCloseTo(11.82)
 	expect(data?.costVsPay.underwater).toBe(false)
 	expect(data?.costVsPay.paidSource).toBe('stripe_catalog')
+	expect(data?.costVsPay.risk).toBe('none')
 })
 
 test('loadAdminUserUsageData converts Durable Object RPC duration to observe-only GB-s', async () => {

--- a/packages/worker/src/admin/user-usage-data.node.test.ts
+++ b/packages/worker/src/admin/user-usage-data.node.test.ts
@@ -153,6 +153,12 @@ function createAdminUserUsageTestDb(input: {
 							null) as T | null
 					}
 					if (
+						normalizedQuery.includes("r.name = 'admin'") &&
+						normalizedQuery.includes('stable_user_id')
+					) {
+						return null
+					}
+					if (
 						normalizedQuery.includes(
 							'select 1 as present from users where stable_user_id = ?',
 						)

--- a/packages/worker/src/admin/user-usage-data.ts
+++ b/packages/worker/src/admin/user-usage-data.ts
@@ -94,7 +94,7 @@ export async function loadAdminUserUsageData(
 		? createKvCachifiedCache(env.BUNDLE_ARTIFACTS_KV)
 		: null
 
-	const [monthRows, entitlementConsumption] = await Promise.all([
+	const [monthRows, entitlementConsumption, isOperator] = await Promise.all([
 		loadUserMonthRollups({
 			db: env.APP_DB,
 			cache: rollupCache,
@@ -108,6 +108,7 @@ export async function loadAdminUserUsageData(
 			ladder,
 			now,
 		}),
+		userHasAdminRole(env.APP_DB, usageUserId),
 	])
 
 	const monthUsage = toMonthUsage(monthRows, currentMonth)
@@ -127,6 +128,7 @@ export async function loadAdminUserUsageData(
 		catalog: resolveStripePriceCatalog(env),
 		manualPlan: row.plan,
 		username: row.username,
+		isOperator,
 	})
 
 	return {
@@ -147,6 +149,22 @@ export async function loadAdminUserUsageData(
 		}),
 		costVsPay,
 	}
+}
+
+async function userHasAdminRole(db: D1Database, stableUserId: string) {
+	const row = await db
+		.prepare(
+			`SELECT 1 AS present
+			 FROM users u
+			 INNER JOIN user_roles ur ON ur.user_id = u.id
+			 INNER JOIN roles r ON r.id = ur.role_id
+			 WHERE u.stable_user_id = ?
+				AND r.name = 'admin'
+				AND u.deleting_at IS NULL`,
+		)
+		.bind(stableUserId)
+		.first<{ present: number }>()
+	return row != null
 }
 
 async function loadUserMonthRollups(input: {

--- a/packages/worker/src/admin/user-usage-data.ts
+++ b/packages/worker/src/admin/user-usage-data.ts
@@ -125,6 +125,8 @@ export async function loadAdminUserUsageData(
 		stripePlan: row.stripe_plan,
 		stripePriceId: row.stripe_price_id,
 		catalog: resolveStripePriceCatalog(env),
+		manualPlan: row.plan,
+		username: row.username,
 	})
 
 	return {

--- a/packages/worker/src/app/admin-insights-data.node.test.ts
+++ b/packages/worker/src/app/admin-insights-data.node.test.ts
@@ -45,7 +45,7 @@ const fleetUsageMocks = vi.hoisted(() => ({
 			usdPerUniqueDay: 0.002,
 			includedPerAccountMonth: 1000,
 			topConsumers: [],
-			underwaterConsumers: [],
+			riskConsumers: [],
 		},
 	})),
 	loadFleetPackageErrorRateSnapshot: vi.fn(async () => null),
@@ -539,7 +539,7 @@ test('loadAdminInsightsData assembles the dashboard payload from D1 plus the Run
 		usdPerUniqueDay: 0.002,
 		includedPerAccountMonth: 1000,
 		topConsumers: [],
-		underwaterConsumers: [],
+		riskConsumers: [],
 	})
 })
 

--- a/packages/worker/src/app/admin-insights-data.ts
+++ b/packages/worker/src/app/admin-insights-data.ts
@@ -86,7 +86,7 @@ export async function loadAdminInsightsData(
 		: null
 	if (!cache) return await queryAdminInsights(env, now)
 	return await cachified({
-		key: 'admin-insights:v10',
+		key: 'admin-insights:v11',
 		cache,
 		ttl: insightsCacheTtlMs,
 		getFreshValue: () => queryAdminInsights(env, now),

--- a/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
+++ b/packages/worker/src/mcp/capabilities/admin/admin-user-usage.ts
@@ -108,6 +108,12 @@ const outputSchema = z.object({
 				estimatedMarginUsd: z.number(),
 				underwater: z.boolean(),
 				paidSource: z.enum(['stripe_catalog', 'none']),
+				risk: z.enum([
+					'none',
+					'paid_underwater',
+					'free_near_allotment',
+					'missing_price_id',
+				]),
 			}),
 			durableObjectDuration: z.object({
 				gbSeconds: z.number().nonnegative(),

--- a/packages/worker/universal/dynamic-worker-cost.node.test.ts
+++ b/packages/worker/universal/dynamic-worker-cost.node.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest'
 import {
+	adminCostRiskNoneStatus,
 	estimateDynamicWorkerUsd,
 	fleetDynamicWorkerCostAlertUsd,
+	fleetFreeDynamicWorkerNearAllotmentUsd,
 	formatDynamicWorkerUsd,
 	toAdminDynamicWorkerCost,
 } from './dynamic-worker-cost.ts'
@@ -27,4 +29,23 @@ test('toAdminDynamicWorkerCost truncates to a non-negative integer day count', (
 	expect(fleetDynamicWorkerCostAlertUsd('standard')).toBe(12)
 	expect(fleetDynamicWorkerCostAlertUsd('pro')).toBe(49)
 	expect(fleetDynamicWorkerCostAlertUsd('max')).toBeNull()
+	expect(fleetFreeDynamicWorkerNearAllotmentUsd()).toBe(1)
+	expect(
+		adminCostRiskNoneStatus({
+			estimatedGrossUsd: 0.18,
+			estimatedPaidUsdCents: 0,
+		}),
+	).toBe('within included allotment')
+	expect(
+		adminCostRiskNoneStatus({
+			estimatedGrossUsd: 40,
+			estimatedPaidUsdCents: 0,
+		}),
+	).toBe('not flagged')
+	expect(
+		adminCostRiskNoneStatus({
+			estimatedGrossUsd: 0.18,
+			estimatedPaidUsdCents: 1_200,
+		}),
+	).toBe('above cost')
 })

--- a/packages/worker/universal/dynamic-worker-cost.node.test.ts
+++ b/packages/worker/universal/dynamic-worker-cost.node.test.ts
@@ -48,4 +48,10 @@ test('toAdminDynamicWorkerCost truncates to a non-negative integer day count', (
 			estimatedPaidUsdCents: 1_200,
 		}),
 	).toBe('above cost')
+	expect(
+		adminCostRiskNoneStatus({
+			estimatedGrossUsd: 14,
+			estimatedPaidUsdCents: 1_200,
+		}),
+	).toBe('not flagged')
 })

--- a/packages/worker/universal/dynamic-worker-cost.ts
+++ b/packages/worker/universal/dynamic-worker-cost.ts
@@ -24,6 +24,29 @@ const fleetDynamicWorkerCostAlertUsdByPlan = {
 	pro: 49,
 } as const
 
+/**
+ * Unpaid accounts enter the insights warn bucket at this fraction of the
+ * Free fleet alert ($2 / 1,000 unique days). Half is $1 / 500 days.
+ */
+export const fleetFreeDynamicWorkerNearAllotmentFraction = 0.5
+
+export function fleetFreeDynamicWorkerNearAllotmentUsd(): number {
+	return (
+		fleetDynamicWorkerCostAlertUsdByPlan.free *
+		fleetFreeDynamicWorkerNearAllotmentFraction
+	)
+}
+
+export function adminCostRiskNoneStatus(input: {
+	estimatedGrossUsd: number
+	estimatedPaidUsdCents: number
+}): 'above cost' | 'within included allotment' | 'not flagged' {
+	if (input.estimatedPaidUsdCents > 0) return 'above cost'
+	return input.estimatedGrossUsd >= fleetFreeDynamicWorkerNearAllotmentUsd()
+		? 'not flagged'
+		: 'within included allotment'
+}
+
 export function fleetDynamicWorkerCostAlertUsd(plan: PlanName): number | null {
 	switch (plan) {
 		case 'free':
@@ -81,4 +104,4 @@ export const dynamicWorkerCostFootnote =
 	'Gross estimate: unique Dynamic Worker ids × $0.002 per UTC day. Cloudflare includes 1,000 unique worker-days per account per month, so this is not a net bill share.'
 
 export const costVsPayFootnote =
-	'Cost is a Cloudflare list-rate estimate on unique Dynamic Worker days only (gross, not a net bill share). The account-wide 1,000 unique days (~$2) included bucket is not subtracted per user. Paid is catalog list MRR from stored stripe_price_id. Gift, referral, max, and manual-only access count as $0. Risk is paid accounts over that list pay, unpaid accounts approaching the $2 included-bucket alert, and paid-looking plans with a missing catalog price id — not every free user with pennies of usage. Not invoice-perfect: no tax, coupons, overage invoices, email, or storage.'
+	'Cost is a Cloudflare list-rate estimate on unique Dynamic Worker days only (gross, not a net bill share). The account-wide 1,000 unique days (~$2) included bucket is not subtracted per user. Paid is catalog list MRR from stored stripe_price_id. Gift, referral, max, and manual-only access count as $0. Risk is paid accounts over that list pay, unpaid accounts at ≥$1 / 500 unique days (50% of the $2 included-bucket alert), and Standard/Pro stripe_plan rows whose stripe_price_id is missing or not in the catalog — not every free user with pennies of usage. Not invoice-perfect: no tax, coupons, overage invoices, email, or storage.'

--- a/packages/worker/universal/dynamic-worker-cost.ts
+++ b/packages/worker/universal/dynamic-worker-cost.ts
@@ -41,7 +41,11 @@ export function adminCostRiskNoneStatus(input: {
 	estimatedGrossUsd: number
 	estimatedPaidUsdCents: number
 }): 'above cost' | 'within included allotment' | 'not flagged' {
-	if (input.estimatedPaidUsdCents > 0) return 'above cost'
+	if (input.estimatedPaidUsdCents > 0) {
+		return input.estimatedGrossUsd > input.estimatedPaidUsdCents / 100
+			? 'not flagged'
+			: 'above cost'
+	}
 	return input.estimatedGrossUsd >= fleetFreeDynamicWorkerNearAllotmentUsd()
 		? 'not flagged'
 		: 'within included allotment'

--- a/packages/worker/universal/dynamic-worker-cost.ts
+++ b/packages/worker/universal/dynamic-worker-cost.ts
@@ -81,4 +81,4 @@ export const dynamicWorkerCostFootnote =
 	'Gross estimate: unique Dynamic Worker ids × $0.002 per UTC day. Cloudflare includes 1,000 unique worker-days per account per month, so this is not a net bill share.'
 
 export const costVsPayFootnote =
-	'Cost is a Cloudflare list-rate estimate on unique Dynamic Worker days only (gross, not a net bill share). Paid is catalog list MRR from stored stripe_price_id. Gift, referral, and manual-only access count as $0. Not invoice-perfect: no tax, coupons, overage invoices, email, or storage.'
+	'Cost is a Cloudflare list-rate estimate on unique Dynamic Worker days only (gross, not a net bill share). The account-wide 1,000 unique days (~$2) included bucket is not subtracted per user. Paid is catalog list MRR from stored stripe_price_id. Gift, referral, max, and manual-only access count as $0. Risk is paid accounts over that list pay, unpaid accounts approaching the $2 included-bucket alert, and paid-looking plans with a missing catalog price id — not every free user with pennies of usage. Not invoice-perfect: no tax, coupons, overage invoices, email, or storage.'

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -604,14 +604,26 @@ export type AdminUserUsageLoaderData = {
 export type AdminPaidSource = 'stripe_catalog' | 'none'
 
 /**
+ * Operator cost-vs-pay risk. `underwater` is only paid catalog list MRR
+ * exceeded by estimated Dynamic Worker cost — not unpaid pennies.
+ */
+export type AdminCostRiskKind =
+	| 'none'
+	| 'paid_underwater'
+	| 'free_near_allotment'
+	| 'missing_price_id'
+
+/**
  * Operator estimate: gross unique-worker-day cost vs catalog list MRR.
  * Not an invoice and not a net Cloudflare bill share.
  */
 export type AdminCostVsPay = AdminDynamicWorkerCost & {
 	estimatedPaidUsdCents: number
 	estimatedMarginUsd: number
+	/** True only for catalog-backed paid accounts over list MRR. */
 	underwater: boolean
 	paidSource: AdminPaidSource
+	risk: AdminCostRiskKind
 }
 
 export type AdminInsightsTotals = {
@@ -822,13 +834,15 @@ export type AdminInsightsDynamicWorkerCostConsumer = {
 	estimatedGrossUsd: number
 	estimatedPaidUsdCents: number
 	estimatedMarginUsd: number
+	/** True only for catalog-backed paid accounts over list MRR. */
 	underwater: boolean
 	paidSource: AdminPaidSource
+	risk: AdminCostRiskKind
 }
 
 export type AdminInsightsDynamicWorkerCost = AdminDynamicWorkerCost & {
 	topConsumers: Array<AdminInsightsDynamicWorkerCostConsumer>
-	underwaterConsumers: Array<AdminInsightsDynamicWorkerCostConsumer>
+	riskConsumers: Array<AdminInsightsDynamicWorkerCostConsumer>
 }
 
 export type AdminInsightsMetricDurationConsumers = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make `/admin/insights` Cost vs pay highlight accounts that are actually worth a look — paid users burning past list MRR, unpaid users climbing toward the included Dynamic Worker bucket, and paid-looking plans with a missing catalog price — instead of tagging every free user with pennies of usage as underwater.

## Why

After launch, Underwater meant `estimatedGrossUsd > catalog list MRR`. Free/gift/max/referral/manual-only count as $0 paid, so any Dynamic Worker usage looked scary. Estimates are gross; Cloudflare includes ~1,000 unique days/account/month (~$2) and that is not subtracted per user. Operator/max accounts (kentcdodds) and test pennies dominated the worry list.

## Summary

- Keep **Highest estimated cost** (bounded top unique-worker-day scan).
- Replace **Underwater** with a **Risk** panel, ranked within each bucket:
  - **Paid underwater** (danger): catalog-backed Standard/Pro list MRR exceeded by estimated DW cost ($12 / $49).
  - **Unpaid near included allotment** (warn): $0-paid users at ≥50% of the Free fleet alert ($1 / 500 unique days, climbing toward $2 / 1,000).
  - **Paid unknown / missing price id** (info): `stripe_plan` is standard/pro but `stripe_price_id` is missing or not in the catalog (the maciek case). Gift/manual Standard stays unpaid, not a data-gap.
- `underwater` is now only paid catalog risk. Max and `kentcdodds` are excluded from every risk bucket. Admin-role accounts stay out of the unpaid warn bucket; catalog-paid admins over list MRR still count as paid underwater.
- Same rollup/scan bounds as #2240 (25 scanned, 10 shown). Insights KV cache bumped to `admin-insights:v11`.
- Per-user usage panel and `adminUserUsage` MCP use the same buckets. Excluded paid rows that are actually over list pay say **not flagged**, not **above cost**.

## Testing

- `npm run test:push` on `cae2d6f0` — 3051 node + 344 workers passed (push hook).
- Focused coverage in `cost-vs-pay.node.test.ts` for pennies, near/past allotment, paid underwater, missing price id, gift Standard, operator noise, catalog-paid admin deficits, and unpaid admin-role exclusion.

## How to verify in admin

1. Sign in as an admin and open `/admin/insights`.
2. **Highest estimated cost** still lists top unique-worker-day users. Free users with pennies must not be badged underwater.
3. **Risk** shows the three buckets (or empty copy). Paid over list pay ranks by deficit; unpaid warn ranks by closeness to / past $2.
4. A Standard/Pro row without a catalog price id is **paid unknown**, not underwater.
5. `kentcdodds` / max must not appear as customer-margin risk. An unpaid admin-role account must not appear in the unpaid warn bucket. A catalog-paid admin over list MRR should still show as paid underwater.
6. Open a user detail pane and confirm the usage line uses the same labels (`paid underwater` / `near included allotment` / `paid unknown` / `above cost` / `within included allotment` / `not flagged`). A paid-but-excluded row that is over list pay must say **not flagged**, not **above cost**.

## System changes

Medium risk (`extends`). Ranking and badge contract only — no schema, no Stripe on the request path.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `550b8125` · **Head:** `cae2d6f0`

**Classification:** extends — Cost vs pay keeps the bounded rollup scan and catalog list MRR, but retargets underwater into risk buckets and bumps the insights KV cache key.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — Risk panel and badges on `/admin/insights` and per-user cost copy |
| `email-reporting` | storage | extends — insights payload uses `riskConsumers` and cache `admin-insights:v11` |
| `rbac` | auth | extends — `adminUserUsage` returns `risk` next to `underwater` |
| `billing` | auth | composes — catalog list MRR unchanged, still no Stripe on the page |

Unmatched modules: `packages/worker/src/admin/cost-vs-pay.ts` and the fleet scan that now also reads `users.plan` and admin-role ids.

### Change flow

Admin insights still reads one bounded `usage_rollups` scan, then classifies each top consumer into a risk bucket instead of `cost > $0 paid`.

```mermaid
sequenceDiagram
	actor admin as Admin
	participant appUi as app-ui
	participant emailReporting as email-reporting
	participant d1AppDb as d1-app-db
	participant billing as billing
	admin->>appUi: GET /admin/insights
	appUi->>emailReporting: loadAdminInsightsData
	emailReporting->>d1AppDb: bounded usage_rollups unique-worker-day scan
	emailReporting->>billing: map stripe_price_id to catalog list MRR
	emailReporting->>emailReporting: classify paid underwater, near allotment, missing price id
	emailReporting-->>appUi: topConsumers plus riskConsumers
	admin->>appUi: GET /admin/users/:id usage
	appUi->>emailReporting: loadAdminUserUsageData
	emailReporting-->>appUi: costVsPay.risk for the same buckets
```

### Before / after

| Signal | Before | After |
| --- | --- | --- |
| Underwater | any scanned user with cost > list pay ($0 for unpaid) | only catalog-paid accounts over list MRR |
| Free pennies | badged underwater | no risk badge |
| Free climbing toward $2 | mixed into underwater | warn bucket, ranked by closeness |
| Standard/Pro missing price id | underwater at $0 paid | paid unknown / missing price id |
| max / kentcdodds | often top underwater | excluded from every risk bucket |
| Admin-role unpaid high usage | mixed into underwater | no unpaid warn badge |
| Admin-role catalog-paid over MRR | labeled above cost when forced to none | still paid underwater |
| Excluded paid row over list pay | user-detail said above cost | not flagged |

### Invariants

Per-user isolation is unchanged. This surface is admin-only and still uses one bounded rollup scan plus the Stripe price catalog in-process — no N+1 Stripe or usage fan-out.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56d7baca-8522-4e9b-8763-60a7c0c51616?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56d7baca-8522-4e9b-8763-60a7c0c51616&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded admin cost-versus-pay insights with risk categories for paid accounts exceeding estimated pay, unpaid accounts nearing included usage limits, and paid-looking accounts missing catalog pricing.
  - Added risk labels and clearer status indicators to cost tables and account detail pages.
  - Added risk classifications to cost-versus-pay data and admin usage details.
  - Operator accounts are excluded from cost-risk alerts.

- **Documentation**
  - Updated admin insights and usage-metering documentation with risk categories, thresholds, exclusions, and account-level availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->