### PR TITLE
Add permalink anchors to docs and blog headings

### DIFF
--- a/packages/worker/client/markdown-heading-anchor.tsx
+++ b/packages/worker/client/markdown-heading-anchor.tsx
@@ -1,0 +1,38 @@
+import { type RemixNode } from 'remix/ui'
+
+/** Inline link icon for prose heading permalinks (decorative). */
+function renderHeadingAnchorIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+			<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+		</svg>
+	)
+}
+
+export function renderMarkdownHeadingAnchor(
+	key: number,
+	headingId: string,
+): RemixNode {
+	return (
+		<a
+			key={`anchor-${key}`}
+			href={`#${headingId}`}
+			data-heading-anchor=""
+			aria-label="Link to this section"
+		>
+			{renderHeadingAnchorIcon()}
+		</a>
+	)
+}

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -223,10 +223,14 @@ test('first-party headingIds emit unique kebab-case heading ids', async () => {
 			),
 		}),
 	)
-	expect(html).toContain('<h2 id="josh-tomaino">Josh Tomaino</h2>')
-	expect(html).toContain('<h2 id="josh-tomaino-2">Josh Tomaino</h2>')
-	expect(html).toContain('<h2 id="jett-hays">Jett Hays</h2>')
-	expect(html).toContain('<h2 id="gabriel-alegria">Gabriel Alegría</h2>')
+	expect(html).toContain('<h2 id="josh-tomaino">')
+	expect(html).toContain('href="#josh-tomaino"')
+	expect(html).toContain('data-heading-anchor=""')
+	expect(html).toContain('aria-label="Link to this section"')
+	expect(html).toContain('<h2 id="josh-tomaino-2">')
+	expect(html).toContain('href="#josh-tomaino-2"')
+	expect(html).toContain('<h2 id="jett-hays">')
+	expect(html).toContain('<h2 id="gabriel-alegria">')
 })
 
 test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths', () => {

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -226,6 +226,7 @@ test('first-party headingIds emit unique kebab-case heading ids', async () => {
 	expect(html).toContain('<h2 id="josh-tomaino">')
 	expect(html).toContain('href="#josh-tomaino"')
 	expect(html).toContain('data-heading-anchor=""')
+	expect(html).toContain('data-heading-text=""')
 	expect(html).toContain('aria-label="Link to this section"')
 	expect(html).toContain('<h2 id="josh-tomaino-2">')
 	expect(html).toContain('href="#josh-tomaino-2"')

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -372,7 +372,7 @@ function renderToken(
 			return (
 				<Tag key={key} id={headingId}>
 					{renderMarkdownHeadingAnchor(key, headingId)}
-					{children}
+					<span data-heading-text="">{children}</span>
 				</Tag>
 			)
 		}

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -33,6 +33,7 @@
 import { lexer, type Token, type Tokens } from 'marked'
 import { type Handle, type RemixNode, css } from 'remix/ui'
 import { CopyCodeBlock } from '#client/copy-code-block.tsx'
+import { renderMarkdownHeadingAnchor } from '#client/markdown-heading-anchor.tsx'
 import {
 	coalesceFirstPartyDetails,
 	firstPartyAlertKind,
@@ -367,11 +368,10 @@ function renderToken(
 			if (!options.headingIds) {
 				return <Tag key={key}>{children}</Tag>
 			}
+			const headingId = nextHeadingId(options.headingSlugCounts, token.text)
 			return (
-				<Tag
-					key={key}
-					id={nextHeadingId(options.headingSlugCounts, token.text)}
-				>
+				<Tag key={key} id={headingId}>
+					{renderMarkdownHeadingAnchor(key, headingId)}
 					{children}
 				</Tag>
 			)

--- a/packages/worker/universal/styles/style-primitives.prose.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.prose.node.test.ts
@@ -35,3 +35,26 @@ test('prose tables keep column layout instead of wrapping the last cell to a sli
 	expect(html).toContain('display: table')
 	expect(html).toContain('[data-markdown-table-compact-last]')
 })
+
+test('prose headings with ids expose permalink anchors and scroll margin', async () => {
+	const html = await renderToString(
+		jsx('div', {
+			mix: css(proseCss),
+			children: jsx('h2', {
+				id: 'example',
+				children: [
+					jsx('a', {
+						href: '#example',
+						'data-heading-anchor': '',
+						children: 'link',
+					}),
+					'Example section',
+				],
+			}),
+		}),
+	)
+
+	expect(html).toContain('scroll-margin-top: 5.5rem')
+	expect(html).toContain('[data-heading-anchor]')
+	expect(html).toContain('display: flex')
+})

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -542,6 +542,47 @@ export const proseCss = {
 		letterSpacing: '-0.018em',
 		lineHeight: 1.15,
 	},
+	'& h2[id], & h3[id], & h4[id], & h5[id], & h6[id]': {
+		display: 'flex',
+		alignItems: 'baseline',
+		columnGap: '0.35rem',
+		scrollMarginTop: '5.5rem',
+		'&:focus-within [data-heading-anchor]': {
+			opacity: 0.85,
+		},
+		[hoverMq]: {
+			'&:hover [data-heading-anchor]': {
+				opacity: 0.85,
+			},
+		},
+	},
+	'& [data-heading-anchor]': {
+		display: 'inline-flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		flex: 'none',
+		width: '2.75rem',
+		height: '2.75rem',
+		margin: '-0.65rem 0 -0.65rem -0.65rem',
+		padding: '0.5rem',
+		color: colors.textMuted,
+		opacity: 0.45,
+		textDecoration: 'none',
+		borderRadius: radius.sm,
+		transition: 'opacity 120ms ease, color 120ms ease',
+		'&:hover, &:focus-visible': {
+			opacity: 1,
+			color: colors.primaryText,
+			outline: 'none',
+		},
+		'&:focus-visible': {
+			boxShadow: `0 0 0 2px ${colors.primaryText}`,
+		},
+		'& svg': {
+			width: '1rem',
+			height: '1rem',
+		},
+	},
 	'& h2 + p': {
 		marginTop: '1rem',
 	},

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -556,6 +556,9 @@ export const proseCss = {
 			},
 		},
 	},
+	'& [data-heading-text]': {
+		minWidth: 0,
+	},
 	'& [data-heading-anchor]': {
 		display: 'inline-flex',
 		alignItems: 'center',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give readers a way to jump to and share a specific section in docs and blog posts.

## Why

Docs and blog headings already had stable `id` attributes for deep links, but there was no visible permalink control in the rendered page. Readers had to guess or construct `#fragment` URLs manually.

## Summary

- When first-party markdown renders with `headingIds`, each h2–h6 now includes a link icon that sets the URL hash for that section.
- `proseCss` styles the anchors for hover/focus visibility, 44px tap targets, scroll margin under the sticky header, and no underline clash with body links.
- Added unit coverage for anchor markup and prose styles.

## Testing

- `npm run validate` (green locally)
- Node tests for markdown heading ids + anchor markup and prose scroll-margin/anchor styles
- Manual demo verification of desktop hover and mobile tap behavior (preview deploy pending PR)

## System changes

<!-- SYSTEM-RECAP:BEGIN -->
**Risk:** Low (`composes` on `app-ui`)

**Touches:** `app-ui` — docs/blog prose heading renderer and shared prose styles

```mermaid
sequenceDiagram
  participant Reader
  participant DocPage as Doc/Blog page
  participant Markdown as renderMarkdownNodes
  participant Prose as proseCss

  Reader->>DocPage: Open /docs/secrets
  DocPage->>Markdown: headingIds true
  Markdown-->>DocPage: h2 id + data-heading-anchor link
  Prose-->>DocPage: hover/focus + scroll-margin styles
  Reader->>DocPage: Click section link
  DocPage-->>Reader: URL hash updates, scroll to section
```
<!-- SYSTEM-RECAP:END -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64cdabf3-e026-5f31-b8e5-019c140b1900?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64cdabf3-e026-5f31-b8e5-019c140b1900&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permalink anchors to Markdown headings, allowing direct links to specific sections.
  * Added an inline link icon with accessible labeling for heading anchors.
  * Heading anchors appear on hover or keyboard focus and include visible focus styling.
  * Added improved positioning when navigating to headings, helping keep linked sections visible.
  * Added responsive heading layout and truncation support for longer heading text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->