### PR TITLE
Fix profile Needs republish stuck after communityPublish

### DIFF
--- a/docs/use/community-packages.md
+++ b/docs/use/community-packages.md
@@ -206,6 +206,9 @@ not `package.json#private`:
 - Public packages on the profile are catalog listings: they carry a listing
   signifier and a fork affordance (same inert-fork rules as
   [forking a listing](#forking-a-listing)).
+- The owner’s own profile can filter **Needs republish** when the listing pin is
+  behind the package published commit. `communityPublish` also bumps
+  `updated_at` after `published_at`; that timestamp order is not this signal.
 
 ### Private mode
 

--- a/packages/worker/src/app/community-public.ts
+++ b/packages/worker/src/app/community-public.ts
@@ -69,6 +69,7 @@ export function toPublicProfilePackageItem(
 		communityListingId: pkg.communityListingId,
 		communityListingKodyId: pkg.communityListingKodyId,
 		communityPublishedAt: pkg.communityPublishedAt,
+		needsRepublish: pkg.needsRepublish,
 		...(options?.includeOwnerVisibility
 			? { isPrivate: pkg.isPrivate, hidden: pkg.hidden }
 			: {}),

--- a/packages/worker/src/app/handlers/profile.node.test.ts
+++ b/packages/worker/src/app/handlers/profile.node.test.ts
@@ -82,6 +82,7 @@ const packageFixture = [
 		communityListingId: 'listing-1',
 		communityListingKodyId: 'helper',
 		communityPublishedAt: '2026-07-01T00:00:00.000Z',
+		needsRepublish: false,
 		isPrivate: false,
 		hidden: false,
 	},

--- a/packages/worker/src/app/profile-content.node.test.ts
+++ b/packages/worker/src/app/profile-content.node.test.ts
@@ -25,6 +25,7 @@ const listedPackage = {
 	communityListingId: 'listing-1',
 	communityListingKodyId: 'fathom-analytics',
 	communityPublishedAt: '2026-07-28T00:00:00.000Z',
+	needsRepublish: true,
 } satisfies PublicProfilePackageItem
 
 const unpublishedPackage = {
@@ -36,6 +37,7 @@ const unpublishedPackage = {
 	communityListingId: null,
 	communityListingKodyId: null,
 	communityPublishedAt: null,
+	needsRepublish: false,
 } satisfies PublicProfilePackageItem
 
 test('profile packages link listings, prefer listing kody ids, and separate published dates from local edits', async () => {
@@ -99,8 +101,27 @@ test('profile packages link listings, prefer listing kody ids, and separate publ
 	})
 
 	expect(ownHtml).toContain('@kody')
-	// Owners also see that the listing is behind their local edits.
+	// Owners also see that the listing pin is behind the published commit.
 	expect(ownHtml).toContain('edited August 7, 2026, not republished')
+
+	// communityPublish bumps updated_at after published_at even when the pin
+	// already matches HEAD / published_commit. That skew is not republish.
+	const ownPublishSkewHtml = await renderProfileContentHtml({
+		profile,
+		packages: [
+			{
+				...listedPackage,
+				updatedAt: '2026-07-28T00:00:01.044Z',
+				communityPublishedAt: '2026-07-28T00:00:00.000Z',
+				needsRepublish: false,
+			},
+		],
+		activity: [],
+		query: null,
+		isSelf: true,
+	})
+	expect(ownPublishSkewHtml).toContain('Published July 28, 2026')
+	expect(ownPublishSkewHtml).not.toContain('not republished')
 
 	const ownInventoryHtml = await renderProfileContentHtml({
 		profile,

--- a/packages/worker/src/app/profile-content.tsx
+++ b/packages/worker/src/app/profile-content.tsx
@@ -75,8 +75,9 @@ function renderForkIcon() {
 /**
  * Package cards carry two unrelated timestamps: the community listing's
  * published_at and the owner's local saved-package edit time. Only the
- * published date lines up with the activity feed, so unpublished edits are
- * labelled as edits and shown to the owner alone as a republish reminder.
+ * published date lines up with the activity feed. Owners see a republish
+ * reminder when the listing pin is behind the package published commit,
+ * not when `updated_at` lands after `published_at` from the same publish.
  */
 function renderProfilePackageDates(
 	pkg: PublicProfilePackageItem,
@@ -86,8 +87,7 @@ function renderProfilePackageDates(
 		return `Edited ${formatCommunityPublishedDate(pkg.updatedAt)}`
 	}
 	const published = `Published ${formatCommunityPublishedDate(pkg.communityPublishedAt)}`
-	const hasUnpublishedEdits = pkg.updatedAt > pkg.communityPublishedAt
-	if (!options.isSelf || !hasUnpublishedEdits) return published
+	if (!options.isSelf || !pkg.needsRepublish) return published
 	return `${published} · edited ${formatCommunityPublishedDate(pkg.updatedAt)}, not republished`
 }
 
@@ -153,7 +153,8 @@ function renderProfilePackageFilters(input: {
 		listingChoices.push({
 			value: 'ahead',
 			label: 'Needs republish',
-			title: 'Published packages edited since their last publish',
+			title:
+				'Published packages whose listing pin is behind the latest published commit',
 		})
 	}
 	return (

--- a/packages/worker/src/community/listing-needs-republish.node.test.ts
+++ b/packages/worker/src/community/listing-needs-republish.node.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest'
+import { listingNeedsRepublish } from './listing-needs-republish.ts'
+
+test('listingNeedsRepublish is pin vs published commit, not timestamp order', () => {
+	expect(
+		listingNeedsRepublish({
+			listingPinnedCommit: 'abc123',
+			sourcePublishedCommit: 'abc123',
+		}),
+	).toBe(false)
+	expect(
+		listingNeedsRepublish({
+			listingPinnedCommit: 'abc123',
+			sourcePublishedCommit: 'def456',
+		}),
+	).toBe(true)
+	expect(
+		listingNeedsRepublish({
+			listingPinnedCommit: '  abc123  ',
+			sourcePublishedCommit: 'abc123',
+		}),
+	).toBe(false)
+	expect(
+		listingNeedsRepublish({
+			listingPinnedCommit: null,
+			sourcePublishedCommit: 'abc123',
+		}),
+	).toBe(false)
+	expect(
+		listingNeedsRepublish({
+			listingPinnedCommit: 'abc123',
+			sourcePublishedCommit: '',
+		}),
+	).toBe(false)
+})

--- a/packages/worker/src/community/listing-needs-republish.ts
+++ b/packages/worker/src/community/listing-needs-republish.ts
@@ -1,0 +1,38 @@
+/**
+ * Owner "Needs republish" is commit-based: the community listing pin is
+ * behind the package runtime published commit. `communityPublish` stamps the
+ * pin to that SHA, then `updateSavedPackage` bumps `saved_packages.updated_at`
+ * after `listing.published_at`, so comparing those timestamps resticks the
+ * badge even when the pin already matches HEAD / published_commit.
+ *
+ * HEAD-ahead-of-published is a different signal (listing `sourceAhead`). This
+ * flag is only "listing pin behind published_commit".
+ */
+export function listingNeedsRepublish(input: {
+	listingPinnedCommit: string | null | undefined
+	sourcePublishedCommit: string | null | undefined
+}): boolean {
+	const pin = input.listingPinnedCommit?.trim()
+	const published = input.sourcePublishedCommit?.trim()
+	if (!pin || !published) return false
+	return pin !== published
+}
+
+/**
+ * Profile `listing=ahead` filter. Same commit comparison as
+ * `listingNeedsRepublish`, joined through the owner's package source so a
+ * foreign `entity_sources` row cannot leak a commit into another user's list.
+ */
+export const listingNeedsRepublishSql = `EXISTS (
+	SELECT 1 FROM community_listings AS cl
+	JOIN entity_sources AS es
+		ON es.id = saved_packages.source_id
+		AND es.user_id = saved_packages.user_id
+		AND es.entity_kind = 'package'
+		AND es.entity_id = saved_packages.id
+	WHERE cl.owner_user_id = saved_packages.user_id
+		AND cl.status = 'active'
+		AND cl.package_id = saved_packages.id
+		AND es.published_commit IS NOT NULL
+		AND cl.pinned_commit != es.published_commit
+)`

--- a/packages/worker/src/community/profile-package-list.ts
+++ b/packages/worker/src/community/profile-package-list.ts
@@ -1,4 +1,5 @@
 import { type ProfilePackageFilters } from '#universal/community-public-types.ts'
+import { listingNeedsRepublishSql } from './listing-needs-republish.ts'
 import { listPublicProfilePackages as listPublicProfilePackagesFromDb } from './profile-repo.ts'
 import { type PublicProfilePackage } from './types.ts'
 
@@ -7,14 +8,6 @@ const activeListingExistsSql = `EXISTS (
 	WHERE cl.owner_user_id = saved_packages.user_id
 		AND cl.status = 'active'
 		AND cl.package_id = saved_packages.id
-)`
-
-const listingAheadSql = `EXISTS (
-	SELECT 1 FROM community_listings AS cl
-	WHERE cl.owner_user_id = saved_packages.user_id
-		AND cl.status = 'active'
-		AND cl.package_id = saved_packages.id
-		AND saved_packages.updated_at > cl.published_at
 )`
 
 function profilePackageFilterWhereSql(
@@ -59,7 +52,7 @@ function profilePackageFilterWhereSql(
 			conditions.push(`NOT ${activeListingExistsSql}`)
 			break
 		case 'ahead':
-			conditions.push(listingAheadSql)
+			conditions.push(listingNeedsRepublishSql)
 			break
 		default: {
 			const exhaustive: never = filters.listing

--- a/packages/worker/src/community/profile-repo.ts
+++ b/packages/worker/src/community/profile-repo.ts
@@ -3,6 +3,7 @@ import { chunkArray } from '@kody-internal/shared/chunk.ts'
 import { utcSqliteTimestamp } from '@kody-internal/shared/date-keys.ts'
 import { parseTagsJson } from '@kody-internal/shared/tags-json.ts'
 import { normalizeStableUserId } from '#worker/user-id.ts'
+import { listingNeedsRepublish } from './listing-needs-republish.ts'
 import { extractCommunityListingLikeTokens } from './repo.ts'
 import {
 	type CommunityActivityEventType,
@@ -376,6 +377,7 @@ export async function listPublicProfilePackages(
 		communityListingId: null as string | null,
 		communityListingKodyId: null as string | null,
 		communityPublishedAt: null as string | null,
+		needsRepublish: false,
 		isPrivate: Number(row['is_private']) === 1,
 		hidden: Number(row['hidden']) === 1,
 	}))
@@ -387,17 +389,32 @@ export async function listPublicProfilePackages(
 	// so it is the id the public URL actually resolves under.
 	const listingByPackageId = new Map<
 		string,
-		{ id: string; kodyId: string | null; publishedAt: string }
+		{
+			id: string
+			kodyId: string | null
+			publishedAt: string
+			pinnedCommit: string
+			sourcePublishedCommit: string | null
+		}
 	>()
 	for (const idChunk of chunkArray(packageIds, maxSqlBindingsPerChunk)) {
 		const placeholders = idChunk.map(() => '?').join(', ')
 		const listingRows = await db
 			.prepare(
-				`SELECT id, package_id, kody_id, published_at
-				FROM community_listings
-				WHERE owner_user_id = ?
-					AND status = 'active'
-					AND package_id IN (${placeholders})`,
+				`SELECT cl.id, cl.package_id, cl.kody_id, cl.published_at, cl.pinned_commit,
+					es.published_commit AS source_published_commit
+				FROM community_listings AS cl
+				JOIN saved_packages AS sp
+					ON sp.id = cl.package_id
+					AND sp.user_id = cl.owner_user_id
+				LEFT JOIN entity_sources AS es
+					ON es.id = sp.source_id
+					AND es.user_id = sp.user_id
+					AND es.entity_kind = 'package'
+					AND es.entity_id = sp.id
+				WHERE cl.owner_user_id = ?
+					AND cl.status = 'active'
+					AND cl.package_id IN (${placeholders})`,
 			)
 			.bind(input.ownerStableUserId, ...idChunk)
 			.all<{
@@ -405,12 +422,19 @@ export async function listPublicProfilePackages(
 				package_id: string
 				kody_id: string | null
 				published_at: string
+				pinned_commit: string
+				source_published_commit: string | null
 			}>()
 		for (const listingRow of listingRows.results ?? []) {
 			listingByPackageId.set(listingRow.package_id, {
 				id: listingRow.id,
 				kodyId: listingRow.kody_id,
 				publishedAt: String(listingRow.published_at),
+				pinnedCommit: String(listingRow.pinned_commit),
+				sourcePublishedCommit:
+					listingRow.source_published_commit == null
+						? null
+						: String(listingRow.source_published_commit),
 			})
 		}
 	}
@@ -422,6 +446,10 @@ export async function listPublicProfilePackages(
 			communityListingId: listing?.id ?? null,
 			communityListingKodyId: listing?.kodyId ?? null,
 			communityPublishedAt: listing?.publishedAt ?? null,
+			needsRepublish: listingNeedsRepublish({
+				listingPinnedCommit: listing?.pinnedCommit,
+				sourcePublishedCommit: listing?.sourcePublishedCommit,
+			}),
 		}
 	})
 }

--- a/packages/worker/src/community/profile-service.workers.test.ts
+++ b/packages/worker/src/community/profile-service.workers.test.ts
@@ -66,6 +66,7 @@ async function insertListing(input: {
 	name: string
 	kodyId: string
 	publishedAt?: string
+	pinnedCommit?: string
 }) {
 	const publishedAt = input.publishedAt ?? new Date().toISOString()
 	await runSql(
@@ -82,10 +83,31 @@ async function insertListing(input: {
 		`${input.kodyId} description`,
 		JSON.stringify(['catalog']),
 		'MIT',
-		'commit-1',
+		input.pinnedCommit ?? 'commit-1',
 		publishedAt,
 		publishedAt,
 		publishedAt,
+	)
+}
+
+async function insertEntitySource(input: {
+	packageId: string
+	userId: string
+	publishedCommit: string
+}) {
+	const now = '2026-07-01T00:00:00.000Z'
+	await runSql(
+		`INSERT INTO entity_sources (
+			id, user_id, entity_kind, entity_id, repo_id, published_commit,
+			indexed_commit, manifest_path, source_root, created_at, updated_at
+		) VALUES (?, ?, 'package', ?, ?, ?, NULL, 'package.json', '/', ?, ?)`,
+		`source-${input.packageId}`,
+		input.userId,
+		input.packageId,
+		`repo-${input.packageId}`,
+		input.publishedCommit,
+		now,
+		now,
 	)
 }
 
@@ -329,6 +351,12 @@ test('listPublicProfilePackages filters private/hidden packages and supports que
 		name: `@${owner.username}/public-notes`,
 		kodyId: 'public-notes',
 		publishedAt: '2026-06-01T00:00:00.000Z',
+		pinnedCommit: 'commit-listed',
+	})
+	await insertEntitySource({
+		packageId: publicNotesId,
+		userId: owner.userId,
+		publishedCommit: 'commit-ahead',
 	})
 
 	const published = await listPublicProfilePackages({
@@ -404,6 +432,90 @@ test('listPublicProfilePackages filters private/hidden packages and supports que
 		},
 	})
 	expect(ahead.map((pkg) => pkg.kodyId)).toEqual(['public-notes'])
+	expect(ahead[0]?.needsRepublish).toBe(true)
+})
+
+test('listPublicProfilePackages ahead filter ignores post-publish updated_at skew when the pin matches published_commit', async () => {
+	const owner = await insertUser({
+		email: `skew-${crypto.randomUUID()}@example.com`,
+		username: `skew${crypto.randomUUID().slice(0, 8)}`,
+	})
+	const syncedId = `synced-${crypto.randomUUID()}`
+	const behindId = `behind-${crypto.randomUUID()}`
+	await insertSavedPackage({
+		id: syncedId,
+		userId: owner.userId,
+		name: `@${owner.username}/grok-bot`,
+		kodyId: 'grok-bot',
+		isPrivate: false,
+		// communityPublish writes listing.published_at first, then
+		// updateSavedPackage bumps updated_at ~0.8–3s later.
+		updatedAt: '2026-09-11T17:41:55.588Z',
+	})
+	await insertSavedPackage({
+		id: behindId,
+		userId: owner.userId,
+		name: `@${owner.username}/skills`,
+		kodyId: 'skills',
+		isPrivate: false,
+		updatedAt: '2026-09-11T17:41:55.588Z',
+	})
+	await insertListing({
+		id: `listing-${syncedId}`,
+		ownerUserId: owner.userId,
+		packageId: syncedId,
+		name: `@${owner.username}/grok-bot`,
+		kodyId: 'grok-bot',
+		publishedAt: '2026-09-11T17:41:54.544Z',
+		pinnedCommit: 'commit-head',
+	})
+	await insertListing({
+		id: `listing-${behindId}`,
+		ownerUserId: owner.userId,
+		packageId: behindId,
+		name: `@${owner.username}/skills`,
+		kodyId: 'skills',
+		publishedAt: '2026-09-11T17:41:54.544Z',
+		pinnedCommit: 'commit-listed',
+	})
+	await insertEntitySource({
+		packageId: syncedId,
+		userId: owner.userId,
+		publishedCommit: 'commit-head',
+	})
+	await insertEntitySource({
+		packageId: behindId,
+		userId: owner.userId,
+		publishedCommit: 'commit-head',
+	})
+
+	const listed = await listPublicProfilePackages({
+		env,
+		ownerStableUserId: owner.userId,
+		limit: 10,
+		includePrivate: true,
+	})
+	expect(listed.find((pkg) => pkg.kodyId === 'grok-bot')?.needsRepublish).toBe(
+		false,
+	)
+	expect(listed.find((pkg) => pkg.kodyId === 'skills')?.needsRepublish).toBe(
+		true,
+	)
+
+	const ahead = await listPublicProfilePackages({
+		env,
+		ownerStableUserId: owner.userId,
+		limit: 10,
+		includePrivate: true,
+		filters: {
+			query: '',
+			visibility: 'all',
+			listing: 'ahead',
+			hidden: 'all',
+		},
+	})
+	expect(ahead.map((pkg) => pkg.kodyId)).toEqual(['skills'])
+	expect(ahead[0]?.needsRepublish).toBe(true)
 })
 
 test('profile activity includes own private publishes and hides them from public reads', async () => {

--- a/packages/worker/src/community/types.ts
+++ b/packages/worker/src/community/types.ts
@@ -133,6 +133,12 @@ export type PublicProfilePackage = {
 	communityListingKodyId: string | null
 	/** published_at of the active community listing, when the package has one. */
 	communityPublishedAt: string | null
+	/**
+	 * True when the active listing pin is behind the package published
+	 * commit. False with no listing, or when the pin matches. Not derived
+	 * from `updated_at` vs `published_at`.
+	 */
+	needsRepublish: boolean
 	/** Owner-only: repo visibility. Always false on public profile lists. */
 	isPrivate: boolean
 	/** Owner-only: hidden from ranked search. Always false on public profile lists. */

--- a/packages/worker/src/mcp/capabilities/community/social-shared.ts
+++ b/packages/worker/src/mcp/capabilities/community/social-shared.ts
@@ -37,6 +37,11 @@ export const communityProfilePackageSchema = z.object({
 		.describe(
 			'Last time the package was published to its community listing, or null when it has no active listing.',
 		),
+	needs_republish: z
+		.boolean()
+		.describe(
+			'True when the active community listing pin is behind the package published commit. False when there is no listing, or the pin matches. Do not derive this from updated_at versus published_at.',
+		),
 	hidden: z
 		.boolean()
 		.optional()
@@ -91,6 +96,7 @@ export function toCommunityProfilePackageOutput(
 		updated_at: string
 		community_listing_id: string | null
 		community_published_at: string | null
+		needs_republish: boolean
 		hidden?: boolean
 		is_private?: boolean
 	} = {
@@ -101,6 +107,7 @@ export function toCommunityProfilePackageOutput(
 		updated_at: pkg.updatedAt,
 		community_listing_id: pkg.communityListingId,
 		community_published_at: pkg.communityPublishedAt,
+		needs_republish: pkg.needsRepublish,
 	}
 	if (options.includePackageId) {
 		output.package_id = pkg.packageId

--- a/packages/worker/universal/community-public-types.ts
+++ b/packages/worker/universal/community-public-types.ts
@@ -104,6 +104,11 @@ export type PublicProfilePackageItem = {
 	/** The listing's package name leaf, which can lag the package's until republish. */
 	communityListingKodyId: string | null
 	communityPublishedAt: string | null
+	/**
+	 * True when the listing pin is behind the package published commit.
+	 * Owners use this for the "Needs republish" filter and date reminder.
+	 */
+	needsRepublish: boolean
 	/** Present on the owner's own profile list; omitted for other viewers. */
 	isPrivate?: boolean
 	/** Present on the owner's own profile list; omitted for other viewers. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Clear the owner profile **Needs republish** filter and date reminder after a successful `communityPublish`, instead of resticking them on the post-publish `updated_at` bump.

## Why

`communityPublish` writes `listing.published_at` first, then `updateSavedPackage` bumps `saved_packages.updated_at` ~0.8–3s later even when the listing pin already equals HEAD / `published_commit`. The profile filter and “not republished” copy compared those timestamps, so every publish left the package in **Needs republish**.

## Summary

- Derive `needsRepublish` from `community_listings.pinned_commit` vs the owner package `entity_sources.published_commit`
- `listing=ahead` SQL uses the same commit join, not `updated_at > published_at`
- Profile UI and `communityProfileGet` (`needs_republish`) consume that flag
- Tests cover pin-matches-HEAD with later `updated_at` (the grok-bot / skills skew)

## Testing

- `vitest` node-unit: listing helper, profile content, profile handler
- `vitest` workers-unit: `profile-service.workers.test.ts` (ahead filter + post-publish skew)
- Pre-push: `test:node` (3096) and `test:workers` (345)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `6b747ede` · **Head:** `1a9c4442`

**Classification:** extends — profile Needs republish is commit-based (`listing.pinned_commit` vs `entity_sources.published_commit`) instead of `updated_at` vs `published_at`.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `community-listings` | assistant | extends — owner `listing=ahead` SQL and `needsRepublish` / `needs_republish` derivation |
| `app-ui` | surfaces | extends — profile date reminder and public package payload |

### Change flow

Owner profile GET derives Needs republish from the listing pin versus the package published commit, so a post-`communityPublish` `updated_at` bump cannot restick the filter.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	participant communityListings as community-listings
	Owner->>appUi: GET /@username?listing=ahead
	appUi->>communityListings: listPublicProfilePackages listing=ahead
	communityListings->>communityListings: join listing pin to package published_commit
	Note over communityListings: needsRepublish when pin differs, not when updated_at is later
	communityListings-->>appUi: needsRepublish on each listed package
	appUi-->>Owner: Needs republish filter and not-republished date line
```

### Before / after

```
needs republish: saved_packages.updated_at > community_listings.published_at
needs republish: community_listings.pinned_commit != entity_sources.published_commit
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4aff3e3-3535-437f-9e83-c985d750b1a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4aff3e3-3535-437f-9e83-c985d750b1a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Needs republish** indicator for profile listings when the listing references an older published commit.
  * Updated profile filters, tooltips, and package details to reflect republish status accurately.
  * Exposed republish status in community profile package data and integrations.

* **Documentation**
  * Clarified that republish status is based on commit differences, not timestamp ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->