### PR TITLE
Add a first-class Connections page and Packages to the account rail

### DIFF
--- a/.agents/skills/control-kody/references/features/README.md
+++ b/.agents/skills/control-kody/references/features/README.md
@@ -27,6 +27,7 @@ Then drive the surface with `login`, `request`, `preview`, and `health`. See the
 - [two-factor](./two-factor.md) — `/account/two-factor`
 - [passkeys](./passkeys.md) — `/account/passkeys`
 - [account](./account.md) — `/account`
+- [connections](./connections.md) — `/account/connections`
 - [packages](./packages.md) — `/@username`
 - [shared](./shared.md) — `/account/shared`
 - [secrets](./secrets.md) — `/account/secrets`

--- a/.agents/skills/control-kody/references/features/account.md
+++ b/.agents/skills/control-kody/references/features/account.md
@@ -1,10 +1,16 @@
 # Account hub
 
-Signed-in home: profile, export, logout, delete, and links to the other account
-surfaces. Logout lives at the bottom of this page, not in the site header.
-Desktop puts an Account link in the header to the left of the avatar; narrower
-viewports keep Account in the menu panel. The header avatar goes to the public
-profile (`/@username`).
+Signed-in home: profile, sign-in providers, export, logout, delete, and links to
+the other account surfaces. Logout lives at the bottom of this page, not in the
+site header. Desktop puts an Account link in the header to the left of the
+avatar; narrower viewports keep Account in the menu panel. The header avatar
+goes to the public profile (`/@username`).
+
+The account rail ("Account sections") lists every account page plus Packages
+(`/@username`, the canonical package list) and Connections
+(`/account/connections`, connected agents). The rail is rendered by
+`AccountPageHeader` in
+`packages/worker/client/routes/account-management-components.tsx`.
 
 ## How to get there
 
@@ -15,7 +21,7 @@ profile (`/@username`).
 ```bash
 node tools/control-kody.ts login
 node tools/control-kody.ts request GET /account/profile.json
-node tools/control-kody.ts request GET /account/connected-agents.json
+node tools/control-kody.ts request GET /account/connections.json
 ```
 
 ## APIs
@@ -26,17 +32,17 @@ node tools/control-kody.ts request GET /account/connected-agents.json
 - `POST /account/email-claim-release.json`
 - `GET /account/export.json`
 - `POST /account/delete`
-- `GET|POST /account/connections.json`
-- `GET|POST /account/connected-agents.json`
+- `GET|POST /account/connections.json` (sign-in providers: GitHub, Google, X,
+  Discord)
 - `POST /logout` (form at the bottom of this page)
 
 ## Gotchas
 
 - Seed users start empty. Profile fields exist; packages/secrets/jobs do not
   until you create them.
-- Connected agents lists inbound OAuth hosts grouped by display name (logos for
-  known kinds, newest-first, best-effort labels, per-`clientId` revoke). That
-  list is not `users.mcp_client_name` and not minted MCP OAuth clients.
+- Connected agents (inbound MCP hosts) are not on this page. They live on
+  [connections](./connections.md) at `/account/connections`; Overview only links
+  there.
 - Former-address release is `POST /account/email-claim-release.json`, then
   confirm at `/verify-email-claim-release`. It drops the claim without reminting
   `users.stable_user_id`.

