### PR TITLE
Hang heading permalinks beside docs and blog text

### DIFF
--- a/packages/worker/client/markdown-heading-anchor.tsx
+++ b/packages/worker/client/markdown-heading-anchor.tsx
@@ -21,22 +21,25 @@ function renderHeadingAnchorIcon() {
 	)
 }
 
+const headingPermalinkAriaLabel = 'Link to this section'
+
 /**
  * Section permalink that sits beside heading text (not around it) so an
  * inline markdown link in the heading cannot nest inside this `<a>`.
  * `proseCss` stretches the control over the heading and hangs the icon.
+ * The heading's `aria-label` owns the title; this control uses a generic name
+ * so screen readers do not announce the title twice.
  */
 export function renderMarkdownHeadingAnchor(
 	key: number,
 	headingId: string,
-	headingLabel: string,
 ): RemixNode {
 	return (
 		<a
 			key={`anchor-${key}`}
 			href={`#${headingId}`}
 			data-heading-permalink=""
-			aria-label={headingLabel}
+			aria-label={headingPermalinkAriaLabel}
 		>
 			<span data-heading-anchor="" aria-hidden="true">
 				{renderHeadingAnchorIcon()}

--- a/packages/worker/client/markdown-heading-anchor.tsx
+++ b/packages/worker/client/markdown-heading-anchor.tsx
@@ -1,6 +1,6 @@
 import { type RemixNode } from 'remix/ui'
 
-/** Inline link icon for prose heading permalinks (decorative). */
+/** Decorative link icon for prose heading permalinks. */
 function renderHeadingAnchorIcon() {
 	return (
 		<svg
@@ -21,18 +21,22 @@ function renderHeadingAnchorIcon() {
 	)
 }
 
+/**
+ * Wraps a heading's contents in the section permalink so the heading text
+ * (not just the icon) is the `#slug` control. The icon is decorative and
+ * hangs beside the text via `proseCss`.
+ */
 export function renderMarkdownHeadingAnchor(
 	key: number,
 	headingId: string,
+	children: RemixNode,
 ): RemixNode {
 	return (
-		<a
-			key={`anchor-${key}`}
-			href={`#${headingId}`}
-			data-heading-anchor=""
-			aria-label="Link to this section"
-		>
-			{renderHeadingAnchorIcon()}
+		<a key={`anchor-${key}`} href={`#${headingId}`} data-heading-permalink="">
+			<span data-heading-anchor="" aria-hidden="true">
+				{renderHeadingAnchorIcon()}
+			</span>
+			<span data-heading-text="">{children}</span>
 		</a>
 	)
 }

--- a/packages/worker/client/markdown-heading-anchor.tsx
+++ b/packages/worker/client/markdown-heading-anchor.tsx
@@ -22,21 +22,25 @@ function renderHeadingAnchorIcon() {
 }
 
 /**
- * Wraps a heading's contents in the section permalink so the heading text
- * (not just the icon) is the `#slug` control. The icon is decorative and
- * hangs beside the text via `proseCss`.
+ * Section permalink that sits beside heading text (not around it) so an
+ * inline markdown link in the heading cannot nest inside this `<a>`.
+ * `proseCss` stretches the control over the heading and hangs the icon.
  */
 export function renderMarkdownHeadingAnchor(
 	key: number,
 	headingId: string,
-	children: RemixNode,
+	headingLabel: string,
 ): RemixNode {
 	return (
-		<a key={`anchor-${key}`} href={`#${headingId}`} data-heading-permalink="">
+		<a
+			key={`anchor-${key}`}
+			href={`#${headingId}`}
+			data-heading-permalink=""
+			aria-label={headingLabel}
+		>
 			<span data-heading-anchor="" aria-hidden="true">
 				{renderHeadingAnchorIcon()}
 			</span>
-			<span data-heading-text="">{children}</span>
 		</a>
 	)
 }

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -223,17 +223,25 @@ test('first-party headingIds emit unique kebab-case heading ids', async () => {
 			),
 		}),
 	)
-	expect(html).toContain('<h2 id="josh-tomaino">')
+	expect(html).toContain('<h2 id="josh-tomaino" aria-label="Josh Tomaino">')
 	expect(html).toContain('href="#josh-tomaino"')
 	expect(html).toContain('data-heading-permalink=""')
-	expect(html).toContain('aria-label="Josh Tomaino"')
+	expect(html).toContain('aria-label="Link to this section"')
 	expect(html).toContain('data-heading-anchor=""')
 	expect(html).toContain('data-heading-text=""')
 	expect(html).toContain('<span data-heading-text="">Josh Tomaino</span>')
-	expect(html).toContain('<h2 id="josh-tomaino-2">')
+	const joshPermalink = html.match(
+		/<a href="#josh-tomaino"[^>]*>[\s\S]*?<\/a>/,
+	)?.[0]
+	expect(joshPermalink).toBeDefined()
+	expect(joshPermalink).toContain('aria-label="Link to this section"')
+	expect(joshPermalink).not.toContain('aria-label="Josh Tomaino"')
+	expect(html).toContain('<h2 id="josh-tomaino-2" aria-label="Josh Tomaino">')
 	expect(html).toContain('href="#josh-tomaino-2"')
-	expect(html).toContain('<h2 id="jett-hays">')
-	expect(html).toContain('<h2 id="gabriel-alegria">')
+	expect(html).toContain('<h2 id="jett-hays" aria-label="Jett Hays">')
+	expect(html).toContain(
+		'<h2 id="gabriel-alegria" aria-label="Gabriel Alegría">',
+	)
 })
 
 test('heading permalinks stay beside inline heading links instead of wrapping them', async () => {
@@ -245,14 +253,17 @@ test('heading permalinks stay beside inline heading links instead of wrapping th
 			),
 		}),
 	)
