### PR TITLE
Add Stripe webhook video second on the homepage

### DIFF
--- a/packages/worker/client/routes/landing-hero-video.node.test.ts
+++ b/packages/worker/client/routes/landing-hero-video.node.test.ts
@@ -55,4 +55,15 @@ test('hero video renders the first video in the player and every video as a list
 	for (const video of rest) {
 		expect(html).toContain(`/youtube-thumb/${video.videoId}`)
 	}
+
+	const optionThumbs = [
+		...html.matchAll(
+			/role="option"[\s\S]*?\/youtube-thumb\/([A-Za-z0-9_-]{11})/g,
+		),
+	].map((match) => match[1])
+	expect(optionThumbs[0]).toBe(first.videoId)
+	expect(optionThumbs[1]).toBe('o5L5OprLhBg')
+	expect(html).toContain(
+		'Kody fixes a Stripe webhook after we renamed the domain',
+	)
 })

--- a/packages/worker/universal/landing-hero-copy.ts
+++ b/packages/worker/universal/landing-hero-copy.ts
@@ -26,6 +26,10 @@ export const landingHeroDemoVideos: ReadonlyArray<{
 		title: 'Build a PR-ready check in Cursor, then run it from Claude',
 	},
 	{
+		videoId: 'o5L5OprLhBg',
+		title: 'Kody fixes a Stripe webhook after we renamed the domain',
+	},
+	{
 		videoId: 'QA0xYMAMjEg',
 		title: 'Introducing Kody: Your Personal Software Factory',
 	},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Add Kent’s Stripe webhook YouTube video to the homepage hero chooser so visitors can play it without changing the default first video.

## Why

The video is ready to sit with the other Kody walkthroughs. It belongs second in the list so the Cursor-to-Claude check stays the default player.

## Summary

- Insert YouTube id `o5L5OprLhBg` as the second homepage hero video.
- Title: **Kody fixes a Stripe webhook after we renamed the domain**.
- Thumbnails, allowlist, and embed still come from the existing `landingHeroDemoVideos` wiring. No homepage redesign.

## Testing

- Focused node tests for the hero chooser and homepage SSR.
- `test:push` (node-unit + workers-unit) on push.
- Browser: homepage desktop and mobile, second thumbnail, play/embed like the others.
- `npm run validate` after the UI pass.

## System changes

Composes existing `app-ui` homepage hero video list. Low risk.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `f610e6ae` · **Head:** `e3721b73`

**Classification:** composes — no primitives added or changed; this PR adds one entry to the existing homepage hero video list.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

The homepage hero still SSRs the lite player plus chooser; the new id is second in that list and rides the existing thumb proxy and nocookie embed.

```mermaid
sequenceDiagram
	actor Visitor
	participant appUi as app-ui
	Visitor->>appUi: GET /
	Note over appUi: landingHeroDemoVideos inserts o5L5OprLhBg second
	appUi->>Visitor: lite player stays first video, chooser lists five thumbs
	Visitor->>appUi: click second chooser thumbnail
	appUi->>Visitor: youtube-nocookie embed for the Stripe webhook video
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca60cee7-d912-5ed9-a980-2066a49b8877?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca60cee7-d912-5ed9-a980-2066a49b8877&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new landing-page demo video showcasing how Kody fixes a Stripe webhook after a domain rename.
  - The demo video is now available among the landing-page video options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->