--- a/.agents/skills/control-kody/references/features/connections.md
+++ b/.agents/skills/control-kody/references/features/connections.md
@@ -1,0 +1,35 @@
+# Connections
+
+Inbound MCP hosts (connected agents): the MCP URL to paste into another agent,
+per-host setup guide links, the grouped list of hosts that already authorized,
+and per-`clientId` revoke. Also links the Advanced MCP OAuth clients page.
+
+## How to get there
+
+`/account/connections` (account rail → Connections; Overview keeps a "Manage
+connections" link). Setup guides link to `/onboarding`, which resumes at the
+right wizard step for the account.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts login
+node tools/control-kody.ts request GET /account/connected-agents.json
+```
+
+## APIs
+
+- `GET|POST /account/connected-agents.json` (`{ intent: 'revoke', clientId }`)
+- `mcpServerUrl` in that payload is empty until the account email is verified
+  (same gate as `/onboarding.json`); the page then shows a verify note instead
+  of the copy card.
+
+## Gotchas
+
+- Seed users start with no connected agents; connect one from onboarding or an
+  MCP host to see the list. Revoke is a double-check button.
+- Hosts are grouped by display name (logos for known kinds, newest-first,
+  best-effort labels). That list is not `users.mcp_client_name` and not minted
+  MCP OAuth clients (`/account/mcp-oauth-clients`).
+- `/account/connections.json` is the sign-in provider (GitHub, Google, …) list
+  on Overview, not this page's data.

--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -608,26 +608,27 @@ routed from `packages/worker/src/index.ts`.
   `packages/worker/src/origin-handler.ts`): a client may present an HTTPS URL as
   its `client_id` with no registration step. Signed-in users can also mint a
   confidential pre-registered client from `/account/mcp-oauth-clients` (Account
-  → Advanced). That page is user-minted clients, not inbound host grants.
-  Account → Connected agents lists inbound grants from `listUserGrants` (paged)
-  joined with `lookupClient` for a best-effort label, authorized time, and
-  revoke. The account UI groups those unique `clientId`s by display name, shows
-  a public icon when the host kind already has an SVG, and sorts newest-first.
-  Timestamps are grant `createdAt` (connected time). The provider grant summary
-  has no last-used / last-accessed field, and recording MCP activity per
-  connection would need new persistence, so the page does not invent a
-  last-heard time. Onboarding Step 3 completion is unique `clientId`s ≥ 2, not
-  raw grant count and not `users.mcp_client_name`. `user_mcp_oauth_clients`
-  stores the account-owned metadata. The provider stores the secret hash in
-  `OAUTH_KV` via `env.OAUTH_PROVIDER.createClient()`. List and revoke are scoped
-  to the owning `user_id`. The plaintext secret is shown once and never written
-  to D1. MCP `2026-07-28` deprecates RFC 7591 dynamic registration in favor of
-  CIMD, so both stay enabled: clients without a pre-registered credential that
-  do not use CIMD register via `/oauth/register`. Failed CIMD fetches throw
-  `CimdFetchError`: authorize maps that to an unknown-client page, and the token
-  endpoint still returns generic `invalid_client`. Any DCR retry after that is
-  the client's own recovery, not a server-side fallback. CIMD metadata fetches
-  rely on the `global_fetch_strictly_public` compatibility flag in
+  → Connections → Advanced). That page is user-minted clients, not inbound host
+  grants. Account → Connections (`/account/connections`) lists inbound grants
+  from `listUserGrants` (paged) joined with `lookupClient` for a best-effort
+  label, authorized time, and revoke. The account UI groups those unique
+  `clientId`s by display name, shows a public icon when the host kind already
+  has an SVG, and sorts newest-first. Timestamps are grant `createdAt`
+  (connected time). The provider grant summary has no last-used / last-accessed
+  field, and recording MCP activity per connection would need new persistence,
+  so the page does not invent a last-heard time. Onboarding Step 3 completion is
+  unique `clientId`s ≥ 2, not raw grant count and not `users.mcp_client_name`.
+  `user_mcp_oauth_clients` stores the account-owned metadata. The provider
+  stores the secret hash in `OAUTH_KV` via `env.OAUTH_PROVIDER.createClient()`.
+  List and revoke are scoped to the owning `user_id`. The plaintext secret is
+  shown once and never written to D1. MCP `2026-07-28` deprecates RFC 7591
+  dynamic registration in favor of CIMD, so both stay enabled: clients without a
+  pre-registered credential that do not use CIMD register via `/oauth/register`.
+  Failed CIMD fetches throw `CimdFetchError`: authorize maps that to an
+  unknown-client page, and the token endpoint still returns generic
+  `invalid_client`. Any DCR retry after that is the client's own recovery, not a
+  server-side fallback. CIMD metadata fetches rely on the
+  `global_fetch_strictly_public` compatibility flag in
   `packages/worker/wrangler.jsonc` for SSRF safety; the provider only advertises
   `client_id_metadata_document_supported` when both are set. ChatGPT CIMD
   documents prefer `private_key_jwt` while also offering `none`; the provider

--- a/docs/contributing/architecture/entitlements.md
+++ b/docs/contributing/architecture/entitlements.md
@@ -120,7 +120,7 @@ payment-adjacent.
 `resolveEffectivePlanWithSecondAgentGift` while `expires_at` is in the future
 and the base rank is still below Standard. The gift never lowers a paid or
 manual grant. Expiry is read-time (no sweeper). Authorize completion and
-grant-list pages (onboarding payload, Account → Connected agents) call
+grant-list pages (onboarding payload, Account → Connections) call
 `maybeEvaluateSecondAgentStandardGift`, which skips the write when unique
 clients are below 2 or listing failed, but still reads the persisted ledger so
 `/onboarding.json` does not hide an already-granted gift. Missing

--- a/docs/contributing/architecture/onboarding.md
+++ b/docs/contributing/architecture/onboarding.md
@@ -37,11 +37,11 @@ weeks." Step 3 copy advertises "Connect a second agent and get Standard free for
 2 weeks." Same-ecosystem greying stays picker UX only. `/onboarding` resumes at
 that step instead of always opening the Step 1 picker, and every wizard step
 still lists already-connected hosts so a return visit cannot hide Cursor or
-Claude Desktop. Account → Connected agents lists those inbound hosts grouped by
-display name, with public logos for known kinds, newest-first sort, best-effort
-labels, and per-`clientId` revoke. That list is not `users.mcp_client_name`
-(first-touch) and not `/account/mcp-oauth-clients` (user-minted confidential
-clients).
+Claude Desktop. Account → Connections (`/account/connections`) lists those
+inbound hosts grouped by display name, with public logos for known kinds,
+newest-first sort, best-effort labels, and per-`clientId` revoke. That list is
+not `users.mcp_client_name` (first-touch) and not `/account/mcp-oauth-clients`
+(user-minted confidential clients).
 
 `first-win` is not a wizard step and is not a checklist item. Signed-in
 `/onboarding` does not probe Mailbox for that loop. MCP registers

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -23,6 +23,10 @@ block and MCP URL, and `/.well-known/mcp/server-card.json` for the server card.
    then approve access. Approving gives that agent full access to this Kody
    account — not a limited permission set.
 
+Once signed in, Account → Connections (`/account/connections`) is the durable
+home for this: it shows the MCP URL with a copy button, links back to these
+per-host guides, lists every agent that has authorized, and lets you revoke one.
+
 Your account email must be verified before authorize can finish or MCP can run.
 If authorize asks you to verify, keep that tab open, finish verification (from
 the email link or `/pending-verification`), then continue. You do not need to
@@ -109,10 +113,10 @@ you only have the MCP URL.
   in a chat must open the Kody authorize window. If that window never opens on
   one browser or device, retry from another. Hosts that need a pre-registered
   confidential client can use **OAuth 2.1 (Static)** with a client minted at
-  Account → Advanced → MCP OAuth clients. Register the exact Open WebUI callback
-  (`{open-webui}/oauth/clients/mcp:{connection-id}/callback`) and set OAuth
-  Server URL to this deployment’s origin when discovery from the MCP URL is not
-  enough.
+  Account → Connections → Advanced → MCP OAuth clients. Register the exact Open
+  WebUI callback (`{open-webui}/oauth/clients/mcp:{connection-id}/callback`) and
+  set OAuth Server URL to this deployment’s origin when discovery from the MCP
+  URL is not enough.
 
 ### Coding vs non-coding agents
 

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -49,8 +49,9 @@ another browser or device. That is a host or environment issue, not a failed
 Kody registration. In Open WebUI, do not set an OAuth MCP tool as a model
 default or pre-enabled tool — enable it in the chat so the host can open the
 authorize window. Hosts that require a pre-registered Client ID and Client
-Secret can mint one at Account → Advanced → MCP OAuth clients and use the host’s
-static OAuth mode. Static mode runs authorize and token exchange.
+Secret can mint one at Account → Connections → Advanced → MCP OAuth clients
+(`/account/mcp-oauth-clients`) and use the host’s static OAuth mode. Static mode
+runs authorize and token exchange.
 
 ## Adding a remote MCP server fails with `Invalid origin uri` or redirect URI errors
 

--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -71,12 +71,21 @@ test('account section switches keep the current page on screen (no loading flash
 		[
 			{ link: 'Memories', heading: 'Memories' },
 			{ link: 'Secrets', heading: 'Secrets' },
+			{ link: 'Connections', heading: 'Connections' },
 			{ link: 'Workflows', heading: 'Workflows' },
 			{ link: 'Overview', heading: 'Account' },
 			{ link: 'Jobs', heading: 'Jobs' },
 		],
 		'Jobs',
 	)
+
+	// Packages sits in the rail at the same level as the other sections and
+	// points at the profile, which is the canonical package list.
+	await expect(
+		page
+			.getByRole('navigation', { name: 'Account sections' })
+			.getByRole('link', { name: 'Packages', exact: true }),
+	).toHaveAttribute('href', `/@${user.username}`)
 })
 
 test('admin section switches keep the current page on screen (no loading flash, no refetch)', async ({

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -259,6 +259,7 @@ registerPreloadPatterns(
 		routePattern(routes.accountBillingSuccess),
 		routePattern(routes.accountUsage),
 		routePattern(routes.accountWaiting),
+		routePattern(routes.accountConnections),
 		routePattern(routes.accountShared),
 		routePattern(routes.communityPackageApproveChanges),
 		routePattern(routes.accountIntegrations),

--- a/packages/worker/client/routes/account-area.ts
+++ b/packages/worker/client/routes/account-area.ts
@@ -7,6 +7,10 @@ export {
 	AccountBillingSuccessRoute,
 	accountBillingSuccessRouteLoader,
 } from './account-billing-success.tsx'
+export {
+	AccountConnectionsRoute,
+	accountConnectionsRouteLoader,
+} from './account-connections.tsx'
 export { AccountEmailRoute, accountEmailRouteLoader } from './account-email.tsx'
 export { AccountUsageRoute, accountUsageRouteLoader } from './account-usage.tsx'
 export {

--- a/packages/worker/client/routes/account-connected-agents-panel.node.test.ts
+++ b/packages/worker/client/routes/account-connected-agents-panel.node.test.ts
@@ -9,6 +9,7 @@ test('connected agents panel groups same-name hosts, shows logos, and keeps revo
 	} as Handle)
 	panel.applyPayload({
 		ok: true,
+		mcpServerUrl: 'https://kody.example/mcp',
 		agents: [
 			{
 				clientId: 'cursor-old',

--- a/packages/worker/client/routes/account-connections.node.test.ts
+++ b/packages/worker/client/routes/account-connections.node.test.ts
@@ -1,0 +1,125 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { AppSessionProvider } from '#client/app-session-context.tsx'
+import { AppLoaderDataProvider } from '#client/loader-data-context.tsx'
+import { RouterLocationProvider } from '#client/router-location.tsx'
+import { AccountConnectionsRoute } from '#client/routes/account-connections.tsx'
+import {
+	accountNavItemsFor,
+	accountPackagesNavHref,
+} from '#client/routes/account-management-components.tsx'
+import { type SessionInfo } from '#client/session.ts'
+import { type AccountConnectedAgentsLoaderData } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
+
+const session: SessionInfo = {
+	email: 'jane@example.com',
+	emailVerified: true,
+	emailVerificationDelivery: null,
+	username: 'jane',
+	avatarUrl: null,
+	roles: [],
+	permissions: [],
+	featureFlags: {} as SessionInfo['featureFlags'],
+}
+
+function renderConnectionsPage(
+	accountConnectedAgents: AccountConnectedAgentsLoaderData,
+) {
+	return renderToString(
+		jsx(RouterLocationProvider, {
+			url: routes.accountConnections.href(),
+			children: jsx(AppSessionProvider, {
+				session,
+				status: 'ready',
+				children: jsx(AppLoaderDataProvider, {
+					loaderData: { accountConnectedAgents },
+					children: jsx(AccountConnectionsRoute, {}),
+				}),
+			}),
+		}),
+	)
+}
+
+test('connections page renders the MCP URL copy card, the connected agents, and the setup guide paths from SSR data', async () => {
+	const html = await renderConnectionsPage({
+		ok: true,
+		mcpServerUrl: 'https://kody.example/mcp',
+		agents: [
+			{
+				clientId: 'cursor-client',
+				grantIds: ['grant-1'],
+				label: 'Cursor',
+				kind: 'cursor',
+				connectedAt: '2026-01-01T00:00:00.000Z',
+			},
+		],
+	})
+
+	expect(html).toContain('>Connections</h1>')
+	expect(html).toContain('aria-label="Connect an agent"')
+	expect(html).toContain('>https://kody.example/mcp<')
+	expect(html).toContain('Copy MCP URL')
+	expect(html).not.toContain('data-testid="account-connections-verify-note"')
+	expect(html).toMatch(/data-testid="account-connections-setup-guides"[^>]*/)
+	expect(html).toContain(`href="${routes.onboarding.href()}"`)
+	expect(html).toContain('href="/docs/connect-your-agent"')
+	expect(html).toContain('aria-label="Connected agents"')
+	expect(html).toContain('data-agent-label="Cursor"')
+	expect(html).toContain('aria-label="Revoke Cursor"')
+	expect(html).toContain(`href="${routes.accountMcpOauthClients.href()}"`)
+	// No cold-path loading copy when the SSR payload is present.
+	expect(html).not.toContain('Loading connections')
+	// The rail marks this page current and links Packages to the profile.
+	expect(html).toMatch(/href="\/account\/connections"[^>]*aria-current="page"/)
+	expect(html).toMatch(/href="\/@jane"[^>]*>Packages<\/a>/)
+})
+
+test('connections page swaps the copy card for a verify note while the email is unverified', async () => {
+	const html = await renderConnectionsPage({
+		ok: true,
+		mcpServerUrl: '',
+		agents: [],
+	})
+
+	expect(html).toContain('data-testid="account-connections-verify-note"')
+	expect(html).toContain(`href="${routes.pendingVerification.href()}"`)
+	expect(html).not.toContain('Copy MCP URL')
+	expect(html).toContain('No agents have authorized yet.')
+})
+
+test('account rail lists Connections and Packages at the same level as the other sections', () => {
+	const labels = accountNavItemsFor({
+		username: 'jane',
+		showShared: false,
+	}).map((item) => item.label)
+	expect(labels).toEqual([
+		'Overview',
+		'Waiting',
+		'Connections',
+		'Packages',
+		'Billing',
+		'Usage',
+		'Activity',
+		'Jobs',
+		'Workflows',
+		'Secrets',
+		'Integrations',
+		'MCP servers',
+		'Memories',
+		'Email',
+	])
+
+	const withShared = accountNavItemsFor({ username: 'jane', showShared: true })
+	expect(withShared.map((item) => item.label)).toContain('Shared')
+	expect(withShared.find((item) => item.label === 'Connections')?.href).toBe(
+		'/account/connections',
+	)
+	// Packages is the profile page — the canonical package list — not the
+	// `/account/packages` redirect, unless the session has no username yet.
+	expect(withShared.find((item) => item.label === 'Packages')?.href).toBe(
+		'/@jane',
+	)
+	expect(accountPackagesNavHref(null)).toBe('/account/packages')
+})

--- a/packages/worker/client/routes/account-connections.tsx
+++ b/packages/worker/client/routes/account-connections.tsx
@@ -1,0 +1,184 @@
+import { type Handle, css } from 'remix/ui'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
+import {
+	type AccountStatus,
+	readJson,
+} from '#client/routes/account-approval-shared.ts'
+import { createAccountConnectedAgents } from '#client/routes/account-connected-agents-panel.tsx'
+import {
+	AccountManagementMessage,
+	AccountManagementPanel,
+	AccountManagementShell,
+	AccountPageHeader,
+	accountActionsCss,
+} from '#client/routes/account-management-components.tsx'
+import { connectedAgentsApiPath } from '#client/routes/account-page-data.ts'
+import { CopyCard } from '#client/routes/onboarding-mcp-client-cards.tsx'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+import { docHref } from '#universal/docs-nav.ts'
+import { type AccountConnectedAgentsLoaderData } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
+import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
+import { colors } from '#universal/styles/tokens.ts'
+
+const connectYourAgentDocHref = docHref('connect-your-agent')
+
+async function fetchConnectedAgents(signal: AbortSignal) {
+	const response = await fetch(connectedAgentsApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) return { kind: 'unauthorized' as const }
+	const payload = await readJson<AccountConnectedAgentsLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load connections.')
+	}
+	return { kind: 'ok' as const, payload }
+}
+
+export async function accountConnectionsRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const result = await fetchConnectedAgents(signal)
+	if (result.kind === 'unauthorized') {
+		return routeLoaderRedirect('/login')
+	}
+	return { accountConnectedAgents: result.payload }
+}
+
+/**
+ * `/account/connections` — the durable home for inbound MCP hosts: the MCP
+ * URL to paste into another agent, the per-host setup guides, and the list of
+ * agents that already authorized (grouped, per-`clientId` revoke). Sign-in
+ * providers stay on Overview; outbound MCP servers stay on MCP servers.
+ */
+export function AccountConnectionsRoute(handle: Handle) {
+	const connectedAgents = createAccountConnectedAgents(handle)
+	let mcpServerUrl = ''
+	let message: string | null = null
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountConnectedAgentsLoaderData | null = null
+	let appliedError: Error | null = null
+	const connectionsData = createRouteData({
+		key: 'accountConnectedAgents',
+		async load(_href, signal) {
+			const result = await fetchConnectedAgents(signal)
+			if (result.kind === 'unauthorized') return routeDataRedirect('/login')
+			return result.payload
+		},
+	})
+
+	function applyPayload(payload: AccountConnectedAgentsLoaderData) {
+		connectedAgents.applyPayload(payload)
+		mcpServerUrl = payload.mcpServerUrl
+		message = null
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const snapshot = connectionsData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			message = snapshot.error.message
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
+
+		return (
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
+				<AccountPageHeader
+					title="Connections"
+					description="The agents connected to this Kody account, and how to connect another."
+					currentHref={currentHref}
+				/>
+
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading connections…
+					</p>
+				) : null}
+				{message ? (
+					<AccountManagementMessage tone="error">
+						{message}
+					</AccountManagementMessage>
+				) : null}
+
+				{status === 'ready' ? (
+					<>
+						<AccountManagementPanel
+							title="Connect an agent"
+							description="Every host reaches the same account through one MCP URL. Paste it into your agent, or open the setup guides for step-by-step instructions per host. The host will ask you to authorize afterwards."
+							ariaLabel="Connect an agent"
+						>
+							{mcpServerUrl ? (
+								<CopyCard
+									label="MCP URL"
+									value={mcpServerUrl}
+									copyLabel="Copy MCP URL"
+									variant="pill"
+								/>
+							) : (
+								<p
+									data-testid="account-connections-verify-note"
+									mix={css({ color: colors.textMuted, margin: 0 })}
+								>
+									Verify your email to get this deployment&apos;s MCP URL. MCP
+									access stays locked until the account email is verified.{' '}
+									<a href={routes.pendingVerification.href()}>
+										Verification page
+									</a>
+								</p>
+							)}
+							<div mix={css(accountActionsCss)}>
+								<a
+									href={routes.onboarding.href()}
+									data-testid="account-connections-setup-guides"
+									mix={css(compactGhostButtonCss)}
+								>
+									Setup guides by agent
+								</a>
+								<a
+									href={connectYourAgentDocHref}
+									mix={css(compactGhostButtonCss)}
+								>
+									Connect your agent docs
+								</a>
+							</div>
+						</AccountManagementPanel>
+						{connectedAgents.render()}
+						<AccountManagementPanel
+							title="Advanced"
+							description="Optional tools for hosts that cannot finish dynamic OAuth on their own. This is not the list of agents already connected to your account."
+						>
+							<div mix={css(accountActionsCss)}>
+								<a
+									href={routes.accountMcpOauthClients.href()}
+									mix={css(compactGhostButtonCss)}
+								>
+									MCP OAuth clients
+								</a>
+							</div>
+						</AccountManagementPanel>
+					</>
+				) : null}
+			</AccountManagementShell>
+		)
+	}
+}
+
+const compactGhostButtonCss = getGhostButtonCss({ size: 'sm' })

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -345,21 +345,45 @@ const adminNavItems = [
 	},
 ] as const
 
-const accountNavItems = [
-	{ href: '/account', label: 'Overview' },
-	{ href: '/account/waiting', label: 'Waiting' },
-	{ href: '/account/shared', label: 'Shared' },
-	{ href: '/account/billing', label: 'Billing' },
-	{ href: '/account/usage', label: 'Usage' },
-	{ href: '/account/activity', label: 'Activity' },
-	{ href: '/account/jobs', label: 'Jobs' },
-	{ href: '/account/workflows', label: 'Workflows' },
-	{ href: '/account/secrets', label: 'Secrets' },
-	{ href: '/account/integrations', label: 'Integrations' },
-	{ href: '/account/mcp-servers', label: 'MCP servers' },
-	{ href: '/account/memories', label: 'Memories' },
-	{ href: '/account/email', label: 'Email' },
-] as const
+/**
+ * Packages live on the signed-in user's public profile (`/@username`);
+ * `/account/packages` only 302s there. Link straight to the canonical page
+ * when the session knows the username and let the redirect cover the rare
+ * case where it does not, so the rail never points at a dead route.
+ */
+export function accountPackagesNavHref(username: string | null | undefined) {
+	return username
+		? routes.profile.href({ username })
+		: routes.accountPackages.href()
+}
+
+type AccountNavItem = { href: string; label: string }
+
+/** Account rail items in display order for the signed-in session. */
+export function accountNavItemsFor(input: {
+	username: string | null | undefined
+	showShared: boolean
+}): Array<AccountNavItem> {
+	return [
+		{ href: '/account', label: 'Overview' },
+		{ href: '/account/waiting', label: 'Waiting' },
+		{ href: routes.accountConnections.href(), label: 'Connections' },
+		{ href: accountPackagesNavHref(input.username), label: 'Packages' },
+		...(input.showShared
+			? [{ href: routes.accountShared.href(), label: 'Shared' }]
+			: []),
+		{ href: '/account/billing', label: 'Billing' },
+		{ href: '/account/usage', label: 'Usage' },
+		{ href: '/account/activity', label: 'Activity' },
+		{ href: '/account/jobs', label: 'Jobs' },
+		{ href: '/account/workflows', label: 'Workflows' },
+		{ href: '/account/secrets', label: 'Secrets' },
+		{ href: '/account/integrations', label: 'Integrations' },
+		{ href: '/account/mcp-servers', label: 'MCP servers' },
+		{ href: '/account/memories', label: 'Memories' },
+		{ href: '/account/email', label: 'Email' },
+	]
+}
 
 function isAccountNavItemActive(itemHref: string, currentPath: string) {
 	if (itemHref === '/account') return currentPath === '/account'
@@ -382,17 +406,16 @@ export function AccountPageHeader(handle: Handle<AccountPageHeaderProps>) {
 	return () => {
 		const currentPath = new URL(handle.props.currentHref, 'http://localhost')
 			.pathname
-		const showShared = isFeatureFlagEnabled(
-			readAppSession(handle)?.session,
-			packageShareGrantsFlagKey,
-		)
+		const session = readAppSession(handle)?.session ?? null
+		const showShared = isFeatureFlagEnabled(session, packageShareGrantsFlagKey)
 		const explainer =
 			!showShared && currentPath === routes.accountShared.href()
 				? null
 				: resolveEntityExplainer(currentPath)
-		const navItems = showShared
-			? accountNavItems
-			: accountNavItems.filter((item) => item.href !== '/account/shared')
+		const navItems = accountNavItemsFor({
+			username: session?.username,
+			showShared,
+		})
 
 		return (
 			<>

--- a/packages/worker/client/routes/account-page-data.ts
+++ b/packages/worker/client/routes/account-page-data.ts
@@ -11,7 +11,6 @@ import {
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
 import {
-	type AccountConnectedAgentsLoaderData,
 	type AccountConnectionsLoaderData,
 	type AccountProfileLoaderData,
 } from '#universal/loader-data.ts'
@@ -22,7 +21,6 @@ export const connectedAgentsApiPath = '/account/connected-agents.json'
 export type AccountPagePayloads = {
 	accountProfile: AccountProfileLoaderData
 	accountConnections: AccountConnectionsLoaderData
-	accountConnectedAgents: AccountConnectedAgentsLoaderData
 	onboarding: OnboardingPayload | null
 }
 
@@ -32,12 +30,7 @@ export async function fetchAccountPagePayloads(
 ): Promise<
 	{ kind: 'unauthorized' } | { kind: 'ok'; payloads: AccountPagePayloads }
 > {
-	const [
-		profileResponse,
-		connectionsResponse,
-		connectedAgentsResponse,
-		onboarding,
-	] = await Promise.all([
+	const [profileResponse, connectionsResponse, onboarding] = await Promise.all([
 		fetch(`${accountProfileApiPath}${search}`, {
 			headers: { Accept: 'application/json' },
 			credentials: 'include',
@@ -48,41 +41,26 @@ export async function fetchAccountPagePayloads(
 			credentials: 'include',
 			signal,
 		}),
-		fetch(connectedAgentsApiPath, {
-			headers: { Accept: 'application/json' },
-			credentials: 'include',
-			signal,
-		}),
 		fetchOnboardingPayload(signal),
 	])
-	if (
-		profileResponse.status === 401 ||
-		connectionsResponse.status === 401 ||
-		connectedAgentsResponse.status === 401
-	) {
+	if (profileResponse.status === 401 || connectionsResponse.status === 401) {
 		return { kind: 'unauthorized' }
 	}
-	const [payload, connectionsPayload, connectedAgentsPayload] =
-		await Promise.all([
-			readJson<AccountProfileLoaderData>(profileResponse),
-			readJson<AccountConnectionsLoaderData>(connectionsResponse),
-			readJson<AccountConnectedAgentsLoaderData>(connectedAgentsResponse),
-		])
+	const [payload, connectionsPayload] = await Promise.all([
+		readJson<AccountProfileLoaderData>(profileResponse),
+		readJson<AccountConnectionsLoaderData>(connectionsResponse),
+	])
 	if (!profileResponse.ok || !payload?.ok) {
 		throw new Error('Unable to load your account.')
 	}
 	if (!connectionsResponse.ok || !connectionsPayload?.ok) {
 		throw new Error('Unable to load connected accounts.')
 	}
-	if (!connectedAgentsResponse.ok || !connectedAgentsPayload?.ok) {
-		throw new Error('Unable to load connected agents.')
-	}
 	return {
 		kind: 'ok',
 		payloads: {
 			accountProfile: payload,
 			accountConnections: connectionsPayload,
-			accountConnectedAgents: connectedAgentsPayload,
 			onboarding,
 		},
 	}
@@ -99,7 +77,6 @@ export async function accountRouteLoader(
 	return {
 		accountProfile: result.payloads.accountProfile,
 		accountConnections: result.payloads.accountConnections,
-		accountConnectedAgents: result.payloads.accountConnectedAgents,
 		...(result.payloads.onboarding
 			? { onboarding: result.payloads.onboarding }
 			: {}),

--- a/packages/worker/client/routes/account.tsx
+++ b/packages/worker/client/routes/account.tsx
@@ -10,6 +10,7 @@ import {
 	type ProfileVisibility,
 } from '#universal/loader-data.ts'
 import { acceptedEmailVerificationDelivery } from '#universal/email-verification-delivery.ts'
+import { routes } from '#universal/routes.ts'
 import {
 	colors,
 	radius,
@@ -53,7 +54,6 @@ import {
 	createAccountConnections,
 	readConnectionCallbackMessage,
 } from '#client/routes/account-connections-panel.tsx'
-import { createAccountConnectedAgents } from '#client/routes/account-connected-agents-panel.tsx'
 import { renderOnboardingBanner } from '#client/routes/onboarding-banner.tsx'
 import { shouldShowOnboardingChecklist } from '#client/routes/onboarding-checklist.tsx'
 import {
@@ -96,7 +96,6 @@ export function AccountRoute(handle: Handle) {
 	let messageTone: 'error' | 'info' = 'info'
 	let usernameSaveError: string | null = null
 	const accountConnections = createAccountConnections(handle)
-	const accountConnectedAgents = createAccountConnectedAgents(handle)
 	const accountEmailClaims = createAccountEmailClaims(handle)
 	let consumedCallbackMessage = false
 	let needsOnboarding = false
@@ -119,17 +118,10 @@ export function AccountRoute(handle: Handle) {
 				href,
 			)
 			if (!accountConnections) return null
-			const accountConnectedAgents = tryConsumeRouteLoaderData(
-				handle,
-				'accountConnectedAgents',
-				href,
-			)
-			if (!accountConnectedAgents) return null
 			const onboarding = tryConsumeRouteLoaderData(handle, 'onboarding', href)
 			return {
 				accountProfile,
 				accountConnections,
-				accountConnectedAgents,
 				onboarding: onboarding ?? null,
 			}
 		},
@@ -150,12 +142,10 @@ export function AccountRoute(handle: Handle) {
 		const {
 			accountProfile: payload,
 			accountConnections: connectionsPayload,
-			accountConnectedAgents: connectedAgentsPayload,
 			onboarding,
 		} = payloads
 		applyOnboardingPayload(onboarding)
 		accountConnections.applyPayload(connectionsPayload)
-		accountConnectedAgents.applyPayload(connectedAgentsPayload)
 		email = payload.email
 		emailVerified = payload.emailVerified
 		emailVerificationDelivery = payload.emailVerificationDelivery ?? null
@@ -639,7 +629,20 @@ export function AccountRoute(handle: Handle) {
 							}}
 						/>
 						{accountConnections.render()}
-						{accountConnectedAgents.render()}
+						<AccountManagementPanel
+							title="Connections"
+							description="The agents that have authorized against this account, the MCP URL for connecting another, and per-host revoke live on the Connections page."
+						>
+							<div mix={css(accountActionsCss)}>
+								<a
+									href={routes.accountConnections.href()}
+									data-testid="account-connections-link"
+									mix={css(compactGhostButtonCss)}
+								>
+									Manage connections
+								</a>
+							</div>
+						</AccountManagementPanel>
 						<AccountManagementPanel
 							title="Your data"
 							description="Download a portable JSON export of your Kody account data for backup or migration. Secret values are never included; secret entries export metadata such as names, hosts, and allowlists only."
@@ -651,19 +654,6 @@ export function AccountRoute(handle: Handle) {
 									mix={css(compactGhostButtonCss)}
 								>
 									Download account export
-								</a>
-							</div>
-						</AccountManagementPanel>
-						<AccountManagementPanel
-							title="Advanced"
-							description="Optional tools for hosts that cannot finish dynamic OAuth on their own. This is not the list of agents already connected to your account."
-						>
-							<div mix={css(accountActionsCss)}>
-								<a
-									href="/account/mcp-oauth-clients"
-									mix={css(compactGhostButtonCss)}
-								>
-									MCP OAuth clients
 								</a>
 							</div>
 						</AccountManagementPanel>

--- a/packages/worker/client/routes/entity-explainer.tsx
+++ b/packages/worker/client/routes/entity-explainer.tsx
@@ -108,6 +108,22 @@ const entityExplainerDefinitions: Array<EntityExplainerDefinition> = [
 		],
 	},
 	{
+		id: 'connections',
+		question: 'What is a connection?',
+		match: accountSection(routes.accountConnections.href()),
+		paragraphs: [
+			'A connection is an AI host — Cursor, Claude, ChatGPT, Codex, a CLI — that has authorized against this Kody account over MCP. Every connected host reaches the same memories, secrets, packages, jobs, and email; Kody is the home they share, not a gateway.',
+			'Copy the MCP URL here to connect another host, open the per-host setup guides, and revoke a host you no longer use. Sign-in providers such as GitHub and Google stay on Overview. Remote MCP servers Kody calls on your behalf live on MCP servers.',
+		],
+		learnMore: [
+			{
+				href: docHref('connect-your-agent'),
+				label: 'Connect your agent',
+			},
+			packagesIntegrationsMcpGuide,
+		],
+	},
+	{
 		id: 'mcp-servers',
 		question: 'What is an MCP server?',
 		match: accountSection(routes.accountMcpServers.href()),

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -47,6 +47,10 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		accountArea,
 		(m) => m.accountWaitingRouteLoader,
 	),
+	[routePattern(routes.accountConnections)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountConnectionsRouteLoader,
+	),
 	[routePattern(routes.accountShared)]: lazyRouteLoader(
 		accountArea,
 		(m) => m.accountSharedRouteLoader,
@@ -374,6 +378,9 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.accountWaiting)]: (
 		<LazyAccountRoute render={(m) => <m.AccountWaitingRoute />} />
+	),
+	[routePattern(routes.accountConnections)]: (
+		<LazyAccountRoute render={(m) => <m.AccountConnectionsRoute />} />
 	),
 	[routePattern(routes.accountShared)]: (
 		<LazyAccountRoute render={(m) => <m.AccountSharedRoute />} />

--- a/packages/worker/src/app/handlers/account-connected-agents.node.test.ts
+++ b/packages/worker/src/app/handlers/account-connected-agents.node.test.ts
@@ -90,6 +90,7 @@ test('connected agents API lists unique inbound clients and revokes every grant 
 	}
 	mockModule.readAuthenticatedAppUser.mockResolvedValue({
 		email: userOneSession.email,
+		emailVerified: true,
 		mcpUser: { userId: userOneSession.stableUserId },
 	})
 	const cookie = await createAuthCookie(userOneSession, false)
@@ -105,12 +106,39 @@ test('connected agents API lists unique inbound clients and revokes every grant 
 	const listBody = (await listed.json()) as {
 		ok: true
 		agents: Array<{ clientId: string; label: string; kind: string | null }>
+		mcpServerUrl: string
 	}
 	expect(listBody.ok).toBe(true)
 	expect(listBody.agents.map((agent) => agent.label)).toEqual([
 		'ChatGPT.com',
 		'Cursor',
 	])
+	// The Connections page pastes this into a new host; it comes from the
+	// request origin so preview and local deployments show their own URL.
+	expect(listBody.mcpServerUrl).toBe('https://example.com/mcp')
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		email: userOneSession.email,
+		emailVerified: false,
+		mcpUser: { userId: userOneSession.stableUserId },
+	})
+	const unverified = await runHandler(
+		handler,
+		new Request('https://example.com/account/connected-agents.json', {
+			headers: { Cookie: cookie, Accept: 'application/json' },
+		}),
+	)
+	expect(unverified.status).toBe(200)
+	// Same gate as the onboarding payload: no MCP URL until the email is
+	// verified, so the page cannot push a user into the authorize → 403 loop.
+	expect(
+		((await unverified.json()) as { mcpServerUrl: string }).mcpServerUrl,
+	).toBe('')
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		email: userOneSession.email,
+		emailVerified: true,
+		mcpUser: { userId: userOneSession.stableUserId },
+	})
 
 	const revoked = await runHandler(
 		handler,

--- a/packages/worker/src/app/handlers/account-connected-agents.ts
+++ b/packages/worker/src/app/handlers/account-connected-agents.ts
@@ -7,6 +7,8 @@ import {
 	logAuditEvent,
 } from '#worker/audit-log.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
 import { hasSecondConnectedMcpClient } from '#universal/connected-mcp-agents.ts'
 import {
 	loadInboundMcpConnectionState,
@@ -18,22 +20,30 @@ import {
 	type OAuthGrantHelpers,
 	type OAuthGrantListHelpers,
 } from '#worker/oauth-grants.ts'
+import { buildMcpServerUrl } from '#worker/onboarding-prompts.ts'
 import { type AccountConnectedAgentsLoaderData } from '#universal/loader-data.ts'
 import { type routes } from '#universal/routes.ts'
 
+type ConnectedAgentsUser = {
+	mcpUser: { userId: string }
+	emailVerified: boolean
+}
+
 export async function loadAccountConnectedAgentsData(input: {
 	env: Env
-	stableUserId: string
+	requestUrl: string | URL
+	user: ConnectedAgentsUser
 }): Promise<AccountConnectedAgentsLoaderData> {
+	const stableUserId = input.user.mcpUser.userId
 	const helpers = await resolveOAuthHelpers<OAuthGrantListHelpers>(input.env)
-	const state = await loadInboundMcpConnectionState(helpers, input.stableUserId)
+	const state = await loadInboundMcpConnectionState(helpers, stableUserId)
 	if (
 		!state.listingFailed &&
 		hasSecondConnectedMcpClient(state.uniqueClientCount)
 	) {
 		await maybeEvaluateSecondAgentStandardGift({
 			db: input.env.APP_DB,
-			stableUserId: input.stableUserId,
+			stableUserId,
 			uniqueClientCount: state.uniqueClientCount,
 			listingFailed: state.listingFailed,
 		})
@@ -41,7 +51,34 @@ export async function loadAccountConnectedAgentsData(input: {
 	return {
 		ok: true,
 		agents: state.agents,
+		mcpServerUrl: input.user.emailVerified
+			? buildMcpServerUrl({ env: input.env, requestUrl: input.requestUrl })
+			: '',
 	}
+}
+
+export function createAccountConnectionsHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
+			}
+
+			const accountConnectedAgents = await loadAccountConnectedAgentsData({
+				env,
+				requestUrl: request.url,
+				user,
+			})
+			return renderAppPage({
+				request,
+				env,
+				title: 'Connections',
+				loaderData: { accountConnectedAgents },
+			})
+		},
+	} satisfies Action<typeof routes.accountConnections>
 }
 
 export function createAccountConnectedAgentsApiHandler(env: Env) {
@@ -57,7 +94,8 @@ export function createAccountConnectedAgentsApiHandler(env: Env) {
 				return jsonResponse(
 					await loadAccountConnectedAgentsData({
 						env,
-						stableUserId: user.mcpUser.userId,
+						requestUrl: request.url,
+						user,
 					}),
 				)
 			}
@@ -105,7 +143,8 @@ export function createAccountConnectedAgentsApiHandler(env: Env) {
 			return jsonResponse(
 				await loadAccountConnectedAgentsData({
 					env,
-					stableUserId: user.mcpUser.userId,
+					requestUrl: request.url,
+					user,
 				}),
 			)
 		},

--- a/packages/worker/src/app/handlers/account.ts
+++ b/packages/worker/src/app/handlers/account.ts
@@ -1,6 +1,5 @@
 import { type Action } from 'remix/router'
 import { loadAccountConnectionsData } from '#app/account-connections-data.ts'
-import { loadAccountConnectedAgentsData } from '#app/handlers/account-connected-agents.ts'
 import { loadAccountProfileData } from '#app/account-profile-data.ts'
 import { loadChecklist } from '#app/handlers/onboarding.ts'
 import { loadOnboardingData } from '#app/onboarding-data.ts'
@@ -17,26 +16,18 @@ export function createAccountHandler(env: Env) {
 				return user
 			}
 
-			const [
-				accountProfile,
-				accountConnections,
-				accountConnectedAgents,
-				onboarding,
-			] = await Promise.all([
-				loadAccountProfileData(user, env),
-				loadAccountConnectionsData({ env, userId: user.userId }),
-				loadAccountConnectedAgentsData({
-					env,
-					stableUserId: user.mcpUser.userId,
-				}),
-				loadOnboardingData({
-					env,
-					requestUrl: request.url,
-					stableUserId: user.mcpUser.userId,
-					username: user.username,
-					emailVerified: user.emailVerified,
-				}),
-			])
+			const [accountProfile, accountConnections, onboarding] =
+				await Promise.all([
+					loadAccountProfileData(user, env),
+					loadAccountConnectionsData({ env, userId: user.userId }),
+					loadOnboardingData({
+						env,
+						requestUrl: request.url,
+						stableUserId: user.mcpUser.userId,
+						username: user.username,
+						emailVerified: user.emailVerified,
+					}),
+				])
 			// The banner shows checklist progress, so the SSR payload needs the
 			// checklist too — hydration keeps SSR data and does not refetch.
 			if (user.emailVerified) {
@@ -57,7 +48,6 @@ export function createAccountHandler(env: Env) {
 				loaderData: {
 					accountProfile,
 					accountConnections,
-					accountConnectedAgents,
 					onboarding,
 				},
 			})

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -119,7 +119,10 @@ import {
 	createAccountMcpOauthClientsHandler,
 } from '#app/handlers/account-mcp-oauth-clients.ts'
 import { createAccountConnectionsApiHandler } from '#app/handlers/account-connections.ts'
-import { createAccountConnectedAgentsApiHandler } from '#app/handlers/account-connected-agents.ts'
+import {
+	createAccountConnectedAgentsApiHandler,
+	createAccountConnectionsHandler,
+} from '#app/handlers/account-connected-agents.ts'
 import { createAccountAvatarApiPostHandler } from '#app/handlers/account-avatar.ts'
 import { createAccountProfileApiHandler } from '#app/handlers/account-profile.ts'
 import {
@@ -407,6 +410,7 @@ export function createAppRouter(env: Env) {
 			accountPackageFilesApi: createAccountPackageFilesApiHandler(env),
 			accountPackagesApi: createAccountPackagesApiHandler(env),
 			accountPackagesApiPost: createAccountPackagesApiHandler(env),
+			accountConnections: createAccountConnectionsHandler(env),
 			accountConnectionsApi: createAccountConnectionsApiHandler(env),
 			accountConnectionsApiPost: createAccountConnectionsApiHandler(env),
 			accountConnectedAgentsApi: createAccountConnectedAgentsApiHandler(env),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -7,6 +7,7 @@ import {
 	type AuthSession,
 } from '#app/auth-session.ts'
 import { createAccountHandler } from '#app/handlers/account.ts'
+import { createAccountConnectionsHandler } from '#app/handlers/account-connected-agents.ts'
 import { createAccountPasskeysHandler } from '#app/handlers/account-passkeys.ts'
 import { createAccountMcpOauthClientsHandler } from '#app/handlers/account-mcp-oauth-clients.ts'
 import { createAccountTwoFactorHandler } from '#app/handlers/account-two-factor.ts'
@@ -424,10 +425,16 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		availableProviders: [],
 		canSyncDiscordRoles: false,
 	})
-	expect(accountProps.loaderData?.accountConnectedAgents).toEqual({
-		ok: true,
-		agents: [],
-	})
+	// Connected agents moved to `/account/connections`; Overview only links there.
+	expect(accountProps.loaderData?.accountConnectedAgents).toBeUndefined()
+	expect(accountHtml).toContain('data-testid="account-connections-link"')
+	expect(accountHtml).toContain('href="/account/connections"')
+	expect(accountHtml).not.toContain('aria-label="Connected agents"')
+	// The rail carries Connections and Packages (the profile is the canonical
+	// package list, so the nav links there rather than the `/account/packages`
+	// redirect).
+	expect(accountHtml).toContain('>Connections</a>')
+	expect(accountHtml).toMatch(/href="\/@account-user"[^>]*>Packages<\/a>/)
 	expect(accountProps.loaderData?.onboarding).toEqual({
 		ok: true,
 		loggedIn: true,
@@ -503,6 +510,37 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	expect(readAppRootProps(waitingHtml).loaderData?.accountWaiting).toEqual({
 		ok: true,
 		items: expect.any(Array),
+	})
+
+	// The Connections page embeds the connected-agents payload. The MCP URL is
+	// gated on email verification (this fixture is unverified), so the page
+	// server-renders the verify note instead of a copy card.
+	const connectionsResponse = await runHtmlHandler(
+		createAccountConnectionsHandler(env),
+		new Request('https://example.com/account/connections', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(connectionsResponse.status).toBe(200)
+	const connectionsHtml = await readResponseText(connectionsResponse)
+	expect(connectionsHtml).toContain('>Connections<')
+	expect(connectionsHtml).toContain('aria-label="Account sections"')
+	expect(connectionsHtml).toMatch(
+		/href="\/account\/connections"[^>]*aria-current="page"/,
+	)
+	expect(connectionsHtml).toContain('aria-label="Connected agents"')
+	expect(connectionsHtml).toContain('aria-label="Connect an agent"')
+	expect(connectionsHtml).toContain(
+		'data-testid="account-connections-verify-note"',
+	)
+	expect(connectionsHtml).toContain('href="/account/mcp-oauth-clients"')
+	expect(connectionsHtml).toContain('data-entity-explainer="connections"')
+	expect(
+		readAppRootProps(connectionsHtml).loaderData?.accountConnectedAgents,
+	).toEqual({
+		ok: true,
+		agents: [],
+		mcpServerUrl: '',
 	})
 
 	const mcpOauthClientsResponse = await runHtmlHandler(

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -178,6 +178,7 @@ const routeDocumentHeads = {
 	[routePattern(routes.accountBillingSuccess)]: titleOnly("You're in"),
 	[routePattern(routes.accountUsage)]: titleOnly('Usage'),
 	[routePattern(routes.accountWaiting)]: titleOnly('Waiting'),
+	[routePattern(routes.accountConnections)]: titleOnly('Connections'),
 	[routePattern(routes.accountShared)]: titleOnly('Shared packages'),
 	[routePattern(routes.accountIntegrations)]: titleOnly('Integrations'),
 	[routePattern(routes.accountOauthAppDetail)]: titleOnly('Integrations'),

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1168,6 +1168,12 @@ export type AccountConnectedAgentListItem = ConnectedMcpAgent & {
 export type AccountConnectedAgentsLoaderData = {
 	ok: true
 	agents: Array<AccountConnectedAgentListItem>
+	/**
+	 * This deployment's MCP URL for connecting another host. Empty until the
+	 * account email is verified, matching the onboarding payload, so the page
+	 * cannot send an unverified user into the authorize → 403 loop.
+	 */
+	mcpServerUrl: string
 }
 
 export type PendingVerificationLoaderData = {

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -85,6 +85,11 @@ export const routes = route({
 	accountEmail: '/account/email',
 	accountEmailDetail: '/account/email/:messageId',
 	accountEmailApi: '/account/email.json',
+	// The Connections page is the home for inbound MCP hosts (connected
+	// agents): MCP URL, setup guides, and per-host revoke. Its data twin is
+	// `/account/connected-agents.json`; `/account/connections.json` is the
+	// older sign-in provider (GitHub, Google, …) list on the Overview page.
+	accountConnections: '/account/connections',
 	accountConnectionsApi: '/account/connections.json',
 	accountConnectionsApiPost: post('/account/connections.json'),
 	accountConnectedAgentsApi: '/account/connected-agents.json',

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -100,8 +100,14 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 			'/account/export.json',
 			'/account/delete',
 			'/account/connections.json',
-			'/account/connected-agents.json',
 		],
+	},
+	{
+		id: 'connections',
+		title: 'Connections (connected agents)',
+		file: 'connections.md',
+		paths: ['/account/connections'],
+		apis: ['/account/connected-agents.json'],
 	},
 	{
 		id: 'packages',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give connected agents (inbound MCP hosts) a first-class home in the account area and make Packages reachable from the account rail — two UX fixes from Tim Krase's feedback.

## Why

The connected-clients list, revoke, and the MCP URL were split between the bottom of the account Overview, the onboarding "connect a second agent" step, and `/account/waiting` items. A user who already connected one agent had no obvious durable place to see what is connected, copy the MCP URL, or connect another. Packages (the profile page) was also not reachable from the account left nav, so it read as missing from the account shell.

## Summary

- New `/account/connections` page (title **Connections**) built the same way as the other account pages (`createRouteData`, SSR-embedded payload, `AccountManagementShell` / `AccountPageHeader`, no-flash nav, lazy `account-area` chunk, `document-head` title, Feature Map entry).
  - **Connect an agent**: MCP URL copy card (`CopyCard` + `CopyTextButton`, same well as onboarding), "Setup guides by agent" → `/onboarding` (resumes at the right wizard step), and "Connect your agent docs".
  - **Connected agents**: the existing grouped list with per-`clientId` double-check revoke (`createAccountConnectedAgents`), moved as-is.
  - **Advanced**: the MCP OAuth clients link, moved from Overview.
  - Unverified email: the copy card is replaced by a verify note linking to `/pending-verification` (no lying-ready URL).
- Overview no longer loads or renders the connected agents or the Advanced panel; it keeps a short **Connections** panel with a "Manage connections" link. The Overview SSR/JSON fan-out drops `/account/connected-agents.json`.
- `/account/connected-agents.json` (GET and revoke POST response) gains `mcpServerUrl`, empty until the email is verified — the same gate as `/onboarding.json`.
- Account rail: adds **Connections** (`/account/connections`, active on the new page and its children) and **Packages**. Packages links to the signed-in user's profile `/@username`, which is the canonical package list; `/account/packages` only 302s there, so the rail falls back to that redirect only when the session has no username.
- Entity explainer "What is a connection?" on the new page; Feature Map `connections` entry + `connections.md`; `account.md`, architecture docs (`authentication`, `onboarding`, `entitlements`), and `docs/use` wording updated from "Account → Connected agents / Advanced" to the Connections page.

Sign-in providers (GitHub, Google, X, Discord — the "Connected accounts" panel served by `/account/connections.json`) stay on Overview next to password/passkeys, since disconnecting one depends on having another sign-in method. A comment in `routes.ts` records that `accountConnectionsApi` is that older list while `accountConnections` is the agents page.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format`
- Node: `account-connections.node.test.ts` (new: SSR render with data, verify-note state, rail order/hrefs), `ssr-render.node.test.ts` (Overview drops the agents payload and links to Connections; `/account/connections` embeds `accountConnectedAgents`, marks the rail current, renders explainer/panels), `account-connected-agents.node.test.ts` (`mcpServerUrl` from request origin, empty when unverified), panel/explainer/metadata tests, `control-kody map --check`.
- E2E `account-navigation.spec.ts`: added the Connections hop to the single-commit / no-refetch walk and asserted the Packages rail link points at `/@username`.
- `npm run validate` green locally (all 24 jobs exit 0, Playwright 15/15) and a browser pass on the dev server as `jane@example.com`: rail → Connections (no flash), Copy MCP URL shows "Copied", "What is a connection?" explainer, Overview → Manage connections → Connections, Packages → `/@jane`, keyboard Tab/Enter on the copy button.
- Preview `kody-pr-2255` as the seeded `me@kentcdodds.com` (`control-kody preview --pr 2255`): `GET /account/connected-agents.json` → `{ ok, agents: [], mcpServerUrl: "https://kody-pr-2255.kody-a99.workers.dev/mcp" }`, `GET /account/connections` and `GET /account` 200; UI pass confirmed the Connections page, the rail (Connections current, Packages → `/@user-me`), and the Overview without the agents list. CI green, Bugbot and CodeRabbit: no issues.

![Connections page on the PR preview](https://cursor.com/artifacts/c/art-55d2c945-b2ab-44e2-bebe-76ab1b27965b)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6e524c5b` · **Head:** `77f7ae86`

**Classification:** extends — `app-ui` gains a route (`/account/connections`) and `/account/connected-agents.json` gains a field (`mcpServerUrl`). No primitive added; `primitives.yaml` unchanged.

### Primitives touched

| Primitive | Group    | Impact                                                                                                                         |
| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
| `app-ui`  | surfaces | extends — new `/account/connections` HTML route and client route, `mcpServerUrl` on `/account/connected-agents.json`, rail items |

Unmatched paths are docs, the Feature Map (`tools/control-kody`, `.agents/skills/control-kody/references/features`), and the e2e spec.

### Change flow

A signed-in user opens Connections from the account rail; the page embeds the connected-agents payload on SSR and the client reuses it (or the router-preloaded copy) without a second fetch.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant appSessions as app-sessions
	participant mcpOauth as mcp-oauth
	User->>appUi: click Connections in the account rail
	appUi->>appSessions: requireAuthenticatedPageUser on GET /account/connections
	appUi->>mcpOauth: listUserGrants + lookupClient (unchanged loadInboundMcpConnectionState)
	Note over appUi: loadAccountConnectedAgentsData adds mcpServerUrl (empty until emailVerified)
	appUi-->>User: SSR page with accountConnectedAgents payload, rail marks Connections current
	User->>appUi: Revoke (double-check)
	appUi->>mcpOauth: POST /account/connected-agents.json intent revoke
	appUi-->>User: refreshed agents + mcpServerUrl
```

### Before / after

| Surface                          | Before                                                          | After                                                                     |
| -------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------- |
| `/account` (Overview)            | Connected agents list, Advanced → MCP OAuth clients             | "Connections" panel with a Manage connections link                        |
| `/account/connections`           | —                                                               | Connect an agent (MCP URL copy), Connected agents (revoke), Advanced link |
| `/account/connected-agents.json` | `{ ok, agents }`                                                | `{ ok, agents, mcpServerUrl }`                                            |
| Account rail                     | Overview, Waiting, Shared*, Billing, …                          | Overview, Waiting, **Connections**, **Packages** (`/@username`), Shared*, Billing, … |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b7ccc30-e6d1-4088-bb8a-f1aeb21931f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b7ccc30-e6d1-4088-bb8a-f1aeb21931f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Account → Connections** page for MCP connection setup and management.
  * Users can view their MCP URL, access setup guides, review authorized agents, and revoke connections.
  * Added Advanced MCP OAuth client access from the Connections page.
  * MCP URL access is now gated until email verification is complete.

* **Documentation**
  * Updated account, onboarding, troubleshooting, and connection guides to reflect the new navigation and workflows.
  * Packages navigation now links directly to the user’s public profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->