-	expect(html).toContain('id="read-the-guide-https-example.com-guide"')
+	expect(html).toContain(
+		'id="read-the-guide-https-example.com-guide" aria-label="Read the guide"',
+	)
 	expect(html).toContain('href="#read-the-guide-https-example.com-guide"')
-	expect(html).toContain('aria-label="Read the guide"')
 	expect(html).toContain('href="https://example.com/guide"')
 	const permalink = html.match(
 		/<a href="#read-the-guide-https-example.com-guide"[^>]*>[\s\S]*?<\/a>/,
 	)?.[0]
 	expect(permalink).toBeDefined()
+	expect(permalink).toContain('aria-label="Link to this section"')
+	expect(permalink).not.toContain('aria-label="Read the guide"')
 	expect(permalink?.match(/<a /g)).toHaveLength(1)
 })
 

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -225,8 +225,12 @@ test('first-party headingIds emit unique kebab-case heading ids', async () => {
 	)
 	expect(html).toContain('<h2 id="josh-tomaino">')
 	expect(html).toContain('href="#josh-tomaino"')
+	expect(html).toContain('data-heading-permalink=""')
 	expect(html).toContain('data-heading-anchor=""')
 	expect(html).toContain('data-heading-text=""')
+	expect(html).toMatch(
+		/<a href="#josh-tomaino" data-heading-permalink="">[\s\S]*Josh Tomaino/,
+	)
 	expect(html).toContain('<h2 id="josh-tomaino-2">')
 	expect(html).toContain('href="#josh-tomaino-2"')
 	expect(html).toContain('<h2 id="jett-hays">')

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -226,15 +226,34 @@ test('first-party headingIds emit unique kebab-case heading ids', async () => {
 	expect(html).toContain('<h2 id="josh-tomaino">')
 	expect(html).toContain('href="#josh-tomaino"')
 	expect(html).toContain('data-heading-permalink=""')
+	expect(html).toContain('aria-label="Josh Tomaino"')
 	expect(html).toContain('data-heading-anchor=""')
 	expect(html).toContain('data-heading-text=""')
-	expect(html).toMatch(
-		/<a href="#josh-tomaino" data-heading-permalink="">[\s\S]*Josh Tomaino/,
-	)
+	expect(html).toContain('<span data-heading-text="">Josh Tomaino</span>')
 	expect(html).toContain('<h2 id="josh-tomaino-2">')
 	expect(html).toContain('href="#josh-tomaino-2"')
 	expect(html).toContain('<h2 id="jett-hays">')
 	expect(html).toContain('<h2 id="gabriel-alegria">')
+})
+
+test('heading permalinks stay beside inline heading links instead of wrapping them', async () => {
+	const html = await renderToString(
+		jsx('div', {
+			children: renderMarkdownNodes(
+				'## Read [the guide](https://example.com/guide)',
+				{ headingOffset: 0, headingIds: true },
+			),
+		}),
+	)
+	expect(html).toContain('id="read-the-guide-https-example.com-guide"')
+	expect(html).toContain('href="#read-the-guide-https-example.com-guide"')
+	expect(html).toContain('aria-label="Read the guide"')
+	expect(html).toContain('href="https://example.com/guide"')
+	const permalink = html.match(
+		/<a href="#read-the-guide-https-example.com-guide"[^>]*>[\s\S]*?<\/a>/,
+	)?.[0]
+	expect(permalink).toBeDefined()
+	expect(permalink?.match(/<a /g)).toHaveLength(1)
 })
 
 test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths', () => {

--- a/packages/worker/client/markdown-view.node.test.ts
+++ b/packages/worker/client/markdown-view.node.test.ts
@@ -267,6 +267,34 @@ test('heading permalinks stay beside inline heading links instead of wrapping th
 	expect(permalink?.match(/<a /g)).toHaveLength(1)
 })
 
