### PR TITLE
Keep the docs nav focus ring fully visible

### DIFF
--- a/packages/worker/client/routes/docs-shell.node.test.ts
+++ b/packages/worker/client/routes/docs-shell.node.test.ts
@@ -31,6 +31,23 @@ test('docs shell marks the sidebar and highlights the open page', async () => {
 	)
 })
 
+test('docs sidebar and mobile menu leave room for hanging nav-link focus rings', async () => {
+	const html = await renderToString(
+		renderDocsShell({
+			current: 'text-your-agent',
+			children: jsx('p', { children: 'Article' }),
+		}),
+	)
+
+	// `overflow-y: auto` computes overflow-x to auto, which clips outlines.
+	// Links hang 0.6rem left so their pill aligns with heading text; the
+	// scroller must pad that hang plus the global 2.5px + 3px focus ring.
+	expect(html).toContain('overflow-y: auto')
+	expect(html).toContain('padding-left: calc(0.6rem + 8px)')
+	expect(html).toContain('margin-left: -0.6rem')
+	expect(html).toContain('overflow: visible')
+})
+
 test('docs shell treats /docs/connect as the providers section', async () => {
 	const html = await renderToString(
 		renderDocsShell({

--- a/packages/worker/client/routes/docs-shell.tsx
+++ b/packages/worker/client/routes/docs-shell.tsx
@@ -187,6 +187,15 @@ export function renderDocListItem(doc: DocSummaryLoaderData, index: number) {
 }
 
 const sidebarWidth = '15.5rem'
+/** Hang so nav-link pills sit left of the section heading text. */
+const docsNavLinkHang = '0.6rem'
+/**
+ * Global `:focus-visible` is 2.5px outline + 3px offset. `overflow-y: auto`
+ * on the sidebar computes overflow-x to auto, which would clip that ring and
+ * the hanging pills. Keep this much extra padding on the scroller.
+ */
+const docsNavFocusGutter = '8px'
+const docsNavScrollerInset = `calc(${docsNavLinkHang} + ${docsNavFocusGutter})`
 
 const docsLayoutCss = {
 	display: 'grid',
@@ -212,6 +221,7 @@ const docsSidebarCss = {
 	overflowY: 'auto' as const,
 	overflowAnchor: 'none' as const,
 	paddingBlock: 'clamp(2.5rem, 6vw, 4rem) 2rem',
+	paddingLeft: docsNavScrollerInset,
 	paddingRight: '0.5rem',
 	borderRight: `1px solid ${colors.border}`,
 	scrollbarWidth: 'thin' as const,
@@ -257,8 +267,8 @@ const docsNavSectionCss = {
 	},
 	'& li a': {
 		display: 'block',
-		padding: '0.32rem 0.6rem',
-		marginLeft: '-0.6rem',
+		padding: `0.32rem ${docsNavLinkHang}`,
+		marginLeft: `-${docsNavLinkHang}`,
 		borderRadius: '0.45rem',
 		color: colors.textMuted,
 		textDecoration: 'none',
@@ -305,8 +315,11 @@ const docsMobileMenuCss = {
 		color: colors.textMuted,
 		fontSize: '0.95rem',
 	},
+	overflow: 'visible' as const,
 	'& > nav': {
-		padding: '0.4rem 0.6rem 0.7rem',
+		paddingBlock: '0.4rem 0.7rem',
+		paddingRight: '0.6rem',
+		paddingLeft: docsNavScrollerInset,
 		borderTop: `1px solid ${colors.border}`,
 	},
 	'& h2 a': {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Keyboard focus on a docs sidebar (and mobile docs menu) item should show the **full** green focus ring, not a ring clipped on the left.

## Why

Nav links hang `0.6rem` left so their hover/current pill aligns with section heading text. The sticky sidebar uses `overflow-y: auto` (which computes `overflow-x` to `auto`), so that hang plus the global `:focus-visible` outline (`2.5px` + `3px` offset) was painted outside the scrollport and clipped. Same hanging links live in the mobile `<details>` menu.

## Summary

- Pad the docs sidebar scroller and the mobile docs menu nav by `calc(0.6rem + 8px)` so the hang and the ring stay inside the overflow box.
- Leave the hanging pill alignment as-is; do not hide or inset the ring.
- Extend the docs-shell unit test to pin that padding contract.

## Testing

- `vitest run packages/worker/client/routes/docs-shell.node.test.ts` — pass
- `npm run validate` — pass (format, lint, typecheck, node/workers/e2e/mcp, mermaid, knip, etc.)
- Keyboard Tab on desktop sidebar: full green ring on “Text your agent” and neighboring items (left edge not clipped)
- Mouse click still navigates; `:focus-visible` does not ring on mouse, as expected
- Mobile docs menu / header docs list: full green ring on “Text your agent”

## System changes

Low risk: CSS padding on the existing docs shell. No route, data, or primitive contract change.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `46e0be87` · **Head:** `03002441`

**Classification:** composes — no primitives added or changed; this PR pads the existing docs nav overflow box so the global focus ring is not clipped.

### Primitives touched

| Primitive | Group    | Impact   |
| --------- | -------- | -------- |
| `app-ui`  | surfaces | composes |

### Change flow

Tab or click a hanging docs nav link; the sidebar scroller now has enough left padding for the hang plus the global focus ring.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	User->>appUi: Tab or click docs nav link
	appUi->>appUi: paint global focus-visible ring
	Note over appUi: padding-left calc(0.6rem hang + 8px ring gutter)
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a8e5185-9ffb-5422-9a11-e0c084ccc428?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a8e5185-9ffb-5422-9a11-e0c084ccc428&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the documentation sidebar and mobile navigation layout so link focus rings have adequate space and remain fully visible.
  * Updated navigation spacing and overflow behavior for more consistent keyboard focus presentation across desktop and mobile views.

* **Tests**
  * Added coverage to verify focus-ring clearance and required navigation layout styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->