### PR TITLE
Redesign the package combobox: names only, select-styled field, no overlapping rows

### DIFF
--- a/packages/worker/client/combobox.node.test.ts
+++ b/packages/worker/client/combobox.node.test.ts
@@ -1,0 +1,60 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { Combobox } from '#client/combobox.tsx'
+
+const options = [
+	{ id: '', label: 'All packages' },
+	{
+		id: '4ad2f1d3-8ea9-4f31-995c-45d59972e665',
+		label: 'rotosphere',
+		keywords: ['4ad2f1d3-8ea9-4f31-995c-45d59972e665'],
+	},
+	{
+		id: '121967c1-7c71-4192-8616-0d27ff07d179',
+		label: 'court-projector',
+		keywords: ['121967c1-7c71-4192-8616-0d27ff07d179'],
+	},
+]
+
+test('combobox shows the selected label, keeps ids out of the list, and can hide its label', async () => {
+	const selectedHtml = await renderToString(
+		jsx(Combobox, {
+			id: 'package-filter',
+			label: 'Filter secrets by package',
+			hideLabel: true,
+			placeholder: 'All packages',
+			value: '4ad2f1d3-8ea9-4f31-995c-45d59972e665',
+			options,
+			onChange: () => {},
+		}),
+	)
+
+	// The field reads the package name, never the UUID behind it.
+	expect(selectedHtml).toMatch(/<input[^>]*value="rotosphere"/)
+	expect(selectedHtml).not.toContain('4ad2f1d3-8ea9-4f31-995c-45d59972e665')
+	expect(selectedHtml).toContain('>rotosphere<')
+	expect(selectedHtml).toContain('>court-projector<')
+	// One row per option: the id is a search keyword, not a second line.
+	expect(selectedHtml.match(/role="option"/g)).toHaveLength(3)
+	// The label still names the field for assistive tech.
+	expect(selectedHtml).toContain('Filter secrets by package')
+	expect(selectedHtml).toMatch(/<input[^>]*id="package-filter"/)
+	expect(selectedHtml).toMatch(/<label[^>]*for="package-filter"/)
+	expect(selectedHtml).toContain('data-field-ring')
+
+	// An empty value shows the placeholder rather than the "all" option's text,
+	// so typing to filter starts on an empty field.
+	const emptyHtml = await renderToString(
+		jsx(Combobox, {
+			id: 'package-filter',
+			label: 'Filter secrets by package',
+			placeholder: 'All packages',
+			value: '',
+			options,
+			onChange: () => {},
+		}),
+	)
+	expect(emptyHtml).not.toMatch(/<input[^>]*value="All packages"/)
+	expect(emptyHtml).toMatch(/<input[^>]*placeholder="All packages"/)
+})