+test('heading accessible names come from parsed inline tokens, not markdown source', async () => {
+	const html = await renderToString(
+		jsx('div', {
+			children: renderMarkdownNodes(
+				[
+					'## **Install** `CLI`',
+					'',
+					'## Read [the guide](https://example.com/guide(nested)/path)',
+					'',
+					'## Heading with ![logo](https://img.example/logo.png) icon',
+				].join('\n'),
+				{ headingOffset: 0, headingIds: true },
+			),
+		}),
+	)
+	expect(html).toContain('aria-label="Install CLI"')
+	expect(html).not.toContain('aria-label="**Install**')
+	expect(html).toContain('aria-label="Read the guide"')
+	expect(html).not.toContain('aria-label="Read [the guide]')
+	expect(html).toContain('aria-label="Heading with logo icon"')
+	expect(html).not.toContain('aria-label="Heading with ![logo]')
+	const formattedPermalink = html.match(
+		/<a href="#install-cli"[^>]*>[\s\S]*?<\/a>/,
+	)?.[0]
+	expect(formattedPermalink).toContain('aria-label="Link to this section"')
+	expect(formattedPermalink).not.toContain('aria-label="Install CLI"')
+})
+
 test('getSafeMarkdownLinkHref allowlists protocols and blocks user-scope paths', () => {
 	expect(getSafeMarkdownLinkHref('https://example.com/a')).toBe(
 		'https://example.com/a',

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -371,8 +371,7 @@ function renderToken(
 			const headingId = nextHeadingId(options.headingSlugCounts, token.text)
 			return (
 				<Tag key={key} id={headingId}>
-					{renderMarkdownHeadingAnchor(key, headingId)}
-					<span data-heading-text="">{children}</span>
+					{renderMarkdownHeadingAnchor(key, headingId, children)}
 				</Tag>
 			)
 		}

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -224,6 +224,11 @@ function slugifyMarkdownHeading(text: string): string {
 		.replace(/^-+|-+$/g, '')
 }
 
+function headingPermalinkLabel(text: string, headingId: string): string {
+	const visible = text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1').trim()
+	return visible || headingId
+}
+
 function nextHeadingId(used: Map<string, number>, text: string): string {
 	const base = slugifyMarkdownHeading(text) || 'section'
 	const seen = used.get(base) ?? 0
@@ -371,7 +376,12 @@ function renderToken(
 			const headingId = nextHeadingId(options.headingSlugCounts, token.text)
 			return (
 				<Tag key={key} id={headingId}>
-					{renderMarkdownHeadingAnchor(key, headingId, children)}
+					{renderMarkdownHeadingAnchor(
+						key,
+						headingId,
+						headingPermalinkLabel(token.text, headingId),
+					)}
+					<span data-heading-text="">{children}</span>
 				</Tag>
 			)
 		}

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -375,12 +375,12 @@ function renderToken(
 			}
 			const headingId = nextHeadingId(options.headingSlugCounts, token.text)
 			return (
-				<Tag key={key} id={headingId}>
-					{renderMarkdownHeadingAnchor(
-						key,
-						headingId,
-						headingPermalinkLabel(token.text, headingId),
-					)}
+				<Tag
+					key={key}
+					id={headingId}
+					aria-label={headingPermalinkLabel(token.text, headingId)}
+				>
+					{renderMarkdownHeadingAnchor(key, headingId)}
 					<span data-heading-text="">{children}</span>
 				</Tag>
 			)

--- a/packages/worker/client/markdown-view.tsx
+++ b/packages/worker/client/markdown-view.tsx
@@ -224,9 +224,57 @@ function slugifyMarkdownHeading(text: string): string {
 		.replace(/^-+|-+$/g, '')
 }
 
-function headingPermalinkLabel(text: string, headingId: string): string {
-	const visible = text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1').trim()
+/**
+ * Accessible name for a heading that also hosts a permalink. Built from
+ * parsed inline tokens so emphasis, code, images, and links contribute
+ * visible text instead of markdown source.
+ */
+function headingPermalinkLabel(
+	tokens: Array<Token> | undefined,
+	headingId: string,
+): string {
+	const visible = inlineTokensAccessibleName(tokens).replace(/\s+/g, ' ').trim()
 	return visible || headingId
+}
+
+function inlineTokensAccessibleName(tokens: Array<Token> | undefined): string {
+	if (!tokens) return ''
+	let name = ''
+	for (const token of tokens) {
+		name += inlineTokenAccessibleName(token)
+	}
+	return name
+}
+
+function inlineTokenAccessibleName(token: Token): string {
+	switch (token.type) {
+		case 'text': {
+			const textToken = token as Tokens.Text
+			if (textToken.tokens?.length) {
+				return inlineTokensAccessibleName(textToken.tokens)
+			}
+			return decodeCharacterReferences(textToken.text)
+		}
+		case 'strong':
+		case 'em':
+		case 'del':
+		case 'link':
+			return inlineTokensAccessibleName(token.tokens)
+		case 'image':
+			return decodeCharacterReferences(token.text)
+		case 'codespan':
+		case 'escape':
+			return token.text
+		case 'br':
+			return ' '
+		case 'html':
+			return ''
+		default:
+			if ('tokens' in token && Array.isArray(token.tokens)) {
+				return inlineTokensAccessibleName(token.tokens)
+			}
+			return ''
+	}
 }
 
 function nextHeadingId(used: Map<string, number>, text: string): string {
@@ -378,7 +426,7 @@ function renderToken(
 				<Tag
 					key={key}
 					id={headingId}
-					aria-label={headingPermalinkLabel(token.text, headingId)}
+					aria-label={headingPermalinkLabel(token.tokens, headingId)}
 				>
 					{renderMarkdownHeadingAnchor(key, headingId)}
 					<span data-heading-text="">{children}</span>

--- a/packages/worker/universal/styles/style-primitives.prose.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.prose.node.test.ts
@@ -42,21 +42,22 @@ test('prose headings with ids expose permalink anchors and scroll margin', async
 			mix: css(proseCss),
 			children: jsx('h2', {
 				id: 'example',
-				children: jsx('a', {
-					href: '#example',
-					'data-heading-permalink': '',
-					children: [
-						jsx('span', {
+				children: [
+					jsx('a', {
+						href: '#example',
+						'data-heading-permalink': '',
+						'aria-label': 'Example section',
+						children: jsx('span', {
 							'data-heading-anchor': '',
 							'aria-hidden': 'true',
 							children: 'link',
 						}),
-						jsx('span', {
-							'data-heading-text': '',
-							children: 'Example section',
-						}),
-					],
-				}),
+					}),
+					jsx('span', {
+						'data-heading-text': '',
+						children: 'Example section',
+					}),
+				],
 			}),
 		}),
 	)

--- a/packages/worker/universal/styles/style-primitives.prose.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.prose.node.test.ts
@@ -42,19 +42,30 @@ test('prose headings with ids expose permalink anchors and scroll margin', async
 			mix: css(proseCss),
 			children: jsx('h2', {
 				id: 'example',
-				children: [
-					jsx('a', {
-						href: '#example',
-						'data-heading-anchor': '',
-						children: 'link',
-					}),
-					'Example section',
-				],
+				children: jsx('a', {
+					href: '#example',
+					'data-heading-permalink': '',
+					children: [
+						jsx('span', {
+							'data-heading-anchor': '',
+							'aria-hidden': 'true',
+							children: 'link',
+						}),
+						jsx('span', {
+							'data-heading-text': '',
+							children: 'Example section',
+						}),
+					],
+				}),
 			}),
 		}),
 	)
 
 	expect(html).toContain('scroll-margin-top: 5.5rem')
+	expect(html).toContain('[data-heading-permalink]')
 	expect(html).toContain('[data-heading-anchor]')
-	expect(html).toContain('display: flex')
+	expect(html).toContain('position: absolute')
+	expect(html).toContain('opacity: 0')
+	expect(html).toContain('h2[id]')
+	expect(html).not.toContain('h1[id]')
 })

--- a/packages/worker/universal/styles/style-primitives.prose.node.test.ts
+++ b/packages/worker/universal/styles/style-primitives.prose.node.test.ts
@@ -42,11 +42,12 @@ test('prose headings with ids expose permalink anchors and scroll margin', async
 			mix: css(proseCss),
 			children: jsx('h2', {
 				id: 'example',
+				'aria-label': 'Example section',
 				children: [
 					jsx('a', {
 						href: '#example',
 						'data-heading-permalink': '',
-						'aria-label': 'Example section',
+						'aria-label': 'Link to this section',
 						children: jsx('span', {
 							'data-heading-anchor': '',
 							'aria-hidden': 'true',

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -559,6 +559,13 @@ export const proseCss = {
 	'& a[data-heading-permalink]': {
 		color: 'inherit',
 		textDecoration: 'none',
+		// Stretch over the heading so clicking the text hits `#slug`
+		// without wrapping heading children (which may themselves be links).
+		'&::after': {
+			content: '""',
+			position: 'absolute' as const,
+			inset: 0,
+		},
 		'&:hover, &:focus, &:focus-visible': {
 			color: 'inherit',
 			textDecoration: 'none',
@@ -570,6 +577,10 @@ export const proseCss = {
 	},
 	'& [data-heading-text]': {
 		minWidth: 0,
+		'& a': {
+			position: 'relative' as const,
+			zIndex: 1,
+		},
 	},
 	'& [data-heading-anchor]': {
 		// Hang the 44px control to the left of the heading so the text stays

--- a/packages/worker/universal/styles/style-primitives.ts
+++ b/packages/worker/universal/styles/style-primitives.ts
@@ -543,44 +543,51 @@ export const proseCss = {
 		lineHeight: 1.15,
 	},
 	'& h2[id], & h3[id], & h4[id], & h5[id], & h6[id]': {
-		display: 'flex',
-		alignItems: 'baseline',
-		columnGap: '0.35rem',
+		position: 'relative' as const,
 		scrollMarginTop: '5.5rem',
 		'&:focus-within [data-heading-anchor]': {
-			opacity: 0.85,
+			opacity: 1,
+			color: colors.primaryText,
 		},
 		[hoverMq]: {
 			'&:hover [data-heading-anchor]': {
-				opacity: 0.85,
+				opacity: 1,
+				color: colors.primaryText,
 			},
+		},
+	},
+	'& a[data-heading-permalink]': {
+		color: 'inherit',
+		textDecoration: 'none',
+		'&:hover, &:focus, &:focus-visible': {
+			color: 'inherit',
+			textDecoration: 'none',
+			outline: 'none',
+		},
+		'&:focus-visible [data-heading-anchor]': {
+			boxShadow: `0 0 0 2px ${colors.primaryText}`,
 		},
 	},
 	'& [data-heading-text]': {
 		minWidth: 0,
 	},
 	'& [data-heading-anchor]': {
+		// Hang the 44px control to the left of the heading so the text stays
+		// aligned with the body; `flex-end` keeps the 16px icon close to it.
+		position: 'absolute' as const,
+		right: '100%',
+		top: '50%',
+		transform: 'translateY(-50%)',
 		display: 'inline-flex',
 		alignItems: 'center',
-		justifyContent: 'center',
-		flex: 'none',
+		justifyContent: 'flex-end',
 		width: '2.75rem',
 		height: '2.75rem',
-		margin: '-0.65rem 0 -0.65rem -0.65rem',
-		padding: '0.5rem',
+		marginRight: '0.15rem',
 		color: colors.textMuted,
-		opacity: 0.45,
-		textDecoration: 'none',
+		opacity: 0,
 		borderRadius: radius.sm,
 		transition: 'opacity 120ms ease, color 120ms ease',
-		'&:hover, &:focus-visible': {
-			opacity: 1,
-			color: colors.primaryText,
-			outline: 'none',
-		},
-		'&:focus-visible': {
-			boxShadow: `0 0 0 2px ${colors.primaryText}`,
-		},
 		'& svg': {
 			width: '1rem',
 			height: '1rem',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Polish the docs/blog heading permalinks from #2247 so they match the dangling-icon look: heading text stays aligned with the body, the icon hangs to the left, and it only appears on hover or focus.

## Why

The first-pass layout kept a 44px icon in the heading's flex flow, so section titles sat indented relative to the page title and body. The icon was also always visible, and only the icon itself was the `#slug` control.

## Summary

- Sit the `#slug` permalink beside h2–h6 text (not around it) and stretch it over the heading so clicking the text updates the hash without nesting inline markdown links.
- Hang the 44px icon absolutely to the left of the heading (`flex-end` so the 16px glyph sits close to the text) instead of indenting the line.
- Hide the icon until the heading is hovered or focused (keyboard included).
- H1 stays page-owned and does not get this treatment.
- Heading `aria-label` owns the section title from parsed inline tokens (emphasis, code, images, links as visible text). The permalink uses a generic "Link to this section" name so screen readers do not announce the title twice.

## Testing

- Targeted node tests: markdown heading HTML, non-nested permalink vs inline heading links, heading vs permalink accessible names (including emphasis, code spans, images, and nested-paren links), and `proseCss` permalink rules.
- `test:push` (node-unit + workers-unit) on push.
- Local browser: docs + blog, desktop and 375px — hover/focus shows the icon, rest state stays aligned, heading-text click updates the hash, H1 unchanged.
- Preview: https://kody-pr-2256.kody-a99.workers.dev — `/docs/secrets` and `/blog/early-kody-users`.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f610e6ae` · **Head:** `dcc3a4d1`

**Classification:** extends — heading permalink HTML and `proseCss` change so h2–h6 text stays aligned, the icon dangles, and the heading is the `#slug` control without wrapping inner links or duplicating the title. Heading `aria-label` is built from parsed inline tokens. H1 is unchanged.

### Primitives touched

| Primitive | Group    | Impact |
| --------- | -------- | ------ |
| `app-ui`  | surfaces | extends — docs/blog h2–h6 permalinks hang beside heading text, hide the icon until hover/focus, stretch the `#slug` control over the heading without nesting `<a>` tags, and name the heading from parsed inline tokens so markdown source does not leak |

### Change flow

First-party markdown headings still get `id`s. The permalink sits beside heading text. The heading owns a token-derived title. `proseCss` hangs the icon and stretches the click target.

```mermaid
sequenceDiagram
	actor Reader
	participant appUi as app-ui
	Reader->>appUi: GET /docs/:slug or /blog/:slug
	appUi->>appUi: render h2-h6 with sibling #slug permalink
	Note over appUi: heading aria-label from parsed inline tokens
	Note over appUi: permalink is Link to this section
	Note over appUi: icon hidden until heading hover or focus
	Reader->>appUi: click heading text or icon
	appUi->>Reader: location hash updates to #slug
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32f0662a-c8c6-56e0-8a8a-e54a96fc482a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32f0662a-c8c6-56e0-8a8a-e54a96fc482a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Heading permalinks now make the full heading text clickable while keeping inline links independently interactive.
  - Headings and permalink controls now include clearer, accurate accessible labels for screen readers.
  - Permalink icons remain hidden by default and appear on hover or focus.

- **Style**
  - Permalink controls are positioned beside headings without affecting their layout.
  - Focused permalink controls receive clearer visual styling for improved keyboard navigation.
  - Updated heading link styling preserves the visibility and interaction of links within heading text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->