### PR TITLE
Give waitForClientHydration a cold Vite compile budget

### DIFF
--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -51,6 +51,7 @@ test('account section switches keep the current page on screen (no loading flash
 	seedE2eUser,
 	login,
 }) => {
+	test.setTimeout(process.env.CI ? 90_000 : 60_000)
 	const runId = Date.now()
 	const user = await seedE2eUser({
 		email: `account-nav-${runId}@example.com`,
@@ -84,6 +85,7 @@ test('admin section switches keep the current page on screen (no loading flash, 
 	assignRole,
 	login,
 }) => {
+	test.setTimeout(process.env.CI ? 90_000 : 60_000)
 	const runId = Date.now()
 	const adminUser = await seedE2eUser({
 		email: `admin-nav-${runId}@example.com`,

--- a/e2e/admin-banners.spec.ts
+++ b/e2e/admin-banners.spec.ts
@@ -1,6 +1,11 @@
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { expect, test, type Page } from './playwright-utils.ts'
+import {
+	expect,
+	test,
+	type Page,
+	waitForClientHydration,
+} from './playwright-utils.ts'
 
 const screenshotDir = process.env.SITE_BANNER_SCREENSHOT_DIR ?? null
 
@@ -76,9 +81,7 @@ test('admin can create a site banner and preview launch looks', async ({
 	await expect(
 		page.getByRole('heading', { name: 'Admin banners' }),
 	).toBeVisible({ timeout: 20_000 })
-	await expect(page.locator('html')).toHaveAttribute('data-hydrated', 'true', {
-		timeout: 15_000,
-	})
+	await waitForClientHydration(page)
 	await expect(page.getByRole('heading', { name: 'New banner' })).toBeVisible()
 	await expect(page.getByTestId('site-banner-preview-promo')).toBeVisible()
 	await expect(page.getByLabel('Title', { exact: true })).toBeVisible()
@@ -138,9 +141,7 @@ test('admin can create a site banner and preview launch looks', async ({
 	await expect(page.getByRole('heading', { name: 'New banner' })).toBeVisible({
 		timeout: 20_000,
 	})
-	await expect(page.locator('html')).toHaveAttribute('data-hydrated', 'true', {
-		timeout: 15_000,
-	})
+	await waitForClientHydration(page)
 	await page.getByLabel('Title', { exact: true }).fill(title)
 	await page.getByLabel('Body').fill('Watch the launch video.')
 	await page.getByLabel('CTA URL').fill('https://example.com/kody-launch-video')

--- a/e2e/playwright-utils.ts
+++ b/e2e/playwright-utils.ts
@@ -20,7 +20,12 @@ import {
 
 export * from '@playwright/test'
 
-const hydrationTimeoutMs = 15_000
+// Cold Vite compile of a lazy route area (account-area, admin-area) happens
+// after `page-init.js` marks `html.js.is-settled`. A first `/account/jobs`
+// load on this VM reached `data-hydrated` ~6s after `goto` returned (~16s
+// from navigation start); a colder first attempt exceeded 15s. CI shares
+// the runner with unit + MCP, so keep the larger budget there.
+const hydrationTimeoutMs = process.env.CI ? 30_000 : 20_000
 
 /**
  * Wait until Remix client hydration has bound event handlers.
@@ -29,11 +34,8 @@ const hydrationTimeoutMs = 15_000
  * buttons are visible while `on('click')` / `on('submit')` mixins are still
  * unbound. Clicking a `type="button"` control in that gap is a silent no-op.
  *
- * Boot (`preloadClientRouteModules` + `run` + `app.ready`) can exceed
- * Playwright's 5s default on a cold Vite compile — `html` already has
- * `js is-settled` from `page-init.js` while `data-hydrated` is still
- * missing. Account/admin navigation has flaked that way on CI; keep this
- * budget aligned with the admin-banners cold-start wait.
+ * Do not use Playwright's 5s default: `is-settled` only means the document
+ * loaded, not that `app.ready()` finished.
  */
 export async function waitForClientHydration(page: Page) {
 	await expect(

--- a/e2e/playwright-utils.ts
+++ b/e2e/playwright-utils.ts
@@ -20,15 +20,28 @@ import {
 
 export * from '@playwright/test'
 
+const hydrationTimeoutMs = 15_000
+
 /**
  * Wait until Remix client hydration has bound event handlers.
  *
  * `entry.tsx` preloads the route chunk before `run()`, so SSR headings and
  * buttons are visible while `on('click')` / `on('submit')` mixins are still
  * unbound. Clicking a `type="button"` control in that gap is a silent no-op.
+ *
+ * Boot (`preloadClientRouteModules` + `run` + `app.ready`) can exceed
+ * Playwright's 5s default on a cold Vite compile — `html` already has
+ * `js is-settled` from `page-init.js` while `data-hydrated` is still
+ * missing. Account/admin navigation has flaked that way on CI; keep this
+ * budget aligned with the admin-banners cold-start wait.
  */
 export async function waitForClientHydration(page: Page) {
-	await expect(page.locator('html')).toHaveAttribute('data-hydrated', 'true')
+	await expect(
+		page.locator('html'),
+		'Remix boot sets html[data-hydrated=true] after preload + run + ready',
+	).toHaveAttribute('data-hydrated', 'true', {
+		timeout: hydrationTimeoutMs,
+	})
 }
 
 const authRetryBudgetMs = 15_000


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop account and admin section Playwright specs from flaking when Remix boot is slower than Playwright's 5s default.

## Why

Validate run [34569561580](https://github.com/kentcdodds/kody/actions/runs/34569561580) on #2246 failed E2E with two distinct signals:

1. **Hard fail (already shipped):** `e2e/a11y.spec.ts` looked for heading `Not Found` after the unified 404 page. That heading mismatch was a mid-PR product change, not a flake, and landed in #2246. Later Validate on that PR and on `main` passed.
2. **Real flake (this PR):** `account section switches…` and `admin section switches…` failed the first attempt at `waitForClientHydration`, then passed on retry. The locator resolved to `<html lang="en" class="js is-settled">` with no `data-hydrated`. `page-init.js` sets `is-settled` on `window.load`; Remix only sets `data-hydrated` after `preloadClientRouteModules` + `run` + `app.ready`.

A local first `/account/jobs` load reproduced it: SSR returned 200 with the Jobs heading visible, `html` already had `js is-settled`, and `data-hydrated` appeared ~6s after `goto` returned (~16s from navigation start). A colder first attempt exceeded 15s. `admin-banners.spec.ts` already waited 15s for the same marker after waiting 20s for the heading; account/admin navigation waited for hydration first, so the cold Vite `account-area` compile sat inside the 5s default.

No other open PR or live agent was fixing this helper.

## Summary

- Give `waitForClientHydration` 20s locally and 30s on CI (Validate shares the runner with unit + MCP).
- Raise the account/admin navigation test budget so seed + login + that wait still fit.
- Route the admin-banners hydration asserts through the shared helper.

Risk: **low** — isolated e2e harness / timing determinism. No auth, isolation, billing, or migration surface.

## Testing

- Local: first `/account/jobs` hydration reached `data-hydrated` in ~16s from navigation start; `npx playwright test e2e/account-navigation.spec.ts` after the helper change.
- CI: Validate on this branch.

## System changes

E2E harness only. Classifier matches no primitives (`e2e/` is outside `primitives.yaml` code roots).

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `299ff6b1` · **Head:** `10490db2`

**Classification:** composes — no primitives added or changed; this PR only widens the Playwright wait for Remix client boot.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| _(none)_  | —     | `e2e/` is unmatched by `primitives.yaml` code roots |

### Change flow

Playwright waits for Remix boot to mark `html[data-hydrated=true]` before clicking JS-only account/admin controls. The shared helper now uses a cold-compile budget (20s local, 30s on CI) instead of Playwright's 5s default.

```mermaid
sequenceDiagram
	actor Spec as Playwright spec
	participant helper as waitForClientHydration
	participant pageInit as page-init.js
	participant viteCompile as Vite route chunk
	participant remixBoot as Remix client boot
	Spec->>helper: after page.goto
	pageInit->>pageInit: add js then is-settled on load
	Note over pageInit: document can be settled while the lazy area is still compiling
	helper->>viteCompile: wait through cold account-area compile
	viteCompile-->>remixBoot: chunk ready
	remixBoot-->>helper: preload plus run plus ready
	helper-->>Spec: click handlers are bound
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e711b406-3412-42e6-89c0-a1d866511d4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e711b406-3412-42e6-89c0-a1d866511d4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by allowing additional time for client hydration during slower initial loads.
  * Added clearer timeout feedback when hydration does not complete as expected.
  * Increased navigation test time allowances in CI and local environments to reduce failures during slower test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->