### PR TITLE
Keep MCP execute status recent for an hour of organic traffic

### DIFF
--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -40,14 +40,16 @@ owns the `MCP` Durable Object (`kody-platform`). Origin
 `proves: "origin-kody-fetch-gateway"`, and `notMcpExecute: true`. A passing
 smoke does not prove MCP execute health. Authenticated MCP execute evidence is a
 timestamp-only fleet heartbeat from successful execute completion, shown on
-`status.kody.codes` with source and last-verified time. When no organic success
-landed in the previous minute, the status worker runs at most one authenticated
-`POST /__maintenance/mcp-execute-health` per hour. Public status reads never
-trigger that execute. When the status Durable Object's last-success timestamp is
-already stale, `/` and `/status.json` refresh `executeEvidence` from origin
-`GET /health/components` and persist a newer timestamp (merged with whatever
-cron or another snapshot wrote during that fetch) so the next cron can skip the
-synthetic.
+`status.kody.codes` with source and last-verified time. The public card is
+recent when that evidence is younger than one hour. Organic traffic alone keeps
+the card green. When no organic success landed in the previous minute, the
+status worker runs at most one authenticated
+`POST /__maintenance/mcp-execute-health` per hour (optional fallback). Public
+status reads never trigger that execute. When the status Durable Object's
+last-success timestamp is already outside the one-minute skip window, `/` and
+`/status.json` refresh `executeEvidence` from origin `GET /health/components`
+and persist a newer timestamp (merged with whatever cron or another snapshot
+wrote during that fetch) so the next cron can skip the synthetic.
 
 ## Core docs
 

--- a/docs/contributing/architecture/request-lifecycle.md
+++ b/docs/contributing/architecture/request-lifecycle.md
@@ -105,11 +105,13 @@ Requests are handled in this order:
      smoke does not prove MCP execute health. Authenticated execute evidence is
      the traffic-backed heartbeat plus the hourly
      `POST /__maintenance/mcp-execute-health` fallback (legacy `/mcp` execute
-     with a dedicated canary token). Public health and status GETs do not run
-     that probe. A stale status-page snapshot may re-read origin
-     `GET /health/components` `executeEvidence` (never execute) so organic
-     last-success is not one cron tick behind the live heartbeat. Persist merges
-     with any newer timestamp written while that fetch was in flight.
+     with a dedicated canary token). The public card is recent for one hour
+     after organic or synthetic success; organic traffic alone is enough. Public
+     health and status GETs do not run that probe. A status-page snapshot older
+     than the one-minute skip window may re-read origin `GET /health/components`
+     `executeEvidence` (never execute) so organic last-success is not one cron
+     tick behind the live heartbeat. Persist merges with any newer timestamp
+     written while that fetch was in flight.
 7. Public `@username` ingress handled in `packages/worker/src/index.ts` before
    the OAuth provider / app router (needs `ExecutionContext` for background
    work). Production forwards package-invocation and package-app paths to

--- a/docs/contributing/setup-manifest.md
+++ b/docs/contributing/setup-manifest.md
@@ -337,15 +337,17 @@ Without that secret, alert sends are skipped and logged.
 
 MCP execute evidence on the status page is a timestamp-only last-success
 heartbeat from real authenticated execute completions, plus at most one hourly
-synthetic when the last organic success is older than a minute. Public status
-GETs and origin `GET /health` never trigger that execute. When the status
-worker's stored last-success is already older than a minute, public `/` and
-`/status.json` re-read origin `GET /health/components` `executeEvidence` so the
-card can stay "recent · organic" under live traffic without waiting for the next
-cron write. The optional origin Worker secret
-`MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN` is a dedicated canary OAuth access
-token for the synthetic; when it is unset the fallback stays unknown rather than
-impersonating a customer.
+synthetic when the last organic success is older than a minute. The public card
+is "recent · organic" when that heartbeat is younger than one hour — organic
+traffic alone keeps it green. Public status GETs and origin `GET /health` never
+trigger that execute. When the status worker's stored last-success is already
+older than a minute, public `/` and `/status.json` re-read origin
+`GET /health/components` `executeEvidence` so the card can pick up a newer
+heartbeat without waiting for the next cron write. The optional origin Worker
+secret `MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN` is a dedicated canary OAuth
+access token for the synthetic; when it is unset the fallback stays unknown
+rather than impersonating a customer, and the card still stays recent from
+organic traffic within the hour.
 
 An optional Worker secret `STATUS_INCIDENT_EVENT_SECRET` (synced from the
 same-named GitHub Actions secret when present) is shared with the main worker.