--- a/packages/worker/client/combobox.tsx
+++ b/packages/worker/client/combobox.tsx
@@ -219,11 +219,10 @@ const comboboxOptionCss = {
 	'&[data-highlighted="true"]': {
 		backgroundColor: colors.primarySoft,
 	},
+	'--combobox-check-opacity': '0',
 	'&[aria-selected="true"]': {
 		fontWeight: typography.fontWeight.medium,
-	},
-	'&[aria-selected="true"] > svg': {
-		opacity: 1,
+		'--combobox-check-opacity': '1',
 	},
 	'&[aria-disabled="true"]': {
 		opacity: 0.5,
@@ -236,7 +235,7 @@ const comboboxCheckCss = {
 	width: '1rem',
 	height: '1rem',
 	color: colors.primary,
-	opacity: 0,
+	opacity: 'var(--combobox-check-opacity)',
 }
 
 const comboboxOptionLabelCss = {

--- a/packages/worker/client/combobox.tsx
+++ b/packages/worker/client/combobox.tsx
@@ -1,21 +1,38 @@
 import { type Handle, css } from 'remix/ui'
+import * as combobox from 'remix/ui/combobox/primitives'
 import {
-	Combobox as RemixCombobox,
-	ComboboxOption as RemixComboboxOption,
-} from 'remix/ui/combobox'
-import { onComboboxChange } from 'remix/ui/combobox/primitives'
-import { colors, radius, shadows, spacing } from '#universal/styles/tokens.ts'
-import { fieldLabelCss, inputCss } from '#universal/styles/style-primitives.ts'
+	colors,
+	radius,
+	shadows,
+	spacing,
+	typography,
+} from '#universal/styles/tokens.ts'
+import {
+	fieldLabelCss,
+	getSelectCss,
+	visuallyHiddenCss,
+} from '#universal/styles/style-primitives.ts'
 
-type ComboboxOption = {
+export type ComboboxOption = {
 	id: string
 	label: string
-	description?: string | null
+	/**
+	 * Extra text a typed query matches (an id, an alias). Never rendered — a
+	 * row is its label alone so a long list scans as names, and an id still
+	 * finds its row when someone pastes one.
+	 */
+	keywords?: Array<string>
 }
 
 type ComboboxProps = {
 	id: string
 	label: string
+	/**
+	 * Toolbar use: the label is the accessible name only. Sibling toolbar
+	 * controls carry `aria-label`, so a visible caption would sit alone above
+	 * this field and push it out of line with them.
+	 */
+	hideLabel?: boolean
 	placeholder?: string
 	value: string
 	options: Array<ComboboxOption>
@@ -24,49 +41,94 @@ type ComboboxProps = {
 }
 
 /**
- * Kody's labeled, design-system adapter for Remix's accessible combobox.
- * Remix owns filtering, draft and committed values, keyboard interaction,
- * focus timing, popover behavior, and ARIA state.
+ * Kody's labeled combobox on Remix's unstyled combobox primitives. Remix owns
+ * filtering, draft and committed values, keyboard interaction, focus timing,
+ * popover positioning, and ARIA state; Kody owns the markup and every style,
+ * so the field is the same box as `getSelectCss` (chevron included) and the
+ * list uses the app's tokens. The styled `remix/ui/combobox` components were
+ * not used because each `css()` call is its own cascade layer ordered by first
+ * use, so their input styles beat any override applied from a parent.
+ *
+ * Remix shows its committed value as the input text, so the option value
+ * handed to Remix is the label and the id is mapped back on change — the
+ * field then reads "sentry", not the package's UUID. Labels must be unique
+ * within one combobox (Remix's own exact-match on blur already assumes so).
  */
 export function Combobox(handle: Handle<ComboboxProps>) {
 	return () => {
 		const props = handle.props
+		const optionsByLabel = new Map(
+			props.options.map((option) => [option.label, option]),
+		)
+		const selectedLabel = props.value
+			? props.options.find((option) => option.id === props.value)?.label
+			: undefined
 		return (
 			<div mix={css(comboboxFieldCss)}>
-				<label for={props.id} mix={css(fieldLabelCss)}>
+				<label
+					for={props.id}
+					mix={css(props.hideLabel ? visuallyHiddenCss : fieldLabelCss)}
+				>
 					{props.label}
 				</label>
-				<RemixCombobox
-					inputId={props.id}
-					defaultValue={props.value || null}
+				<combobox.Context
+					defaultValue={selectedLabel ?? null}
 					disabled={props.disabled}
-					placeholder={props.placeholder}
-					mix={[
-						css(comboboxRootCss),
-						onComboboxChange((event) => {
-							if (event.value == null) return
-							props.onChange(event.value)
-						}),
-					]}
 				>
-					{props.options.map((option) => (
-						<RemixComboboxOption
-							key={option.id}
-							label={option.label}
-							searchValue={[option.label, option.description ?? '', option.id]}
-							value={option.id}
-						>
-							<span mix={css(comboboxOptionContentCss)}>
-								<span>{option.label}</span>
-								{option.description ? (
-									<span mix={css(comboboxDescriptionCss)}>
-										{option.description}
-									</span>
-								) : null}
-							</span>
-						</RemixComboboxOption>
-					))}
-				</RemixCombobox>
+					<div
+						mix={[
+							css(comboboxRootCss),
+							combobox.onComboboxChange((event) => {
+								if (event.value == null) return
+								const option = optionsByLabel.get(event.value)
+								if (option) props.onChange(option.id)
+							}),
+						]}
+					>
+						<input
+							data-field-ring
+							id={props.id}
+							defaultValue={selectedLabel}
+							placeholder={props.placeholder}
+							mix={[css(comboboxInputCss), combobox.input()]}
+						/>
+						<div mix={[css(comboboxPopoverCss), combobox.popover()]}>
+							<div mix={[css(comboboxListCss), combobox.list()]}>
+								{props.options.map((option) => (
+									<div
+										key={option.id}
+										mix={[
+											css(comboboxOptionCss),
+											combobox.option({
+												label: option.label,
+												searchValue: [option.label, ...(option.keywords ?? [])],
+												value: option.label,
+											}),
+										]}
+									>
+										<svg
+											aria-hidden="true"
+											viewBox="0 0 16 16"
+											mix={css(comboboxCheckCss)}
+										>
+											<path
+												d="M3 8.5l3 3 7-7"
+												fill="none"
+												stroke="currentColor"
+												stroke-width="2"
+												stroke-linecap="round"
+												stroke-linejoin="round"
+											/>
+										</svg>
+										<span mix={css(comboboxOptionLabelCss)}>
+											{option.label}
+										</span>
+									</div>
+								))}
+							</div>
+						</div>
+					</div>
+				</combobox.Context>
 			</div>
 		)
 	}
@@ -80,39 +142,108 @@ const comboboxFieldCss = {
 
 const comboboxRootCss = {
 	position: 'relative' as const,
-	'& input[role="combobox"]': {
-		...inputCss,
-		minHeight: 'auto',
-		boxShadow: 'none',
-	},
-	'& [popover]': {
-		zIndex: 10,
-		maxHeight: '18rem',
-		overflowY: 'auto' as const,
-		borderRadius: radius.md,
-		border: `1px solid ${colors.border}`,
-		backgroundColor: colors.surface,
-		boxShadow: shadows.md,
-		padding: spacing.xs,
-		color: colors.text,
-	},
-	'& [role="option"]': {
-		borderRadius: radius.md,
-		color: colors.text,
-		'&[data-highlighted="true"], &:hover': {
-			backgroundColor: colors.primarySoftest,
-		},
-	},
-}
-
-const comboboxOptionContentCss = {
-	display: 'grid',
-	gap: spacing.xs,
 	minWidth: 0,
 }
 
-const comboboxDescriptionCss = {
-	fontSize: 'var(--font-size-sm)',
-	color: colors.textMuted,
-	overflowWrap: 'anywhere' as const,
+const comboboxInputCss = {
+	...getSelectCss(),
+	cursor: 'text',
+	'&:disabled': {
+		opacity: 0.6,
+		cursor: 'not-allowed',
+	},
+}
+
+/**
+ * Remix's anchor positioning writes `top`/`left` inline on the popover, so
+ * the UA's centered `[popover]` box (`inset: 0`, `margin: auto`) has to be
+ * reset here for that to take effect.
+ */
+const comboboxPopoverCss = {
+	position: 'fixed' as const,
+	inset: 'auto',
+	margin: 0,
+	padding: 0,
+	zIndex: 10,
+	display: 'flex',
+	flexDirection: 'column' as const,
+	minWidth: '12rem',
+	maxWidth: `min(24rem, calc(100vw - (${spacing.lg} * 2)))`,
+	maxHeight: 'min(18rem, 50dvh)',
+	overflow: 'hidden',
+	border: `1px solid ${colors.border}`,
+	borderRadius: radius.md,
+	backgroundColor: colors.surface,
+	color: colors.text,
+	boxShadow: shadows.md,
+	opacity: 0,
+	'&:popover-open': {
+		opacity: 1,
+	},
+	'&:not(:popover-open)': {
+		pointerEvents: 'none',
+	},
+	'&::backdrop': {
+		background: 'transparent',
+	},
+}
+
+const comboboxListCss = {
+	display: 'flex',
+	flexDirection: 'column' as const,
+	flex: '1 1 auto',
+	minHeight: 0,
+	padding: spacing.xs,
+	overflow: 'auto',
+	overscrollBehavior: 'contain' as const,
+	outline: 'none',
+	userSelect: 'none' as const,
+}
+
+const comboboxOptionCss = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: spacing.xs,
+	// The list is a flex column: without this, rows shrink toward zero once
+	// the list scrolls and their text spills onto the next row.
+	flexShrink: 0,
+	minHeight: '2.25rem',
+	paddingInline: spacing.sm,
+	borderRadius: radius.sm,
+	fontSize: typography.fontSize.sm,
+	color: colors.text,
+	cursor: 'pointer',
+	'&[hidden]': {
+		display: 'none',
+	},
+	'&[data-highlighted="true"]': {
+		backgroundColor: colors.primarySoft,
+	},
+	'&[aria-selected="true"]': {
+		fontWeight: typography.fontWeight.medium,
+	},
+	'&[aria-selected="true"] > svg': {
+		opacity: 1,
+	},
+	'&[aria-disabled="true"]': {
+		opacity: 0.5,
+		cursor: 'default',
+	},
+}
+
+const comboboxCheckCss = {
+	flex: 'none',
+	width: '1rem',
+	height: '1rem',
+	color: colors.primary,
+	opacity: 0,
+}
+
+const comboboxOptionLabelCss = {
+	display: 'block',
+	flex: '1 1 auto',
+	minWidth: 0,
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap' as const,
 }

--- a/packages/worker/client/combobox.tsx
+++ b/packages/worker/client/combobox.tsx
@@ -101,7 +101,7 @@ export function Combobox(handle: Handle<ComboboxProps>) {
 											css(comboboxOptionCss),
 											combobox.option({
 												label: option.label,
-												searchValue: [option.label, ...(option.keywords ?? [])],
+												searchValue: getOptionSearchValues(option),
 												value: option.label,
 											}),
 										]}
@@ -132,6 +132,16 @@ export function Combobox(handle: Handle<ComboboxProps>) {
 			</div>
 		)
 	}
+}
+
+/**
+ * Remix matches a typed query as a prefix of any search value, so a label's
+ * later words join the list: "discord" then finds `kody-discord` and
+ * "notifier" finds `platform-feedback-discord-notifier`.
+ */
+function getOptionSearchValues(option: ComboboxOption) {
+	const words = option.label.split(/[^\p{L}\p{N}]+/u).filter(Boolean)
+	return [option.label, ...words.slice(1), ...(option.keywords ?? [])]
 }
 
 const comboboxFieldCss = {

--- a/packages/worker/client/routes/account-secrets-editor.tsx
+++ b/packages/worker/client/routes/account-secrets-editor.tsx
@@ -3,7 +3,7 @@ import { on } from '#client/event-mixin.ts'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { type AccountSecretDetail } from '#universal/loader-data.ts'
 import { type createDoubleCheck } from '#client/double-check.ts'
-import { Combobox } from '#client/combobox.tsx'
+import { Combobox, type ComboboxOption } from '#client/combobox.tsx'
 import {
 	colors,
 	mq,
@@ -41,16 +41,8 @@ export type SecretEditorProps = {
 	editorState: EditorState
 	setEditorState: (next: EditorState) => void
 	packageOptions: Array<{ id: string }>
-	packageSelectOptions: Array<{
-		id: string
-		label: string
-		description: string
-	}>
-	availableAllowedPackageOptions: Array<{
-		id: string
-		label: string
-		description: string
-	}>
+	packageSelectOptions: Array<ComboboxOption>
+	availableAllowedPackageOptions: Array<ComboboxOption>
 	packagesById: ReadonlyMap<string, { kodyId: string; name: string }>
 	canCreatePackageSecrets: boolean
 	isMutating: boolean

--- a/packages/worker/client/routes/account-secrets.tsx
+++ b/packages/worker/client/routes/account-secrets.tsx
@@ -20,7 +20,7 @@ import {
 	readJson,
 	submitApprovalRequest,
 } from '#client/routes/account-approval-shared.ts'
-import { Combobox } from '#client/combobox.tsx'
+import { Combobox, type ComboboxOption } from '#client/combobox.tsx'
 import { colors } from '#universal/styles/tokens.ts'
 import { getPillButtonCss } from '#universal/styles/style-primitives.ts'
 import { getNewSecretValueAutofocusKey } from './new-secret-query.ts'
@@ -69,6 +69,17 @@ import {
 export { accountSecretsRouteLoader }
 
 const clampedCellCss = css(recordCellClamp(26))
+
+/**
+ * A fixed measure that fits a package name beside the scope select on a wide
+ * row. On a narrow container it takes a row of its own: sharing one with the
+ * select squeezed both below their labels ("All sco…").
+ */
+const packageFilterSlotCss = {
+	flex: '0 1 15rem',
+	minWidth: '9rem',
+	'@container (max-width: 620px)': { flex: '1 1 100%' },
+}
 
 export function AccountSecretsRoute(handle: Handle) {
 	let packageOptions: Array<PackageOption> = []
@@ -496,23 +507,21 @@ export function AccountSecretsRoute(handle: Handle) {
 
 		const filters = readFilterState(currentHref, packageOptions)
 		const filteredSecrets = filterSecrets(secrets, filters, packagesById)
-		const packageSelectOptions = packageOptions.map((packageOption) => {
-			const metadata = packagesById.get(packageOption.id)
-			return {
-				id: packageOption.id,
-				label: metadata?.kodyId ?? packageOption.title,
-				description: packageOption.id,
-			}
-		})
+		const packageSelectOptions: Array<ComboboxOption> = packageOptions.map(
+			(packageOption) => {
+				const metadata = packagesById.get(packageOption.id)
+				return {
+					id: packageOption.id,
+					label: metadata?.kodyId ?? packageOption.title,
+					keywords: [packageOption.id],
+				}
+			},
+		)
 		const availableAllowedPackageOptions = packageSelectOptions.filter(
 			(option) => !editorState.allowedPackages.includes(option.id),
 		)
-		const filterPackageOptions = [
-			{
-				id: '',
-				label: 'All packages',
-				description: 'Show secrets across every package',
-			},
+		const filterPackageOptions: Array<ComboboxOption> = [
+			{ id: '', label: 'All packages' },
 			...packageSelectOptions,
 		]
 
@@ -664,12 +673,13 @@ export function AccountSecretsRoute(handle: Handle) {
 								<option value="package">Package</option>
 							</RecordTableSelect>
 							{packageOptions.length > 0 ? (
-								<span mix={css({ flex: '1 1 14rem', minWidth: '10rem' })}>
+								<span mix={css(packageFilterSlotCss)}>
 									<Combobox
 										key={`secret-package-filter:${filters.packageId}`}
 										id="secret-package-filter"
-										label="Package filter"
-										placeholder="Filter by package"
+										label="Filter secrets by package"
+										hideLabel
+										placeholder="All packages"
 										value={filters.scope === 'user' ? '' : filters.packageId}
 										disabled={filters.scope === 'user'}
 										options={filterPackageOptions}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make the package pickers in the account UI (the secrets toolbar filter and the two pickers in the secret editor) clear and scannable instead of looking broken.

## Why

The "Package filter" on `/account/secrets` stacked each package's name over its UUID inside a Remix combobox whose list is a flex column. Once the list was long enough to scroll, rows shrank to the control height and the UUID of one row collided with the name of the next. The visible caption also pushed the field below the sibling scope select, the field used a different box than the other toolbar controls, and after picking a package the input showed the raw UUID.

## Summary

- `client/combobox.tsx` is rebuilt on Remix's unstyled combobox primitives (`remix/ui/combobox/primitives`) so Kody owns the markup and styles. The styled `remix/ui/combobox` components could not be overridden reliably: each `css()` call is its own `@layer rmx.<hash>` ordered by first use, so their input styles beat any override applied from a parent.
- Rows show the name only. Ids move to a `keywords` search value, so pasting a package id still finds its row, and rows no longer shrink (`flex-shrink: 0`).
- Remix's typeahead is prefix-only, so each later word of a label also joins its search values: typing `discord` finds `kody-discord` and `platform-feedback-discord-notifier`.
- The field is the same box as `getSelectCss` (chevron included), so it matches the sibling toolbar select and the editor's scope select. The selected row carries a check mark in the primary color.
- The option value handed to Remix is the label and the id is mapped back on change, so the committed field text reads `sentry` rather than a UUID.
- Secrets toolbar: the caption becomes the accessible name (`hideLabel`), placeholder is `All packages`, and on narrow containers the filter takes its own row so the scope select is not squeezed to `All sco…`.
- Same shared treatment for the editor's "Package" chooser and "Add allowed package" picker (the added-package chip still shows the id).
- The filter combobox keeps its existing `key` so it does not remount while typing; this PR does not touch `RecordTableSearch`.

## Testing

- `npm run validate`: every gate green locally (format, lint, typecheck, knip, node + workers + mcp unit suites, builds, startup budgets, docs and migration checks) except the Playwright leg, whose Vite web server failed to start (`Parent environment not initialized`) because a second `npm run dev` was running on the VM. With that server stopped, `CI=1 npm run test:e2e:run` passed: 15 passed. CI is green on the head commit.
- New `client/combobox.node.test.ts` renders the adapter: selected label as field text, ids absent from the list, one row per option, hidden label still names the field, empty value shows the placeholder.
- Local browser pass as `jane@example.com` with 16 saved packages and 8 secrets on desktop (1280) and mobile (390): open, type-to-filter (`sen`, `discord`), arrow + enter selection, URL `?package=<id>`, editor pickers, dark mode.
- Preview (`npm run control-kody -- preview -- --pr 2254 --check /account/secrets`) as `me@kentcdodds.com`: three saved packages via `package-create`, one package secret and one user secret via `POST /account/secrets.json`; the filter renders names only, typing `beta` shows `preview-beta`, selecting it navigates to `?package=8768faae-…`.

## System changes

See the recap block below.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e524c5b` · **Head:** `8d1d564a`

**Classification:** composes — no primitives added or changed; this PR restyles one shared browser-app component and its three call sites inside `app-ui`. No route, handler, storage, or worker code changes.

### Primitives touched

| Primitive | Group    | Impact                                                                              |
| --------- | -------- | ----------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — `client/combobox.tsx` rebuilt on Remix combobox primitives; secrets page |

### Change flow

Picking a package in the secrets toolbar now shows the package name and writes the same `?package=<id>` the route already read.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant remixCombobox as remix/ui/combobox primitives
	User->>appUi: open package filter, type a name or paste an id
	appUi->>remixCombobox: options carry label as value, label words and id as search keywords
	remixCombobox-->>appUi: rmx:combobox-change with the chosen label
	appUi->>appUi: map label back to package id, replaceLocation(?package=id)
	Note over appUi: field text reads the package name, not its UUID
```

### Before / after

| Surface                                  | Before                                                                     | After                                                                  |
| ---------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| Secrets toolbar filter                   | Visible "Package filter" caption pushed the field below the sibling select | Caption is the accessible name; field sits in line, styled as a select |
| Combobox rows                            | Name + UUID stacked, rows shrank and overlapped once the list scrolled     | Name only, `flex-shrink: 0`, ids and later words still match a query   |
| Committed value                          | Input showed the raw UUID after a pick                                     | Input shows the label, list marks it with a check                      |
| Editor "Package" / "Add allowed package" | Same stacked rows                                                          | Same shared treatment                                                  |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eb87690-2a15-55ae-8d5d-a09637951aba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eb87690-2a15-55ae-8d5d-a09637951aba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved package selection and filtering with a more consistent combobox experience.
  - Added support for hiding combobox labels when appropriate while preserving accessibility connections.
  - Package options now support searchable keywords.

- **Bug Fixes**
  - Selected package names are displayed instead of internal identifiers.
  - Empty selections now show the configured placeholder rather than an option label.
  - Improved option rendering and accessibility behavior for package selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->