### PR TITLE
Keep live search focused while filtered lists update

### DIFF
--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
 	expect,
 	test,
+	type Locator,
 	type Page,
 	waitForClientHydration,
 } from './playwright-utils.ts'
@@ -77,6 +78,82 @@ test('account section switches keep the current page on screen (no loading flash
 		],
 		'Jobs',
 	)
+})
+
+async function markSearchNode(search: Locator) {
+	await search.evaluate((element) => {
+		;(element as HTMLElement).dataset.kodySearchMount = '1'
+	})
+}
+
+test('account live search keeps the same focused input while the list filters', async ({
+	page,
+	seedE2eUser,
+	login,
+}) => {
+	test.setTimeout(process.env.CI ? 90_000 : 60_000)
+	const runId = Date.now()
+	const user = await seedE2eUser({
+		email: `account-search-${runId}@example.com`,
+		username: `account-search-${runId}`,
+		password: 'account-search-password',
+	})
+	await login({ email: user.email, password: user.password, mode: 'login' })
+
+	const alphaSecret = await page.request.post('/account/secrets.json', {
+		data: {
+			action: 'save',
+			name: `alphaSecret${runId}`,
+			scope: 'user',
+			value: 'alpha-secret-value',
+			description: 'Matches the alpha query',
+			allowedHosts: ['api.example.com'],
+			allowedPackages: [],
+		},
+		headers: { 'Content-Type': 'application/json' },
+	})
+	expect(alphaSecret.ok()).toBe(true)
+	const betaSecret = await page.request.post('/account/secrets.json', {
+		data: {
+			action: 'save',
+			name: `betaSecret${runId}`,
+			scope: 'user',
+			value: 'beta-secret-value',
+			description: 'Does not match the alpha query',
+			allowedHosts: ['api.example.com'],
+			allowedPackages: [],
+		},
+		headers: { 'Content-Type': 'application/json' },
+	})
+	expect(betaSecret.ok()).toBe(true)
+
+	await page.goto('/account/secrets')
+	await waitForClientHydration(page)
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Secrets' }),
+	).toBeVisible()
+	await expect(page.getByText(`alphaSecret${runId}`)).toBeVisible()
+	await expect(page.getByText(`betaSecret${runId}`)).toBeVisible()
+
+	const secretsSearch = page.getByRole('searchbox', { name: 'Search secrets' })
+	await secretsSearch.click()
+	await markSearchNode(secretsSearch)
+	await secretsSearch.pressSequentially(`alphaSecret${runId}`, { delay: 20 })
+	await expect(secretsSearch).toBeFocused()
+	await expect(secretsSearch).toHaveAttribute('data-kody-search-mount', '1')
+	await expect(secretsSearch).toHaveValue(`alphaSecret${runId}`)
+	await expect(page.getByText(`alphaSecret${runId}`)).toBeVisible()
+	await expect(page.getByText(`betaSecret${runId}`)).toHaveCount(0)
+
+	await page.goto('/account/jobs')
+	await waitForClientHydration(page)
+	const jobsSearch = page.getByRole('searchbox', { name: 'Search jobs' })
+	await jobsSearch.click()
+	await markSearchNode(jobsSearch)
+	await jobsSearch.pressSequentially('no-such-job', { delay: 20 })
+	await expect(jobsSearch).toBeFocused()
+	await expect(jobsSearch).toHaveAttribute('data-kody-search-mount', '1')
+	await expect(jobsSearch).toHaveValue('no-such-job')
 })
 
 test('admin section switches keep the current page on screen (no loading flash, no refetch)', async ({

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -166,8 +166,10 @@ export function PackageFilesExplorer(
 							<div mix={css(filterFieldCss)}>
 								<span mix={css(filterIconCss)}>{searchIcon()}</span>
 								<input
-									type="search"
-									value={query}
+									type="text"
+									role="searchbox"
+									inputMode="search"
+									autoComplete="off"
 									placeholder="Go to file"
 									aria-label="Filter files"
 									mix={[

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -1,6 +1,7 @@
 // remix-skill: Handle-based files explorer (tree + blob). Must be a Handle
 // component so Remix can mount it from the shared /files route.
-import { type Handle, type RemixNode, css } from 'remix/ui'
+import { type Handle, type RemixNode, css, ref } from 'remix/ui'
+import { writeUncontrolledSearchInput } from '#client/routes/record-table-search-sync.ts'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
 import { matchesSearchQuery } from '#client/search-filter.ts'
@@ -67,6 +68,7 @@ export function PackageFilesExplorer(
 	const expanded = new Set<string>()
 	let openedFor: string | null = null
 	let query = ''
+	let filterInput: HTMLInputElement | null = null
 
 	// Opening a directory opens it in the tree too, the way GitHub's sidebar
 	// does — the row navigates *and* unfolds, rather than only doing one.
@@ -74,6 +76,10 @@ export function PackageFilesExplorer(
 		if (openedFor === selectedPath) return
 		openedFor = selectedPath
 		query = ''
+		// The filter is uncontrolled so keystrokes do not remount it. Navigation
+		// still has to wipe the DOM string, or the tree shows every file while
+		// the box keeps the previous query.
+		writeUncontrolledSearchInput(filterInput, '')
 		for (const directory of ancestorDirectories(selectedPath)) {
 			expanded.add(directory)
 		}
@@ -174,6 +180,12 @@ export function PackageFilesExplorer(
 									aria-label="Filter files"
 									mix={[
 										css(filterInputCss),
+										ref((node, signal) => {
+											filterInput = node as HTMLInputElement
+											signal.addEventListener('abort', () => {
+												if (filterInput === node) filterInput = null
+											})
+										}),
 										on('input', (event) => {
 											const target = event.target
 											if (target instanceof HTMLInputElement) {

--- a/packages/worker/client/routes/admin-provider-marks.tsx
+++ b/packages/worker/client/routes/admin-provider-marks.tsx
@@ -492,6 +492,7 @@ export function AdminProviderMarksRoute(handle: Handle) {
 				) : null}
 				{status === 'loading' ? <p>Loading provider marks…</p> : null}
 				<RecordTableSearch
+					key="provider-marks-search"
 					label="Filter marks"
 					placeholder="Filter marks"
 					value={search}

--- a/packages/worker/client/routes/admin-reserved-usernames.tsx
+++ b/packages/worker/client/routes/admin-reserved-usernames.tsx
@@ -384,8 +384,10 @@ export function AdminReservedUsernamesRoute(handle: Handle) {
 						<span mix={css(fieldLabelCss)}>Search</span>
 						<input
 							data-field-ring
-							type="search"
-							value={builtInQuery}
+							type="text"
+							role="searchbox"
+							inputMode="search"
+							autoComplete="off"
 							placeholder="autodiscover"
 							mix={[
 								on('input', (event) => {

--- a/packages/worker/client/routes/connect-oauth-sections.tsx
+++ b/packages/worker/client/routes/connect-oauth-sections.tsx
@@ -1,6 +1,6 @@
 import { type ConnectOauthExistingConnection } from '#universal/loader-data.ts'
 import { docHref } from '#universal/docs-nav.ts'
-import { css } from 'remix/ui'
+import { css, ref } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { buildIncompleteConnectOauthPrompt } from '#universal/oauth-scopes.ts'
 import { isConnectOauthCallbackUrl } from '#universal/oauth-connect.ts'
@@ -109,6 +109,7 @@ export function renderChooser(input: {
 	chooserOptions: Array<ConnectOauthChooserOption>
 	chooserFilter: string
 	onFilterChange: (value: string) => void
+	onFilterInput?: (node: HTMLInputElement | null) => void
 }) {
 	const showFilter =
 		input.chooserOptions.length > connectOauthChooserFilterMinOptions
@@ -134,6 +135,14 @@ export function renderChooser(input: {
 					data-testid="connect-oauth-chooser-filter"
 					mix={[
 						css(inputCss),
+						ref((node, signal) => {
+							if (node instanceof HTMLInputElement) {
+								input.onFilterInput?.(node)
+							}
+							signal.addEventListener('abort', () => {
+								input.onFilterInput?.(null)
+							})
+						}),
 						on('input', (event) => {
 							const target = event.currentTarget
 							if (target instanceof HTMLInputElement) {

--- a/packages/worker/client/routes/connect-oauth-sections.tsx
+++ b/packages/worker/client/routes/connect-oauth-sections.tsx
@@ -109,7 +109,8 @@ export function renderChooser(input: {
 	chooserOptions: Array<ConnectOauthChooserOption>
 	chooserFilter: string
 	onFilterChange: (value: string) => void
-	onFilterInput?: (node: HTMLInputElement | null) => void
+	onFilterInput?: (node: HTMLInputElement) => void
+	onFilterDetach?: (node: HTMLInputElement) => void
 }) {
 	const showFilter =
 		input.chooserOptions.length > connectOauthChooserFilterMinOptions
@@ -136,11 +137,10 @@ export function renderChooser(input: {
 					mix={[
 						css(inputCss),
 						ref((node, signal) => {
-							if (node instanceof HTMLInputElement) {
-								input.onFilterInput?.(node)
-							}
+							if (!(node instanceof HTMLInputElement)) return
+							input.onFilterInput?.(node)
 							signal.addEventListener('abort', () => {
-								input.onFilterInput?.(null)
+								input.onFilterDetach?.(node)
 							})
 						}),
 						on('input', (event) => {

--- a/packages/worker/client/routes/connect-oauth-sections.tsx
+++ b/packages/worker/client/routes/connect-oauth-sections.tsx
@@ -125,8 +125,10 @@ export function renderChooser(input: {
 			</p>
 			{showFilter ? (
 				<input
-					type="search"
-					value={input.chooserFilter}
+					type="text"
+					role="searchbox"
+					inputMode="search"
+					autoComplete="off"
 					placeholder="Filter services"
 					aria-label="Filter services"
 					data-testid="connect-oauth-chooser-filter"

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -12,6 +12,7 @@ import { isConnectOauthCallbackUrl } from '#universal/oauth-connect.ts'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
 import { submitApprovalRequest } from '#client/routes/account-approval-shared.ts'
+import { writeUncontrolledSearchInput } from '#client/routes/record-table-search-sync.ts'
 import { ProviderMark } from '#client/provider-icons.tsx'
 import {
 	pageDescriptionCss,
@@ -96,6 +97,7 @@ export function ConnectOauthRoute(handle: Handle) {
 	let replaceConfirmed = false
 	let chooserOptions: Array<ConnectOauthChooserOption> = []
 	let chooserFilter = ''
+	let chooserFilterInput: HTMLInputElement | null = null
 	let requestedProvider: string | null = null
 	/**
 	 * Scope checkboxes stay on this list while the user unchecks. BYO has no
@@ -135,6 +137,7 @@ export function ConnectOauthRoute(handle: Handle) {
 		replaceConfirmed = false
 		chooserOptions = []
 		chooserFilter = ''
+		writeUncontrolledSearchInput(chooserFilterInput, '')
 		requestedProvider = null
 		offeredScopeMenu = []
 		hostApprovalLinks = []
@@ -679,6 +682,9 @@ export function ConnectOauthRoute(handle: Handle) {
 									onFilterChange: (value) => {
 										chooserFilter = value
 										update()
+									},
+									onFilterInput: (node) => {
+										chooserFilterInput = node
 									},
 								})}
 				</section>

--- a/packages/worker/client/routes/connect-oauth.tsx
+++ b/packages/worker/client/routes/connect-oauth.tsx
@@ -686,6 +686,9 @@ export function ConnectOauthRoute(handle: Handle) {
 									onFilterInput: (node) => {
 										chooserFilterInput = node
 									},
+									onFilterDetach: (node) => {
+										if (chooserFilterInput === node) chooserFilterInput = null
+									},
 								})}
 				</section>
 			)

--- a/packages/worker/client/routes/record-table-controls.tsx
+++ b/packages/worker/client/routes/record-table-controls.tsx
@@ -27,34 +27,15 @@ type Slot = RemixNode
 /**
  * Live filter fields write the query into the URL on every keystroke. A
  * Remix-controlled `value` lets the first character schedule a restore of the
- * previous (empty) query, and WebKit's search cancel control appears on that
- * same keystroke — either one drops focus and the reader has to click back in.
- * The field stays uncontrolled. URL/back-button updates apply immediately
- * when it is not focused, and on blur if they arrived while it was. A
- * keystroke records the typed string as the last applied value so a later
- * render that returns `q` to that value (clear, or back to the same query)
- * cannot leave a stale pending string for blur to write back.
+ * previous (empty) query, which drops focus. `type="search"` is worse: the
+ * native cancel control appears on that same keystroke and steals focus even
+ * when CSS tries to hide it. The field stays uncontrolled `type="text"` with
+ * `role="searchbox"`. URL/back-button updates apply immediately when it is not
+ * focused, and on blur if they arrived while it was. Focus is tracked from
+ * focus/blur, not `document.activeElement` during render — Remix captures
+ * selection before the render phase, so the input is often not active then
+ * and a racy read would write the URL string back over the keystroke.
  */
-const searchCancelHiddenCss = {
-	'&::-webkit-search-decoration': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-	},
-	'&::-webkit-search-cancel-button': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-		display: 'none',
-	},
-	'&::-webkit-search-results-button': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-	},
-	'&::-webkit-search-results-decoration': {
-		WebkitAppearance: 'none',
-		appearance: 'none',
-	},
-} as const
-
 export function RecordTableSearch(
 	handle: Handle<{
 		label: string
@@ -65,6 +46,7 @@ export function RecordTableSearch(
 ) {
 	let input: HTMLInputElement | null = null
 	const initialValue = handle.props.value
+	let focused = false
 	let sync: RecordTableSearchSync = {
 		lastExternalValue: initialValue,
 		pendingExternalValue: null,
@@ -77,18 +59,23 @@ export function RecordTableSearch(
 
 	return () => {
 		const nextValue = handle.props.value
-		const focused = Boolean(input && document.activeElement === input)
 		const reconciled = reconcileRecordTableSearchExternalValue(
 			sync,
 			nextValue,
 			focused,
 		)
 		sync = reconciled.state
-		if (reconciled.applyValue !== null)
+		if (reconciled.applyValue !== null) {
 			applyExternalValue(reconciled.applyValue)
+		}
 		return (
 			<input
-				type="search"
+				type="text"
+				role="searchbox"
+				inputMode="search"
+				autoComplete="off"
+				autoCorrect="off"
+				spellCheck="false"
 				data-field-ring
 				defaultValue={initialValue}
 				placeholder={handle.props.placeholder}
@@ -100,22 +87,27 @@ export function RecordTableSearch(
 							if (input === node) input = null
 						})
 					}),
+					on('focus', () => {
+						focused = true
+					}),
 					on('input', (event) => {
 						const value = (event.currentTarget as HTMLInputElement).value
 						sync = acknowledgeRecordTableSearchInput(value)
 						handle.props.onInput(value)
 					}),
 					on('blur', () => {
+						focused = false
 						if (sync.pendingExternalValue !== null) {
 							applyExternalValue(sync.pendingExternalValue)
 						}
 					}),
 					css({
 						...getAuthInputCss(),
+						appearance: 'none',
+						WebkitAppearance: 'none',
 						flex: '1 1 12rem',
 						minWidth: '7rem',
 						width: 'auto',
-						...searchCancelHiddenCss,
 					}),
 				]}
 			/>

--- a/packages/worker/client/routes/record-table-controls.tsx
+++ b/packages/worker/client/routes/record-table-controls.tsx
@@ -13,6 +13,7 @@ import {
 import {
 	acknowledgeRecordTableSearchInput,
 	reconcileRecordTableSearchExternalValue,
+	writeUncontrolledSearchInput,
 	type RecordTableSearchSync,
 } from './record-table-search-sync.ts'
 
@@ -53,7 +54,7 @@ export function RecordTableSearch(
 	}
 
 	function applyExternalValue(nextValue: string) {
-		if (input) input.value = nextValue
+		writeUncontrolledSearchInput(input, nextValue)
 		sync = acknowledgeRecordTableSearchInput(nextValue)
 	}
 

--- a/packages/worker/client/routes/record-table-search-sync.ts
+++ b/packages/worker/client/routes/record-table-search-sync.ts
@@ -16,8 +16,11 @@ export function acknowledgeRecordTableSearchInput(
 
 /**
  * Reconcile an incoming `value` prop (URL / back-button) with the last
- * applied or typed string. Focused changes wait for blur; a return to the
- * last applied value clears a stale pending string instead of keeping it.
+ * applied or typed string. `focused` is a focus/blur latch on the field —
+ * not `document.activeElement` during render, which Remix's selection
+ * capture often leaves pointing at body. Focused changes wait for blur; a
+ * return to the last applied value clears a stale pending string instead of
+ * keeping it.
  */
 export function reconcileRecordTableSearchExternalValue(
 	state: RecordTableSearchSync,

--- a/packages/worker/client/routes/record-table-search-sync.ts
+++ b/packages/worker/client/routes/record-table-search-sync.ts
@@ -53,3 +53,11 @@ export function reconcileRecordTableSearchExternalValue(
 		applyValue: nextValue,
 	}
 }
+
+/** Write a programmatic filter string into an uncontrolled live-search field. */
+export function writeUncontrolledSearchInput(
+	input: HTMLInputElement | null,
+	value: string,
+) {
+	if (input) input.value = value
+}

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -3,6 +3,7 @@ import { renderToString } from 'remix/ui/server'
 import { expect, test } from 'vitest'
 import {
 	RecordTable,
+	RecordTableSearch,
 	recordTableCreateId,
 	resolveRecordTableSelection,
 	type RecordTableColumn,
@@ -299,6 +300,52 @@ test('record table search defers focused URL updates and drops a stale pending s
 		state: empty,
 		applyValue: '',
 	})
+})
+
+test('record table search stays an uncontrolled searchbox outside the filtered rows', async () => {
+	const toolbar = jsx(RecordTableSearch, {
+		label: 'Search secrets',
+		placeholder: 'Search secrets',
+		value: '',
+		onInput: () => {},
+	})
+	const withRows = await renderToString(
+		jsx(RecordTable, {
+			mode: 'none',
+			ariaLabel: 'Secrets',
+			columns,
+			rows,
+			toolbar,
+			countLabel: '2 of 2 shown',
+		}),
+	)
+	const filteredEmpty = await renderToString(
+		jsx(RecordTable, {
+			mode: 'none',
+			ariaLabel: 'Secrets',
+			columns,
+			rows: [],
+			toolbar,
+			countLabel: '0 of 2 shown',
+			emptyLabel: 'No secrets match the current filters.',
+		}),
+	)
+
+	for (const html of [withRows, filteredEmpty]) {
+		expect(html).toContain('role="searchbox"')
+		expect(html).toContain('aria-label="Search secrets"')
+		expect(html).toContain('type="text"')
+		expect(html).toContain('inputmode="search"')
+		expect(html).not.toContain('type="search"')
+	}
+	expect(withRows.indexOf('role="searchbox"')).toBeLessThan(
+		withRows.indexOf('<tbody'),
+	)
+
+	expect(withRows).toContain('<table')
+	expect(filteredEmpty).not.toContain('<table')
+	expect(filteredEmpty).toContain('No secrets match the current filters.')
+	expect(filteredEmpty).toContain('0 of 2 shown')
 })
 
 test('record table empty and busy states keep toolbar layout stable', async () => {

--- a/packages/worker/client/routes/record-table.node.test.ts
+++ b/packages/worker/client/routes/record-table.node.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	acknowledgeRecordTableSearchInput,
 	reconcileRecordTableSearchExternalValue,
+	writeUncontrolledSearchInput,
 } from '#client/routes/record-table-search-sync.ts'
 
 const columns: Array<RecordTableColumn> = [
@@ -300,6 +301,13 @@ test('record table search defers focused URL updates and drops a stale pending s
 		state: empty,
 		applyValue: '',
 	})
+})
+
+test('programmatic live-search resets write the uncontrolled input', () => {
+	const input = { value: 'src/auth' } as HTMLInputElement
+	writeUncontrolledSearchInput(input, '')
+	expect(input.value).toBe('')
+	writeUncontrolledSearchInput(null, 'ignored')
 })
 
 test('record table search stays an uncontrolled searchbox outside the filtered rows', async () => {

--- a/packages/worker/client/routes/record-table.tsx
+++ b/packages/worker/client/routes/record-table.tsx
@@ -563,7 +563,7 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 			>
 				<div mix={[css(paneCss), css(cardFallbackCss)]}>
 					{handle.props.toolbar || handle.props.countLabel ? (
-						<div mix={css(toolbarCss)}>
+						<div key="record-table-toolbar" mix={css(toolbarCss)}>
 							{handle.props.toolbar}
 							{handle.props.countLabel ? (
 								<p
@@ -583,26 +583,35 @@ export function RecordTable(handle: Handle<RecordTableProps>) {
 							</span>
 						</div>
 					) : null}
-					{rows.length === 0 ? (
-						<p mix={css(emptyCss)}>
-							{handle.props.emptyLabel ?? 'Nothing to show yet.'}
-						</p>
-					) : (
-						<div
-							mix={css({
-								...tableScrollerCss,
-								...(capped
-									? {
-											maxHeight:
-												handle.props.scrollHeight ?? defaultScrollHeight,
-											overflowY: 'auto' as const,
-										}
-									: null),
-							})}
-						>
-							{table}
-						</div>
-					)}
+					{/*
+					 * Keep a stable keyed host around the collection so filtering
+					 * from some rows to none (or the reverse) replaces only the
+					 * inner empty copy / table, not a sibling of the toolbar. An
+					 * unkeyed type swap next to the search field remounts it and
+					 * drops focus on the keystroke that emptied the list.
+					 */}
+					<div key="record-table-collection">
+						{rows.length === 0 ? (
+							<p mix={css(emptyCss)}>
+								{handle.props.emptyLabel ?? 'Nothing to show yet.'}
+							</p>
+						) : (
+							<div
+								mix={css({
+									...tableScrollerCss,
+									...(capped
+										? {
+												maxHeight:
+													handle.props.scrollHeight ?? defaultScrollHeight,
+												overflowY: 'auto' as const,
+											}
+										: null),
+								})}
+							>
+								{table}
+							</div>
+						)}
+					</div>
 					{handle.props.footer ? (
 						<div mix={css(footerCss)}>{handle.props.footer}</div>
 					) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop account search fields from dropping focus after the first keystroke so you can keep typing without clicking the field again.

## Why

On `/account/secrets` and other live-filter tables, focusing the search input and typing one character sometimes stole focus. Three things were fighting the field:

- `type="search"` shows a native cancel control on the first character. CSS did not reliably hide it, so WebKit/Blink could move focus off the field.
- Remix captures document selection *before* render, so `document.activeElement === input` during render was often false. That let a URL/`q` update write back over the keystroke.
- Filtering the list to zero rows swapped an unkeyed empty `<p>` in as a sibling of the toolbar, which remounted the input on the keystroke that emptied the list.

Making those fields uncontrolled also meant a programmatic query reset (file navigation, OAuth resolver href change) left the old text in the box while the list showed everything. This follow-up writes that reset into the DOM without putting Remix back in control of `value`, and the OAuth chooser ref only clears on detach of the same node.

## Summary

- `RecordTableSearch` is `type="text"` + `role="searchbox"` + `inputMode="search"` (no native search cancel).
- Focus is a focus/blur latch, not `activeElement` during render.
- The table toolbar and collection sit on stable keys so empty-vs-rows swaps do not remount the search field.
- Other live filters (OAuth chooser, package files, reserved usernames) drop Remix-controlled `value` and `type="search"`.
- File-tree and OAuth chooser filters still clear the input when navigation or resolver state wipes the query.
- Node HTML contract test plus an account e2e that types without losing the same focused node.

## Testing

- `npx vitest run packages/worker/client/routes/record-table.node.test.ts --project node-unit`
- Playwright against local origin and PR preview: type `alphaSecretFocus` on `/account/secrets` without remount or focus loss
- `test:push` on commit (node-unit + workers-unit)
- Preview: seed two secrets as `me@kentcdodds.com`, open `/account/secrets`, type without clicking again
- Headed preview recording: `/opt/cursor/artifacts/preview_secrets_search_keeps_focus.mp4`

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends app-ui</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e524c5b` · **Head:** `757c3d78`

**Classification:** extends — live search focus and table toolbar reconciliation in `app-ui` change so a keystroke no longer remounts or blurs the field.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | extends — search input host, focus latch, keyed table collection, programmatic reset write-back |

Unmatched: `e2e/account-navigation.spec.ts` (Playwright coverage for the same path).

### Change flow

Typing into a live account search updates the URL-backed filter and the visible rows without remounting or blurring the field.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: type first character into searchbox
	Note over appUi: type=text searchbox, no native cancel
	appUi->>appUi: acknowledge typed string, replaceLocation q
	appUi->>appUi: filter rows, keep keyed toolbar host
	appUi-->>User: same focused input, list updates
```

### Before / after

| Before | After |
| ------ | ----- |
| `type="search"` + CSS hide for cancel | `type="text"` `role="searchbox"` |
| `document.activeElement` during render | focus/blur latch |
| Unkeyed empty copy swapped next to toolbar | keyed `record-table-collection` host |
| Uncontrolled filter kept stale text after nav reset | write the cleared query into the input |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-306e5569-22da-5d2a-8b8d-6591a99c271e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-306e5569-22da-5d2a-8b8d-6591a99c271e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Search fields now remain focused and retain entered text while filtering, including when no matches are found.
  - Improved filtering behavior across account secrets, jobs, provider marks, reserved usernames, OAuth services, and package files.
  - Search controls no longer unexpectedly remount or lose focus as result lists change.
  - Search fields are cleared correctly when navigating to a different path or resetting a selection.

- **Accessibility**
  - Standardized search controls with searchable roles, appropriate input modes, and disabled autocomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->