--- a/packages/status/execute-health.node.test.ts
+++ b/packages/status/execute-health.node.test.ts
@@ -6,6 +6,7 @@ import {
 	decideExecuteHealthProbe,
 	deriveExecuteHealthView,
 	executeHealthOrganicFreshMs,
+	executeHealthRecentMs,
 	executeHealthSyntheticCooldownMs,
 	mergeExecuteLastSuccess,
 	readExecuteHealthSyntheticResult,
@@ -14,6 +15,7 @@ import {
 } from './execute-health.ts'
 
 const hourMs = executeHealthSyntheticCooldownMs
+const recentMs = executeHealthRecentMs
 const minuteMs = executeHealthOrganicFreshMs
 const start = Date.parse('2026-09-07T17:00:00.000Z')
 
@@ -143,7 +145,7 @@ test('stale or missing telemetry is unknown, not an outage or a fresh healthy si
 	expect(missing.detail).not.toMatch(/operational|down|outage confirmed/i)
 
 	const stale = deriveExecuteHealthView({
-		now: start + 10 * minuteMs,
+		now: start + recentMs,
 		lastSuccessAt: start,
 		lastSyntheticAttemptAt: null,
 		lastSyntheticSuccessAt: null,
@@ -153,8 +155,39 @@ test('stale or missing telemetry is unknown, not an outage or a fresh healthy si
 	expect(stale.status).toBe('unknown')
 	expect(stale.source).toBe('organic')
 	expect(stale.lastVerifiedAt).toBe(new Date(start).toISOString())
-	expect(stale.freshnessMs).toBe(10 * minuteMs)
+	expect(stale.freshnessMs).toBe(recentMs)
 	expect(stale.detail).toMatch(/not recently exercised/i)
+})
+
+test('minutes-old organic success stays recent even when synthetic is unconfigured', () => {
+	const aFewMinutesOld = deriveExecuteHealthView({
+		now: start + 173_132,
+		lastSuccessAt: start,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: false,
+	})
+	expect(aFewMinutesOld.status).toBe('recent')
+	expect(aFewMinutesOld.source).toBe('organic')
+	expect(aFewMinutesOld.lastVerifiedAt).toBe(new Date(start).toISOString())
+	expect(aFewMinutesOld.freshnessMs).toBe(173_132)
+	expect(aFewMinutesOld.detail).toMatch(/organic/i)
+	expect(aFewMinutesOld.detail).toMatch(/2m ago/)
+	expect(aFewMinutesOld.detail).not.toMatch(/not recently exercised/i)
+	expect(aFewMinutesOld.detail).not.toMatch(/not configured/i)
+
+	const almostHourOld = deriveExecuteHealthView({
+		now: start + recentMs - 1,
+		lastSuccessAt: start,
+		lastSyntheticAttemptAt: null,
+		lastSyntheticSuccessAt: null,
+		lastSyntheticError: null,
+		syntheticConfigured: false,
+	})
+	expect(almostHourOld.status).toBe('recent')
+	expect(almostHourOld.source).toBe('organic')
+	expect(almostHourOld.detail).toMatch(/organic/i)
 })
 
 test('caller failures are not automatically a global outage, and one organic success does not hide other incidents', () => {
@@ -171,7 +204,7 @@ test('caller failures are not automatically a global outage, and one organic suc
 	expect(failedSynthetic.detail).toMatch(/caller-code errors/i)
 
 	const staleOrganicAfterFailedSynthetic = deriveExecuteHealthView({
-		now: start + 2 * minuteMs,
+		now: start + recentMs,
 		lastSuccessAt: start,
 		lastSyntheticAttemptAt: start + minuteMs,
 		lastSyntheticSuccessAt: null,
@@ -234,8 +267,23 @@ test('synthetic success plus heartbeat echo stays synthetic; later organic is or
 		syntheticConfigured: true,
 	})
 	expect(laterOrganic.source).toBe('organic')
+	expect(laterOrganic.status).toBe('recent')
 	expect(laterOrganic.lastVerifiedAt).toBe(
 		new Date(start + 2 * minuteMs).toISOString(),
+	)
+
+	const syntheticStillRecent = deriveExecuteHealthView({
+		now: start + 30 * minuteMs,
+		lastSuccessAt: heartbeatEchoAt,
+		lastSyntheticAttemptAt: start,
+		lastSyntheticSuccessAt: syntheticAt,
+		lastSyntheticError: null,
+		syntheticConfigured: true,
+	})
+	expect(syntheticStillRecent.status).toBe('recent')
+	expect(syntheticStillRecent.source).toBe('synthetic')
+	expect(syntheticStillRecent.detail).toMatch(
+		/hourly authenticated MCP execute probe/i,
 	)
 })
 

--- a/packages/status/execute-health.ts
+++ b/packages/status/execute-health.ts
@@ -6,13 +6,19 @@
  * synthetic. Otherwise the status worker runs at most one authenticated
  * MCP execute per rolling hour. Failed attempts consume that budget.
  *
- * Missing or stale telemetry is unknown / not recently exercised — not an
- * outage and not proof the path is freshly healthy. One organic success
- * does not override other measured component incidents.
+ * The public card uses the hourly window, not the one-minute skip window:
+ * organic or synthetic success within that hour is "recently verified".
+ * Organic traffic alone keeps the card green; the synthetic is an optional
+ * fallback when traffic is quiet. Missing or stale telemetry is unknown /
+ * not recently exercised — not an outage and not proof the path is freshly
+ * healthy. One organic success does not override other measured component
+ * incidents.
  */
 
 export const executeHealthOrganicFreshMs = 60_000
 export const executeHealthSyntheticCooldownMs = 60 * 60 * 1000
+/** Public "recently verified" window. Matches the hourly synthetic cadence. */
+export const executeHealthRecentMs = executeHealthSyntheticCooldownMs
 
 type ExecuteHealthSource = 'organic' | 'synthetic'
 type ExecuteHealthStatus = 'recent' | 'unknown'
@@ -206,8 +212,7 @@ export function deriveExecuteHealthView(
 	const source = executeHealthSource(input, lastVerifiedAtMs)
 	const freshnessMs =
 		lastVerifiedAtMs === null ? null : Math.max(0, input.now - lastVerifiedAtMs)
-	const recent =
-		freshnessMs !== null && freshnessMs < executeHealthOrganicFreshMs
+	const recent = freshnessMs !== null && freshnessMs < executeHealthRecentMs
 	return {
 		status: recent ? 'recent' : 'unknown',
 		source: lastVerifiedAtMs === null ? null : source,

--- a/packages/status/readme.md
+++ b/packages/status/readme.md
@@ -21,12 +21,15 @@ deploys, code, or database are broken (see decision record 0004).
     `POST /__maintenance/mcp-execute-health` per rolling hour. Failed attempts
     consume that budget. Public `/` and `/status.json` never trigger that
     execute. When the Durable Object's last-success timestamp is already outside
-    the one-minute organic window, those public reads refresh `executeEvidence`
+    the one-minute skip window, those public reads refresh `executeEvidence`
     from origin `GET /health/components` (same cheap timestamp-only field the
     cron uses; a down origin fails open to stored state; persist and cron
     synthetic writes merge with any newer timestamp written during those
-    fetches). Missing or stale telemetry is unknown, not an outage, and does not
-    change overall status or hide other incidents.
+    fetches). The public card treats organic or synthetic success in the last
+    hour as recently verified — organic traffic alone keeps the card green; the
+    hourly synthetic is an optional fallback when traffic is quiet. Missing or
+    stale telemetry is unknown, not an outage, and does not change overall
+    status or hide other incidents.
 - Public storage cards are the main-worker bindings that take the product down
   (`app_db`, `kv`, `assets`). Operator `GET /health/components` reports
   `audit_db` as well; it is not a public card and does not open incidents or

--- a/packages/worker/src/execute-health-heartbeat.node.test.ts
+++ b/packages/worker/src/execute-health-heartbeat.node.test.ts
@@ -99,6 +99,17 @@ test('heartbeat coalesces writes and stays fail-open so customer execute is not 
 		'fleet-execute-heartbeat-schedule-failed',
 		'waitUntil exploded',
 	)
+
+	const fallbackStore = kv(null)
+	const fallbackNow = now + 180_000
+	await scheduleFleetExecuteLastSuccess({
+		kv: fallbackStore,
+		now: fallbackNow,
+		memory: memory(),
+	})
+	await expect(
+		readFleetExecuteLastSuccess({ kv: fallbackStore }),
+	).resolves.toEqual({ at: fallbackNow })
 })
 
 test('public evidence reads stay cheap and treat missing or invalid telemetry as unknown', async () => {

--- a/packages/worker/src/execute-health-heartbeat.ts
+++ b/packages/worker/src/execute-health-heartbeat.ts
@@ -80,7 +80,7 @@ export async function readFleetExecuteLastSuccess(input: {
 	}
 }
 
-export function scheduleFleetExecuteLastSuccess(input: {
+export async function scheduleFleetExecuteLastSuccess(input: {
 	waitUntil?: ((promise: Promise<unknown>) => void) | undefined
 	kv?: FleetExecuteHeartbeatKv | null
 	now?: number
@@ -94,16 +94,15 @@ export function scheduleFleetExecuteLastSuccess(input: {
 	try {
 		if (input.waitUntil) {
 			input.waitUntil(work)
-			return work
+			return
 		}
-		// MCP tool success still counts when the agent has no Durable Object
-		// waitUntil. recordFleetExecuteLastSuccess is fail-open.
-		return work
+		// No Durable Object waitUntil: finish the fail-open write before the
+		// execute handler returns so the isolate cannot drop it.
+		await work
 	} catch (error) {
 		console.warn(
 			'fleet-execute-heartbeat-schedule-failed',
 			error instanceof Error ? error.message : String(error),
 		)
-		return work
 	}
 }

--- a/packages/worker/src/execute-health-heartbeat.ts
+++ b/packages/worker/src/execute-health-heartbeat.ts
@@ -85,19 +85,25 @@ export function scheduleFleetExecuteLastSuccess(input: {
 	kv?: FleetExecuteHeartbeatKv | null
 	now?: number
 	memory?: FleetExecuteHeartbeatMemory
-}): void {
+}): Promise<void> {
+	const work = recordFleetExecuteLastSuccess({
+		kv: input.kv,
+		now: input.now,
+		memory: input.memory,
+	})
 	try {
-		input.waitUntil?.(
-			recordFleetExecuteLastSuccess({
-				kv: input.kv,
-				now: input.now,
-				memory: input.memory,
-			}),
-		)
+		if (input.waitUntil) {
+			input.waitUntil(work)
+			return work
+		}
+		// MCP tool success still counts when the agent has no Durable Object
+		// waitUntil. recordFleetExecuteLastSuccess is fail-open.
+		return work
 	} catch (error) {
 		console.warn(
 			'fleet-execute-heartbeat-schedule-failed',
 			error instanceof Error ? error.message : String(error),
 		)
+		return work
 	}
 }

--- a/packages/worker/src/mcp/tools/execute.ts
+++ b/packages/worker/src/mcp/tools/execute.ts
@@ -595,7 +595,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 								)
 					const isError = passthrough?.isError ?? false
 					if (!isError) {
-						scheduleFleetExecuteLastSuccess({
+						await scheduleFleetExecuteLastSuccess({
 							waitUntil,
 							kv: env.BUNDLE_ARTIFACTS_KV,
 						})
@@ -650,7 +650,7 @@ export async function registerExecuteTool(agent: McpRegistrationAgent) {
 					: limitedResult
 				const isError = markerOnlyPassthrough?.isError ?? false
 				if (!isError) {
-					scheduleFleetExecuteLastSuccess({
+					await scheduleFleetExecuteLastSuccess({
 						waitUntil,
 						kv: env.BUNDLE_ARTIFACTS_KV,
 					})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keep the public MCP execute card on `status.kody.codes` green when organic execute traffic is actually happening, without treating a minutes-old heartbeat as "not recently exercised."

## Why

Live production (~2026-09-11T16:47Z) showed a split that is **not** the #2236 ingest lag:

- `https://kody.codes/health/components` `executeEvidence.lastSuccessAt` = `2026-09-11T16:44:58.197Z`
- `https://status.kody.codes/status.json` `executeHealth.lastVerifiedAt` = the same timestamp
- `executeHealth.status` = `unknown`, `source` = `organic`, `freshnessMs` ≈ 168–191s
- Detail: **Not recently exercised. Synthetic fallback is not configured. Missing telemetry is not an outage.**

#2236 fixed the Durable Object lag so public reads see the live heartbeat. That part is working. The leftover is that `deriveExecuteHealthView` reused the 60s skip-synthetic window as the public "recent" gate. A ~2–3 minute gap between Kent's executes (normal organic use) flipped the card gray and then the unconfigured-synthetic copy hid the fact that organic evidence was present.

### Heartbeat write path (checked)

`executeEvidence.lastSuccessAt` is a cheap KV read of `fleet-execute-last-success:v1`. The MCP `execute` tool writes it on successful completion via `scheduleFleetExecuteLastSuccess` (45s coalesce). Live recaptures after later executes advanced the timestamp (`16:44:58` → `16:51:36` → `16:52:39`), so this is not a stuck heartbeat.

Intentional skips: caller/sandbox errors, `__mcpContent` `isError`, 45s coalesce, and idempotent replays. Nested `kody.execute` (capability, not the MCP tool) does not write the fleet heartbeat — that is a different surface. One real MCP-tool footgun: `scheduleFleetExecuteLastSuccess` no-oped when `waitUntil` was missing; this PR falls back to the same fail-open write and awaits it when `waitUntil` is absent.

Synthetic is still not configured in prod after #2236 (`MCP_EXECUTE_HEALTH_CANARY_ACCESS_TOKEN` remains an ops leftover). Organic traffic alone should keep the card green.

## Summary

- Split public "recent" from the 60s skip/refresh window. `executeHealthRecentMs` matches the hourly synthetic cadence (1 hour).
- Organic or synthetic success younger than that hour is **Recently verified**. Organic alone is enough; synthetic stays an optional quiet-traffic fallback.
- 60s still decides "skip the hourly synthetic" and "refresh stored last-success from origin."
- Successful MCP execute still records the fleet heartbeat when the agent has no Durable Object `waitUntil`, and the handler awaits that write.
- Docs in the status readme, architecture index, request lifecycle, and setup manifest now name both windows.

## Testing

- `vitest run` in `packages/status` — including the Kent reproduction (173s-old organic, synthetic unconfigured → `recent` / organic / `2m ago`).
- `vitest run --project node-unit` heartbeat + execute tool tests — missing `waitUntil` still writes last-success.
- Pre-push hook: `test:node` + `test:workers`

## How to verify after status-worker deploy

1. Compare the same second:
   - `curl -fsS https://kody.codes/health/components`
   - `curl -fsS https://status.kody.codes/status.json`
2. Under live execute traffic, `executeHealth.lastVerifiedAt` should match `executeEvidence.lastSuccessAt`, and `status` should be `recent` with `source: organic` for up to an hour after that heartbeat.
3. The MCP execute card should read **Recently verified · organic traffic**.
4. `overallStatus` stays `operational` even if execute evidence is unknown.

The kody.codes PR preview does not deploy the status worker, so a logged-in preview UI pass cannot prove this card. Verification is the live `status.kody.codes` card after the status-worker deploy.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e524c5b` · **Head:** `ce722a83`

**Classification:** extends — the public MCP execute card uses a one-hour "recent" window instead of the 60s skip-synthetic window, and the fleet heartbeat still writes when waitUntil is missing.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `status-page` | surfaces | extends — `deriveExecuteHealthView` treats organic or synthetic success younger than one hour as recent |
| `mcp-server` | surfaces | extends — `scheduleFleetExecuteLastSuccess` records last-success even without Durable Object waitUntil, and execute awaits that write |

### Change flow

A viewer of `status.kody.codes` sees minutes-old organic execute evidence as recently verified. A successful MCP execute still advances the fleet heartbeat when the agent has no waitUntil.

```mermaid
sequenceDiagram
	actor Viewer
	participant mcpServer as mcp-server
	participant appUi as app-ui
	participant statusPage as status-page
	mcpServer->>appUi: schedule fleet last-success on execute success
	Note over mcpServer,appUi: write even when waitUntil is missing
	Viewer->>statusPage: GET / or /status.json
	statusPage->>appUi: GET /health/components when stored last-success is older than 60s
	appUi-->>statusPage: executeEvidence.lastSuccessAt
	statusPage->>statusPage: derive recent when freshness is under 1 hour
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64dfc3ef-8572-4d5f-b0e5-7d9fb5eca6c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64dfc3ef-8572-4d5f-b0e5-7d9fb5eca6c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Public MCP execute-health status now remains “recently verified” for up to one hour after organic or synthetic success.
  - Organic traffic alone can keep the status card green; synthetic checks remain an optional fallback during quiet periods.
  - Status-page refresh behavior is clarified: snapshots outside the one-minute skip window may re-check origin health evidence.
- **Reliability**
  - Execute-health heartbeat records are now completed reliably before execution finishes when background scheduling is unavailable.
- **Documentation**
  - Updated architecture, setup, and status documentation to describe the revised freshness rules and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->