### PR TITLE
Connections: Add connection opens the full client wall and per-host steps

### DIFF
--- a/.agents/skills/control-kody/references/features/connections.md
+++ b/.agents/skills/control-kody/references/features/connections.md
@@ -1,20 +1,29 @@
 # Connections
 
-Inbound MCP hosts (connected agents): the MCP URL to paste into another agent,
-per-host setup guide links, the grouped list of hosts that already authorized,
-and per-`clientId` revoke. Also links the Advanced MCP OAuth clients page.
+Inbound MCP hosts (connected agents). The connected list is the same grouped
+panel with per-`clientId` revoke that Overview used to host. **Add connection**
+opens the full client wall from onboarding Step 1 — every named agent, on every
+device, none folded under Not listed — then one host's install steps. The MCP
+URL card covers any other host that speaks MCP. Also links the Advanced MCP
+OAuth clients page.
 
 ## How to get there
 
-`/account/connections` (account rail → Connections; Overview keeps a "Manage
-connections" link). Setup guides link to `/onboarding`, which resumes at the
-right wizard step for the account.
+- `/account/connections` — connected list, Add connection button, MCP URL.
+- `/account/connections/new` — the agent grid.
+- `/account/connections/new/:agent` — install steps for one `McpClientKind`
+  (`cursor`, `claude-code`, `chatgpt`, …; `other` is not a page here). Unknown
+  agents 404.
+
+Account rail → Connections; Overview keeps a "Manage connections" link.
 
 ## Drive it
 
 ```bash
 node tools/control-kody.ts login
 node tools/control-kody.ts request GET /account/connected-agents.json
+node tools/control-kody.ts request GET /account/connections/new
+node tools/control-kody.ts request GET /account/connections/new/cursor
 ```
 
 ## APIs
@@ -22,14 +31,18 @@ node tools/control-kody.ts request GET /account/connected-agents.json
 - `GET|POST /account/connected-agents.json` (`{ intent: 'revoke', clientId }`)
 - `mcpServerUrl` in that payload is empty until the account email is verified
   (same gate as `/onboarding.json`); the page then shows a verify note instead
-  of the copy card.
+  of the grid and copy card.
+- All three HTML views share that one payload (no refetch between them).
 
 ## Gotchas
 
-- Seed users start with no connected agents; connect one from onboarding or an
-  MCP host to see the list. Revoke is a double-check button.
+- Seed users start with no connected agents; connect one from Add connection or
+  an MCP host to see the list. Revoke is a double-check button.
 - Hosts are grouped by display name (logos for known kinds, newest-first,
   best-effort labels). That list is not `users.mcp_client_name` and not minted
   MCP OAuth clients (`/account/mcp-oauth-clients`).
+- The grid reuses onboarding's `AgentPickerGrid` with `viewport: 'both'` on
+  every entry, so the phone/desktop split and greyed same-ecosystem cards that
+  onboarding applies do not appear here.
 - `/account/connections.json` is the sign-in provider (GitHub, Google, …) list
   on Overview, not this page's data.

--- a/docs/use/connect-your-agent.md
+++ b/docs/use/connect-your-agent.md
@@ -24,8 +24,9 @@ block and MCP URL, and `/.well-known/mcp/server-card.json` for the server card.
    account — not a limited permission set.
 
 Once signed in, Account → Connections (`/account/connections`) is the durable
-home for this: it shows the MCP URL with a copy button, links back to these
-per-host guides, lists every agent that has authorized, and lets you revoke one.
+home for this: it lists every agent that has authorized (with revoke), shows the
+MCP URL with a copy button, and **Add connection** opens the same per-host steps
+as Get started for every agent Kody knows how to connect.
 
 Your account email must be verified before authorize can finish or MCP can run.
 If authorize asks you to verify, keep that tab open, finish verification (from

--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -89,7 +89,7 @@ test('account section switches keep the current page on screen (no loading flash
 	).toHaveAttribute('href', `/@${user.username}`)
 })
 
-test('Add connection opens the full client wall and a host step without refetching the connections payload', async ({
+test('Add connection opens the full client wall and a host step in place (no loading flash, no double fetch)', async ({
 	page,
 	seedE2eUser,
 	login,
@@ -120,6 +120,9 @@ test('Add connection opens the full client wall and a host step without refetchi
 		fromHeading: 'Connections',
 		toHeading: 'Connections',
 	})
+	// Like every router hop, the destination loader (or its intent prefetch)
+	// fetches the payload once before commit; the contract here is that the
+	// route never asks for the same payload a second time.
 	expect(requests.duplicates(), requests.paths.join(', ')).toEqual([])
 	requests.reset()
 	// Every named client is a card and none is greyed or hidden by viewport.

--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -89,6 +89,68 @@ test('account section switches keep the current page on screen (no loading flash
 	).toHaveAttribute('href', `/@${user.username}`)
 })
 
+test('Add connection opens the full client wall and a host step without refetching the connections payload', async ({
+	page,
+	seedE2eUser,
+	login,
+}) => {
+	test.setTimeout(process.env.CI ? 90_000 : 60_000)
+	const runId = Date.now()
+	const user = await seedE2eUser({
+		email: `connections-${runId}@example.com`,
+		username: `connections-${runId}`,
+		password: 'connections-password',
+	})
+	await login({ email: user.email, password: user.password, mode: 'login' })
+	await page.goto('/account/connections')
+	await waitForClientHydration(page)
+	await expect(
+		page.getByRole('heading', { level: 1, name: 'Connections' }),
+	).toBeVisible()
+
+	const requests = collectJsonRequests(page)
+	await observeMainTransitions(page)
+	await page.getByTestId('account-connections-add').click()
+	await expect(page).toHaveURL(/\/account\/connections\/new$/)
+	const grid = page.getByTestId('account-connections-agent-grid')
+	await expect(grid).toBeVisible()
+	// The heading never leaves the screen: the grid is a view of the same page.
+	await page.waitForTimeout(250)
+	expectSingleCommitTransition(await readMainTransitions(page), {
+		fromHeading: 'Connections',
+		toHeading: 'Connections',
+	})
+	expect(requests.duplicates(), requests.paths.join(', ')).toEqual([])
+	requests.reset()
+	// Every named client is a card and none is greyed or hidden by viewport.
+	await expect(grid.getByRole('link')).toHaveCount(14)
+	await expect(grid.locator('[data-greyed="true"]')).toHaveCount(0)
+	await expect(page.getByTestId('onboarding-agent-claude-code')).toBeVisible()
+	await expect(page.getByTestId('onboarding-agent-grok')).toBeVisible()
+
+	await page.getByTestId('onboarding-agent-claude-code').click()
+	await expect(page).toHaveURL(/\/account\/connections\/new\/claude-code$/)
+	await expect(
+		page.getByRole('heading', { level: 2, name: 'Connect Claude Code' }),
+	).toBeVisible()
+	await expect(
+		page.getByTestId('account-connections-agent-instructions'),
+	).toBeVisible()
+	// Connections stays current in the rail on the nested views.
+	await expect(
+		page
+			.getByRole('navigation', { name: 'Account sections' })
+			.getByRole('link', { name: 'Connections', exact: true }),
+	).toHaveAttribute('aria-current', 'page')
+
+	expect(requests.duplicates(), requests.paths.join(', ')).toEqual([])
+	requests.reset()
+
+	await page.getByTestId('account-connections-change-agent').click()
+	await expect(grid).toBeVisible()
+	expect(requests.duplicates(), requests.paths.join(', ')).toEqual([])
+})
+
 async function markSearchNode(search: Locator) {
 	await search.evaluate((element) => {
 		;(element as HTMLElement).dataset.kodySearchMount = '1'

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -260,6 +260,8 @@ registerPreloadPatterns(
 		routePattern(routes.accountUsage),
 		routePattern(routes.accountWaiting),
 		routePattern(routes.accountConnections),
+		routePattern(routes.accountConnectionNew),
+		routePattern(routes.accountConnectionNewAgent),
 		routePattern(routes.accountShared),
 		routePattern(routes.communityPackageApproveChanges),
 		routePattern(routes.accountIntegrations),

--- a/packages/worker/client/routes/account-connected-agents-panel.tsx
+++ b/packages/worker/client/routes/account-connected-agents-panel.tsx
@@ -1,10 +1,11 @@
-import { type Handle, css } from 'remix/ui'
+import { type Handle, type RemixNode, css } from 'remix/ui'
 import { createDoubleCheck } from '#client/double-check.ts'
 import { readJson } from '#client/routes/account-approval-shared.ts'
 import { connectedAgentsApiPath } from '#client/routes/account-page-data.ts'
 import {
 	AccountManagementPanel,
 	TimestampValue,
+	accountActionsCss,
 } from '#client/routes/account-management-components.tsx'
 import {
 	connectedAgentConnectionLabel,
@@ -86,7 +87,8 @@ export function createAccountConnectedAgents(handle: Handle) {
 
 	return {
 		applyPayload,
-		render() {
+		/** `actions` renders under the list (the Connections page puts Add connection there). */
+		render(options?: { actions?: RemixNode }) {
 			const groups = groupConnectedAgents(agents)
 			return (
 				<AccountManagementPanel
@@ -257,6 +259,9 @@ export function createAccountConnectedAgents(handle: Handle) {
 							MCP host.
 						</p>
 					)}
+					{options?.actions ? (
+						<div mix={css(accountActionsCss)}>{options.actions}</div>
+					) : null}
 				</AccountManagementPanel>
 			)
 		},

--- a/packages/worker/client/routes/account-connections.node.test.ts
+++ b/packages/worker/client/routes/account-connections.node.test.ts
@@ -10,6 +10,11 @@ import {
 	accountPackagesNavHref,
 } from '#client/routes/account-management-components.tsx'
 import { type SessionInfo } from '#client/session.ts'
+import {
+	accountConnectionAgentIds,
+	accountConnectionsNewHref,
+	parseAccountConnectionsPathname,
+} from '#universal/account-connections.ts'
 import { type AccountConnectedAgentsLoaderData } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
 
@@ -26,10 +31,11 @@ const session: SessionInfo = {
 
 function renderConnectionsPage(
 	accountConnectedAgents: AccountConnectedAgentsLoaderData,
+	url: string = routes.accountConnections.href(),
 ) {
 	return renderToString(
 		jsx(RouterLocationProvider, {
-			url: routes.accountConnections.href(),
+			url,
 			children: jsx(AppSessionProvider, {
 				session,
 				status: 'ready',
@@ -42,38 +48,155 @@ function renderConnectionsPage(
 	)
 }
 
-test('connections page renders the MCP URL copy card, the connected agents, and the setup guide paths from SSR data', async () => {
-	const html = await renderConnectionsPage({
-		ok: true,
-		mcpServerUrl: 'https://kody.example/mcp',
-		agents: [
-			{
-				clientId: 'cursor-client',
-				grantIds: ['grant-1'],
-				label: 'Cursor',
-				kind: 'cursor',
-				connectedAt: '2026-01-01T00:00:00.000Z',
-			},
-		],
-	})
+const connectedCursor: AccountConnectedAgentsLoaderData = {
+	ok: true,
+	mcpServerUrl: 'https://kody.example/mcp',
+	agents: [
+		{
+			clientId: 'cursor-client',
+			grantIds: ['grant-1'],
+			label: 'Cursor',
+			kind: 'cursor',
+			connectedAt: '2026-01-01T00:00:00.000Z',
+		},
+	],
+}
+
+test('connections page renders the connected list with Add connection, the MCP URL card, and the rail from SSR data', async () => {
+	const html = await renderConnectionsPage(connectedCursor)
 
 	expect(html).toContain('>Connections</h1>')
-	expect(html).toContain('aria-label="Connect an agent"')
-	expect(html).toContain('>https://kody.example/mcp<')
-	expect(html).toContain('Copy MCP URL')
-	expect(html).not.toContain('data-testid="account-connections-verify-note"')
-	expect(html).toMatch(/data-testid="account-connections-setup-guides"[^>]*/)
-	expect(html).toContain(`href="${routes.onboarding.href()}"`)
-	expect(html).toContain('href="/docs/connect-your-agent"')
+	// The connected list is the panel Overview used to host, plus the entry
+	// point to the client wall.
 	expect(html).toContain('aria-label="Connected agents"')
 	expect(html).toContain('data-agent-label="Cursor"')
 	expect(html).toContain('aria-label="Revoke Cursor"')
+	expect(html).toMatch(
+		/data-testid="account-connections-add"[^>]*>Add connection</,
+	)
+	expect(html).toContain(`href="${routes.accountConnectionNew.href()}"`)
+	expect(html).toContain('aria-label="MCP URL"')
+	expect(html).toContain('>https://kody.example/mcp<')
+	expect(html).toContain('Copy MCP URL')
+	expect(html).not.toContain('data-testid="account-connections-verify-note"')
+	expect(html).not.toContain('data-testid="account-connections-agent-grid"')
+	expect(html).toContain('href="/docs/connect-your-agent"')
 	expect(html).toContain(`href="${routes.accountMcpOauthClients.href()}"`)
 	// No cold-path loading copy when the SSR payload is present.
 	expect(html).not.toContain('Loading connections')
 	// The rail marks this page current and links Packages to the profile.
 	expect(html).toMatch(/href="\/account\/connections"[^>]*aria-current="page"/)
 	expect(html).toMatch(/href="\/@jane"[^>]*>Packages<\/a>/)
+})
+
+test('Add connection shows every named client on every viewport with none greyed or folded away', async () => {
+	const html = await renderConnectionsPage(
+		connectedCursor,
+		routes.accountConnectionNew.href(),
+	)
+
+	expect(html).toContain('data-testid="account-connections-agent-grid"')
+	expect(html).toContain('aria-label="Add connection"')
+	// The list stays on screen above the grid; its Add button steps aside.
+	expect(html).toContain('aria-label="Connected agents"')
+	expect(html).not.toContain('data-testid="account-connections-add"')
+	// Every named client is a card, in catalog order; `other` is not a card
+	// because the generic MCP URL path sits under the grid instead.
+	for (const id of accountConnectionAgentIds) {
+		expect(html).toMatch(
+			new RegExp(
+				`href="/account/connections/new/${id}"[^>]*data-testid="onboarding-agent-${id}"`,
+			),
+		)
+	}
+	expect(accountConnectionAgentIds).toHaveLength(14)
+	expect(accountConnectionAgentIds).not.toContain('other')
+	expect(html).not.toContain('data-testid="onboarding-agent-other"')
+	expect(html).not.toContain('data-greyed="true"')
+	// No card is hidden behind the onboarding phone/desktop media query: every
+	// card `<li>` shares one class whose rules never reach `display: none`.
+	const cards = [
+		...html.matchAll(
+			/<li class="(rmxc-[^"]+)"><a href="\/account\/connections\/new\//g,
+		),
+	]
+	expect(cards).toHaveLength(accountConnectionAgentIds.length)
+	const cardClasses = new Set(cards.map((card) => card[1]))
+	expect(cardClasses.size).toBe(1)
+	const [cardClass] = cardClasses
+	const rulesStart = html.indexOf(`@layer rmx.${cardClass}`)
+	expect(rulesStart).toBeGreaterThan(-1)
+	const rules = html.slice(rulesStart, html.indexOf('</style>', rulesStart))
+	expect(rules).toContain('display: list-item')
+	expect(rules).not.toContain('display: none')
+	// The generic MCP URL path stays available under the grid.
+	expect(html).toContain('Using something else?')
+	expect(html).toContain('>https://kody.example/mcp<')
+	// The standalone MCP URL panel is not repeated on this view.
+	expect(html).not.toContain('aria-label="MCP URL"')
+})
+
+test('picking a client shows that host’s install steps with a way back to the grid', async () => {
+	const html = await renderConnectionsPage(
+		connectedCursor,
+		routes.accountConnectionNewAgent.href({ agent: 'claude-code' }),
+	)
+
+	expect(html).toContain('aria-label="Connect Claude Code"')
+	expect(html).toContain('>Connect Claude Code</h2>')
+	expect(html).toMatch(
+		/data-testid="account-connections-agent-instructions"[^>]*data-agent="claude-code"/,
+	)
+	expect(html).toContain('claude mcp add --transport http -s user kody')
+	expect(html).toContain('data-testid="onboarding-authenticate-callout"')
+	expect(html).toMatch(
+		new RegExp(
+			`href="${routes.accountConnectionNew.href()}"[^>]*data-testid="account-connections-change-agent"`,
+		),
+	)
+	expect(html).not.toContain('data-testid="account-connections-agent-grid"')
+	// Connections stays the current rail item on the nested view.
+	expect(html).toMatch(/href="\/account\/connections"[^>]*aria-current="page"/)
+})
+
+test('an unknown agent segment renders the fallback instead of instructions', async () => {
+	const html = await renderConnectionsPage(
+		connectedCursor,
+		'/account/connections/new/not-a-client',
+	)
+	expect(html).toContain('>Unknown agent</h2>')
+	expect(html).not.toContain(
+		'data-testid="account-connections-agent-instructions"',
+	)
+})
+
+test('connections views parse from the pathname', () => {
+	expect(parseAccountConnectionsPathname('/account/connections')).toEqual({
+		kind: 'list',
+	})
+	expect(parseAccountConnectionsPathname('/account/connections/new')).toEqual({
+		kind: 'new',
+		agent: null,
+	})
+	expect(
+		parseAccountConnectionsPathname('/account/connections/new/cursor'),
+	).toEqual({ kind: 'new', agent: 'cursor' })
+	expect(
+		parseAccountConnectionsPathname('/account/connections/new/other'),
+	).toBeNull()
+	expect(
+		parseAccountConnectionsPathname('/account/connections/new/nope'),
+	).toBeNull()
+	expect(
+		parseAccountConnectionsPathname('/account/connections/new/cursor/x'),
+	).toBeNull()
+	expect(
+		parseAccountConnectionsPathname('/account/connections/nope'),
+	).toBeNull()
+	expect(accountConnectionsNewHref(null)).toBe('/account/connections/new')
+	expect(accountConnectionsNewHref('grok-cli')).toBe(
+		'/account/connections/new/grok-cli',
+	)
 })
 
 test('connections page swaps the copy card for a verify note while the email is unverified', async () => {

--- a/packages/worker/client/routes/account-connections.tsx
+++ b/packages/worker/client/routes/account-connections.tsx
@@ -16,14 +16,31 @@ import {
 import { connectedAgentsApiPath } from '#client/routes/account-page-data.ts'
 import { CopyCard } from '#client/routes/onboarding-mcp-client-cards.tsx'
 import {
+	AgentPickerGrid,
+	AgentSurfaceInstructions,
+} from '#client/routes/onboarding-mcp-client-tabs.tsx'
+import {
 	routeLoaderRedirect,
 	type RouteLoaderResult,
 } from '#client/route-loader.ts'
+import {
+	type AccountConnectionsView,
+	accountConnectionAgentIds,
+	accountConnectionsNewHref,
+	parseAccountConnectionsPathname,
+} from '#universal/account-connections.ts'
 import { docHref } from '#universal/docs-nav.ts'
 import { type AccountConnectedAgentsLoaderData } from '#universal/loader-data.ts'
+import {
+	type McpClientKind,
+	onboardingAgentLabel,
+} from '#universal/onboarding-mcp-clients.ts'
 import { routes } from '#universal/routes.ts'
-import { getGhostButtonCss } from '#universal/styles/style-primitives.ts'
-import { colors } from '#universal/styles/tokens.ts'
+import {
+	getGhostButtonCss,
+	getPillButtonCss,
+} from '#universal/styles/style-primitives.ts'
+import { colors, spacing } from '#universal/styles/tokens.ts'
 
 const connectYourAgentDocHref = docHref('connect-your-agent')
 
@@ -52,11 +69,24 @@ export async function accountConnectionsRouteLoader(
 	return { accountConnectedAgents: result.payload }
 }
 
+/** The list, grid, and per-agent views all read one connected-agents payload. */
+function connectionsLatchKey() {
+	return routes.accountConnections.href()
+}
+
+function readView(href: string): AccountConnectionsView | null {
+	return parseAccountConnectionsPathname(
+		new URL(href, 'http://localhost').pathname,
+	)
+}
+
 /**
- * `/account/connections` — the durable home for inbound MCP hosts: the MCP
- * URL to paste into another agent, the per-host setup guides, and the list of
- * agents that already authorized (grouped, per-`clientId` revoke). Sign-in
- * providers stay on Overview; outbound MCP servers stay on MCP servers.
+ * `/account/connections` — the durable home for inbound MCP hosts. The
+ * connected list is the same panel Overview used to host. Add connection
+ * (`/new`) opens the full client wall from onboarding Step 1 with no
+ * phone/desktop split and nothing folded under Not listed, and `/new/:agent`
+ * shows that host's install steps. Sign-in providers stay on Overview;
+ * outbound MCP servers stay on MCP servers.
  */
 export function AccountConnectionsRoute(handle: Handle) {
 	const connectedAgents = createAccountConnectedAgents(handle)
@@ -67,6 +97,7 @@ export function AccountConnectionsRoute(handle: Handle) {
 	let appliedError: Error | null = null
 	const connectionsData = createRouteData({
 		key: 'accountConnectedAgents',
+		locationKey: connectionsLatchKey,
 		async load(_href, signal) {
 			const result = await fetchConnectedAgents(signal)
 			if (result.kind === 'unauthorized') return routeDataRedirect('/login')
@@ -82,6 +113,7 @@ export function AccountConnectionsRoute(handle: Handle) {
 
 	return () => {
 		const currentHref = readCurrentRouterHref(handle)
+		const view = readView(currentHref)
 		const snapshot = connectionsData.read(handle, currentHref)
 		if (snapshot.data && snapshot.data !== appliedPayload) {
 			appliedPayload = snapshot.data
@@ -98,6 +130,8 @@ export function AccountConnectionsRoute(handle: Handle) {
 				: pending && appliedPayload === null
 					? 'loading'
 					: 'ready'
+		const adding = view?.kind === 'new'
+		const selectedAgent = view?.kind === 'new' ? view.agent : null
 
 		return (
 			<AccountManagementShell busy={pending && appliedPayload !== null}>
@@ -120,47 +154,25 @@ export function AccountConnectionsRoute(handle: Handle) {
 
 				{status === 'ready' ? (
 					<>
-						<AccountManagementPanel
-							title="Connect an agent"
-							description="Every host reaches the same account through one MCP URL. Paste it into your agent, or open the setup guides for step-by-step instructions per host. The host will ask you to authorize afterwards."
-							ariaLabel="Connect an agent"
-						>
-							{mcpServerUrl ? (
-								<CopyCard
-									label="MCP URL"
-									value={mcpServerUrl}
-									copyLabel="Copy MCP URL"
-									variant="pill"
-								/>
-							) : (
-								<p
-									data-testid="account-connections-verify-note"
-									mix={css({ color: colors.textMuted, margin: 0 })}
-								>
-									Verify your email to get this deployment&apos;s MCP URL. MCP
-									access stays locked until the account email is verified.{' '}
-									<a href={routes.pendingVerification.href()}>
-										Verification page
-									</a>
-								</p>
-							)}
-							<div mix={css(accountActionsCss)}>
+						{connectedAgents.render({
+							actions: adding ? null : (
 								<a
-									href={routes.onboarding.href()}
-									data-testid="account-connections-setup-guides"
-									mix={css(compactGhostButtonCss)}
+									href={accountConnectionsNewHref(null)}
+									data-testid="account-connections-add"
+									mix={css(primaryButtonCss)}
 								>
-									Setup guides by agent
+									Add connection
 								</a>
-								<a
-									href={connectYourAgentDocHref}
-									mix={css(compactGhostButtonCss)}
-								>
-									Connect your agent docs
-								</a>
-							</div>
-						</AccountManagementPanel>
-						{connectedAgents.render()}
+							),
+						})}
+						{view === null ? renderUnknownAgent() : null}
+						{adding && selectedAgent === null
+							? renderAgentGrid({ mcpServerUrl })
+							: null}
+						{selectedAgent
+							? renderAgentInstructions({ agent: selectedAgent, mcpServerUrl })
+							: null}
+						{!adding ? renderMcpUrlPanel({ mcpServerUrl }) : null}
 						<AccountManagementPanel
 							title="Advanced"
 							description="Optional tools for hosts that cannot finish dynamic OAuth on their own. This is not the list of agents already connected to your account."
@@ -181,4 +193,147 @@ export function AccountConnectionsRoute(handle: Handle) {
 	}
 }
 
+function renderVerifyNote() {
+	return (
+		<p
+			data-testid="account-connections-verify-note"
+			mix={css({ color: colors.textMuted, margin: 0 })}
+		>
+			Verify your email to get this deployment&apos;s MCP URL. MCP access stays
+			locked until the account email is verified.{' '}
+			<a href={routes.pendingVerification.href()}>Verification page</a>
+		</p>
+	)
+}
+
+function renderMcpUrlPanel(input: { mcpServerUrl: string }) {
+	return (
+		<AccountManagementPanel
+			title="MCP URL"
+			description="Every host reaches the same account through one MCP URL. Add connection walks through a specific agent; any other agent that speaks MCP can paste this URL and approve the Kody OAuth window."
+			ariaLabel="MCP URL"
+		>
+			{input.mcpServerUrl ? (
+				<CopyCard
+					label="MCP URL"
+					value={input.mcpServerUrl}
+					copyLabel="Copy MCP URL"
+					variant="pill"
+				/>
+			) : (
+				renderVerifyNote()
+			)}
+			<div mix={css(accountActionsCss)}>
+				<a href={connectYourAgentDocHref} mix={css(compactGhostButtonCss)}>
+					Connect your agent docs
+				</a>
+			</div>
+		</AccountManagementPanel>
+	)
+}
+
+function renderAgentGrid(input: { mcpServerUrl: string }) {
+	return (
+		<AccountManagementPanel
+			title="Add connection"
+			description="Pick the agent you want to connect. Every agent Kody knows how to connect is listed here, on every device; the next step shows that host's install path."
+			ariaLabel="Add connection"
+		>
+			{input.mcpServerUrl ? (
+				<div
+					data-testid="account-connections-agent-grid"
+					mix={css({ display: 'grid', gap: spacing.lg })}
+				>
+					<span class="visually-hidden" id="account-connections-add-title">
+						Agents you can connect
+					</span>
+					<AgentPickerGrid
+						ids={accountConnectionAgentIds.map((id) => ({
+							id,
+							viewport: 'both' as const,
+						}))}
+						labelledBy="account-connections-add-title"
+						agentHref={(agent) => accountConnectionsNewHref(agent)}
+					/>
+					<div mix={css({ display: 'grid', gap: spacing.sm })}>
+						<p mix={css({ color: colors.textMuted, margin: 0 })}>
+							Using something else? Any agent that speaks MCP connects with this
+							URL. Approve the Kody OAuth window when the host opens it.
+						</p>
+						<CopyCard
+							label="MCP URL"
+							value={input.mcpServerUrl}
+							copyLabel="Copy MCP URL"
+						/>
+					</div>
+				</div>
+			) : (
+				renderVerifyNote()
+			)}
+		</AccountManagementPanel>
+	)
+}
+
+function renderAgentInstructions(input: {
+	agent: McpClientKind
+	mcpServerUrl: string
+}) {
+	const label = onboardingAgentLabel(input.agent)
+	return (
+		<AccountManagementPanel
+			title={`Connect ${label}`}
+			description="Follow the steps for this host, then approve the Kody OAuth window when it opens. The new connection appears in the list above once the host authorizes."
+			ariaLabel={`Connect ${label}`}
+		>
+			<div mix={css(accountActionsCss)}>
+				<a
+					href={accountConnectionsNewHref(null)}
+					data-testid="account-connections-change-agent"
+					mix={css(compactGhostButtonCss)}
+				>
+					Change agent
+				</a>
+			</div>
+			{input.mcpServerUrl ? (
+				<div
+					data-testid="account-connections-agent-instructions"
+					data-agent={input.agent}
+					mix={css({ display: 'grid', gap: spacing.lg })}
+				>
+					<AgentSurfaceInstructions
+						agent={input.agent}
+						mcpServerUrl={input.mcpServerUrl}
+					/>
+				</div>
+			) : (
+				renderVerifyNote()
+			)}
+		</AccountManagementPanel>
+	)
+}
+
+function renderUnknownAgent() {
+	return (
+		<AccountManagementPanel
+			title="Unknown agent"
+			description="That agent is not one Kody knows how to connect. Pick one from the list, or use the MCP URL with any host that speaks MCP."
+		>
+			<div mix={css(accountActionsCss)}>
+				<a
+					href={accountConnectionsNewHref(null)}
+					mix={css(compactGhostButtonCss)}
+				>
+					Choose an agent
+				</a>
+			</div>
+		</AccountManagementPanel>
+	)
+}
+
 const compactGhostButtonCss = getGhostButtonCss({ size: 'sm' })
+
+const primaryButtonCss = {
+	...getPillButtonCss({ size: 'sm' }),
+	textDecoration: 'none',
+	width: 'fit-content',
+}

--- a/packages/worker/client/routes/entity-explainer.tsx
+++ b/packages/worker/client/routes/entity-explainer.tsx
@@ -113,7 +113,7 @@ const entityExplainerDefinitions: Array<EntityExplainerDefinition> = [
 		match: accountSection(routes.accountConnections.href()),
 		paragraphs: [
 			'A connection is an AI host — Cursor, Claude, ChatGPT, Codex, a CLI — that has authorized against this Kody account over MCP. Every connected host reaches the same memories, secrets, packages, jobs, and email; Kody is the home they share, not a gateway.',
-			'Copy the MCP URL here to connect another host, open the per-host setup guides, and revoke a host you no longer use. Sign-in providers such as GitHub and Google stay on Overview. Remote MCP servers Kody calls on your behalf live on MCP servers.',
+			'Add connection lists every agent Kody knows how to connect and shows that host’s install steps; the MCP URL works for any other host that speaks MCP. Revoke a host you no longer use from the connected list. Sign-in providers such as GitHub and Google stay on Overview. Remote MCP servers Kody calls on your behalf live on MCP servers.',
 		],
 		learnMore: [
 			{

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -51,6 +51,14 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		accountArea,
 		(m) => m.accountConnectionsRouteLoader,
 	),
+	[routePattern(routes.accountConnectionNew)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountConnectionsRouteLoader,
+	),
+	[routePattern(routes.accountConnectionNewAgent)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountConnectionsRouteLoader,
+	),
 	[routePattern(routes.accountShared)]: lazyRouteLoader(
 		accountArea,
 		(m) => m.accountSharedRouteLoader,
@@ -380,6 +388,12 @@ export const clientRoutes = {
 		<LazyAccountRoute render={(m) => <m.AccountWaitingRoute />} />
 	),
 	[routePattern(routes.accountConnections)]: (
+		<LazyAccountRoute render={(m) => <m.AccountConnectionsRoute />} />
+	),
+	[routePattern(routes.accountConnectionNew)]: (
+		<LazyAccountRoute render={(m) => <m.AccountConnectionsRoute />} />
+	),
+	[routePattern(routes.accountConnectionNewAgent)]: (
 		<LazyAccountRoute render={(m) => <m.AccountConnectionsRoute />} />
 	),
 	[routePattern(routes.accountShared)]: (

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -418,7 +418,13 @@ export function OnboardingMcpClientTabs(
 	}
 }
 
-function AgentSurfaceInstructions(
+/**
+ * One host's install path: desktop and phone surfaces both render and CSS
+ * shows the one that matches the viewport, followed by the help link, any
+ * host caveat, and the authenticate callout. Shared with Add connection on
+ * `/account/connections`.
+ */
+export function AgentSurfaceInstructions(
 	handle: Handle<{
 		agent: McpClientKind
 		mcpServerUrl: string
@@ -463,20 +469,26 @@ function AgentSurfaceInstructions(
 	)
 }
 
-function AgentPickerGrid(
+/**
+ * The client wall. Entries given as bare ids follow the onboarding
+ * viewport split (desktop-only hosts hide on a phone); pass
+ * `{ id, viewport: 'both' }` entries to show every card everywhere, which
+ * is what Add connection on `/account/connections` does.
+ */
+export function AgentPickerGrid(
 	handle: Handle<{
 		ids:
 			| Array<McpClientKind>
 			| Array<{ id: McpClientKind; viewport: OnboardingAgentViewport }>
 		labelledBy: string
-		search: string
+		search?: string
 		agentHref: (agent: McpClientKind | null, search?: string) => string
-		greyedAgents: ReadonlyArray<McpClientKind>
-		greyedReasons: Partial<
+		greyedAgents?: ReadonlyArray<McpClientKind>
+		greyedReasons?: Partial<
 			Record<McpClientKind, OnboardingSecondAgentDisableReason>
 		>
-		greyedTitles: Partial<Record<McpClientKind, string>>
-		greyedReason: string | null
+		greyedTitles?: Partial<Record<McpClientKind, string>>
+		greyedReason?: string | null
 	}>,
 ) {
 	return () => (
@@ -488,9 +500,13 @@ function AgentPickerGrid(
 						? onboardingAgentViewport(id)
 						: entry.viewport
 				const shown = viewport === 'none' ? 'both' : viewport
-				const greyed = handle.props.greyedAgents.includes(id)
-				const reason = handle.props.greyedReasons[id] ?? 'same-ecosystem'
-				const title = handle.props.greyedTitles[id] ?? handle.props.greyedReason
+				const greyedAgents = handle.props.greyedAgents ?? []
+				const greyedReasons = handle.props.greyedReasons ?? {}
+				const greyedTitles = handle.props.greyedTitles ?? {}
+				const search = handle.props.search ?? ''
+				const greyed = greyedAgents.includes(id)
+				const reason = greyedReasons[id] ?? 'same-ecosystem'
+				const title = greyedTitles[id] ?? handle.props.greyedReason ?? null
 				return (
 					<li key={id} mix={css(onboardingViewportCss(shown, 'list-item'))}>
 						{greyed ? (
@@ -512,7 +528,7 @@ function AgentPickerGrid(
 							</span>
 						) : (
 							<a
-								href={handle.props.agentHref(id, handle.props.search)}
+								href={handle.props.agentHref(id, search)}
 								data-testid={`onboarding-agent-${id}`}
 								data-prevent-scroll-reset=""
 								mix={css(pickerCardCss)}

--- a/packages/worker/src/app/handlers/account-connected-agents.ts
+++ b/packages/worker/src/app/handlers/account-connected-agents.ts
@@ -21,6 +21,7 @@ import {
 	type OAuthGrantListHelpers,
 } from '#worker/oauth-grants.ts'
 import { buildMcpServerUrl } from '#worker/onboarding-prompts.ts'
+import { parseAccountConnectionsPathname } from '#universal/account-connections.ts'
 import { type AccountConnectedAgentsLoaderData } from '#universal/loader-data.ts'
 import { type routes } from '#universal/routes.ts'
 
@@ -57,6 +58,11 @@ export async function loadAccountConnectedAgentsData(input: {
 	}
 }
 
+/**
+ * `/account/connections`, `/account/connections/new`, and
+ * `/account/connections/new/:agent` share one payload; the client renders
+ * the view from the pathname. An unknown agent segment is a 404 page.
+ */
 export function createAccountConnectionsHandler(env: Env) {
 	return {
 		middleware: [],
@@ -66,19 +72,37 @@ export function createAccountConnectionsHandler(env: Env) {
 				return user
 			}
 
+			const view = parseAccountConnectionsPathname(
+				new URL(request.url).pathname,
+			)
+			if (!view) {
+				return renderAppPage({
+					request,
+					env,
+					title: 'Connection not found',
+					notFound: true,
+					status: 404,
+				})
+			}
+
 			const accountConnectedAgents = await loadAccountConnectedAgentsData({
 				env,
 				requestUrl: request.url,
 				user,
 			})
+			// Titles come from the document-head registry so SPA navigation
+			// between the list, grid, and per-agent views agrees with SSR.
 			return renderAppPage({
 				request,
 				env,
-				title: 'Connections',
 				loaderData: { accountConnectedAgents },
 			})
 		},
-	} satisfies Action<typeof routes.accountConnections>
+	} satisfies Action<
+		| typeof routes.accountConnections
+		| typeof routes.accountConnectionNew
+		| typeof routes.accountConnectionNewAgent
+	>
 }
 
 export function createAccountConnectedAgentsApiHandler(env: Env) {

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -411,6 +411,8 @@ export function createAppRouter(env: Env) {
 			accountPackagesApi: createAccountPackagesApiHandler(env),
 			accountPackagesApiPost: createAccountPackagesApiHandler(env),
 			accountConnections: createAccountConnectionsHandler(env),
+			accountConnectionNew: createAccountConnectionsHandler(env),
+			accountConnectionNewAgent: createAccountConnectionsHandler(env),
 			accountConnectionsApi: createAccountConnectionsApiHandler(env),
 			accountConnectionsApiPost: createAccountConnectionsApiHandler(env),
 			accountConnectedAgentsApi: createAccountConnectedAgentsApiHandler(env),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -529,7 +529,7 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		/href="\/account\/connections"[^>]*aria-current="page"/,
 	)
 	expect(connectionsHtml).toContain('aria-label="Connected agents"')
-	expect(connectionsHtml).toContain('aria-label="Connect an agent"')
+	expect(connectionsHtml).toContain('aria-label="MCP URL"')
 	expect(connectionsHtml).toContain(
 		'data-testid="account-connections-verify-note"',
 	)
@@ -542,6 +542,30 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		agents: [],
 		mcpServerUrl: '',
 	})
+	expect(connectionsHtml).toContain('data-testid="account-connections-add"')
+
+	// Add connection and the per-agent step share the handler and payload;
+	// an unknown agent segment is a 404 page, not an empty grid.
+	const addConnectionResponse = await runHtmlHandler(
+		createAccountConnectionsHandler(env),
+		new Request('https://example.com/account/connections/new/cursor', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(addConnectionResponse.status).toBe(200)
+	const addConnectionHtml = await readResponseText(addConnectionResponse)
+	expect(addConnectionHtml).toContain('<title>Connect Cursor')
+	expect(addConnectionHtml).toContain('aria-label="Connect Cursor"')
+	expect(addConnectionHtml).toMatch(
+		/href="\/account\/connections"[^>]*aria-current="page"/,
+	)
+	const unknownAgentResponse = await runHtmlHandler(
+		createAccountConnectionsHandler(env),
+		new Request('https://example.com/account/connections/new/not-a-client', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(unknownAgentResponse.status).toBe(404)
 
 	const mcpOauthClientsResponse = await runHtmlHandler(
 		createAccountMcpOauthClientsHandler(env),

--- a/packages/worker/universal/account-connections.ts
+++ b/packages/worker/universal/account-connections.ts
@@ -1,0 +1,62 @@
+/**
+ * `/account/connections` views. The page is one payload
+ * (`/account/connected-agents.json`) rendered three ways: the connected
+ * list, the full client grid (Add connection), and one host's install steps.
+ */
+
+import {
+	type McpClientKind,
+	isMcpClientKind,
+	mcpClientTabs,
+} from '#universal/onboarding-mcp-clients.ts'
+import { routes } from '#universal/routes.ts'
+
+export type AccountConnectionsView =
+	| { kind: 'list' }
+	| { kind: 'new'; agent: McpClientKind | null }
+
+/**
+ * Every named client, in catalog order, with no viewport split and nothing
+ * folded under Not listed: the account page is where someone adds a second
+ * or third host, so the phone-vs-desktop guess onboarding makes does not
+ * apply. The generic MCP URL path is rendered below the grid instead of as
+ * an `other` card.
+ */
+export const accountConnectionAgentIds: ReadonlyArray<McpClientKind> =
+	mcpClientTabs.map((tab) => tab.id).filter((id) => id !== 'other')
+
+export function isAccountConnectionAgent(
+	value: string | null | undefined,
+): value is McpClientKind {
+	return isMcpClientKind(value) && value !== 'other'
+}
+
+export function accountConnectionsNewHref(agent: McpClientKind | null) {
+	if (!agent) return routes.accountConnectionNew.href()
+	return routes.accountConnectionNewAgent.href({ agent })
+}
+
+/** `null` when the pathname is under the page but names an unknown agent. */
+export function parseAccountConnectionsPathname(
+	pathname: string,
+): AccountConnectionsView | null {
+	const base = routes.accountConnections.href()
+	if (pathname === base || pathname === `${base}/`) return { kind: 'list' }
+	const newBase = routes.accountConnectionNew.href()
+	if (pathname === newBase || pathname === `${newBase}/`) {
+		return { kind: 'new', agent: null }
+	}
+	const prefix = `${newBase}/`
+	if (!pathname.startsWith(prefix)) return null
+	const segment = pathname.slice(prefix.length).replace(/\/$/u, '')
+	if (!segment || segment.includes('/')) return null
+	let decoded: string
+	try {
+		decoded = decodeURIComponent(segment)
+	} catch {
+		return null
+	}
+	return isAccountConnectionAgent(decoded)
+		? { kind: 'new', agent: decoded }
+		: null
+}

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -1,5 +1,7 @@
 import { createMultiMatcher } from 'remix/route-pattern/match'
+import { isAccountConnectionAgent } from '#universal/account-connections.ts'
 import { type AppLoaderData } from '#universal/loader-data.ts'
+import { onboardingAgentLabel } from '#universal/onboarding-mcp-clients.ts'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { routePattern } from '#universal/route-pattern.ts'
 import { routes } from '#universal/routes.ts'
@@ -179,6 +181,15 @@ const routeDocumentHeads = {
 	[routePattern(routes.accountUsage)]: titleOnly('Usage'),
 	[routePattern(routes.accountWaiting)]: titleOnly('Waiting'),
 	[routePattern(routes.accountConnections)]: titleOnly('Connections'),
+	[routePattern(routes.accountConnectionNew)]: titleOnly('Add connection'),
+	[routePattern(routes.accountConnectionNewAgent)]: ({ params }) => {
+		const agent = params.agent
+		return titleOnly(
+			isAccountConnectionAgent(agent)
+				? `Connect ${onboardingAgentLabel(agent)}`
+				: 'Add connection',
+		)
+	},
 	[routePattern(routes.accountShared)]: titleOnly('Shared packages'),
 	[routePattern(routes.accountIntegrations)]: titleOnly('Integrations'),
 	[routePattern(routes.accountOauthAppDetail)]: titleOnly('Integrations'),

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -90,6 +90,9 @@ export const routes = route({
 	// `/account/connected-agents.json`; `/account/connections.json` is the
 	// older sign-in provider (GitHub, Google, …) list on the Overview page.
 	accountConnections: '/account/connections',
+	// Add connection: the full client grid, then one host's install steps.
+	accountConnectionNew: '/account/connections/new',
+	accountConnectionNewAgent: '/account/connections/new/:agent',
 	accountConnectionsApi: '/account/connections.json',
 	accountConnectionsApiPost: post('/account/connections.json'),
 	accountConnectedAgentsApi: '/account/connected-agents.json',

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -106,7 +106,11 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 		id: 'connections',
 		title: 'Connections (connected agents)',
 		file: 'connections.md',
-		paths: ['/account/connections'],
+		paths: [
+			'/account/connections',
+			'/account/connections/new',
+			'/account/connections/new/:agent',
+		],
 		apis: ['/account/connected-agents.json'],
 	},
 	{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Finish the Connections page to Kent's design clarification: the connected list stays the panel Overview used to host, and an **Add connection** button opens the full client wall from onboarding Step 1 — every client, on every device, none greyed or folded under Not listed — then that host's install steps. Follow-up to #2255 (already merged, so this lands as its own PR).

## Why

#2255 gave `/account/connections` a home for connected agents but only linked out to `/onboarding` for adding one. Kent's clarification (from Tim Krase's feedback) asks for the add path to live on the page itself, with the whole grid visible rather than onboarding's phone/desktop split and "Not listed" fold.

## Summary

- **Add connection** button in the Connected agents panel → `/account/connections/new`.
  - `/account/connections/new` renders the onboarding `AgentPickerGrid` with every named client (14 cards, catalog order) as `viewport: 'both'`, so no card hides on a phone or desktop and none is greyed. The generic MCP URL copy card sits under the grid for any other MCP host, so there is no `other` / "Not listed" card.
  - `/account/connections/new/:agent` renders that host's `AgentSurfaceInstructions` (install path, help link, caveats, authenticate callout) under a "Connect {label}" heading with a **Change agent** link back to the grid. Unknown agents 404 on SSR and render an inline fallback on SPA navigation.
  - All three views share one payload (`/account/connected-agents.json`) via `locationKey`, keep Connections current in the rail, and titles come from the document-head registry (`Connections` / `Add connection` / `Connect Cursor`).
- The list view keeps the Connected agents panel (moved from Overview in #2255), the MCP URL panel, and the Advanced MCP OAuth clients link; the "Setup guides by agent" link to onboarding is gone since the grid is now on the page.
- `AgentPickerGrid` and `AgentSurfaceInstructions` are exported from `onboarding-mcp-client-tabs.tsx`; the greyed props became optional. Onboarding behavior is unchanged (its tests still pass).
- `#universal/account-connections.ts`: `accountConnectionAgentIds`, `accountConnectionsNewHref`, `parseAccountConnectionsPathname`.
- Feature Map paths, `connections.md`, `docs/use/connect-your-agent.md`, and the explainer copy updated. Overview already only links to Connections; the rail already carries Connections and Packages (from #2255).

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format`; `control-kody map --check`.
- Node: `account-connections.node.test.ts` — list view (Add connection button, MCP URL panel), grid view (all 14 ids linked, no `other`, no `data-greyed`, one shared `<li>` class with no `display: none`, generic MCP URL under the grid, MCP URL panel not duplicated), agent view (Connect Claude Code, `claude mcp add` snippet, authenticate callout, Change agent), unknown agent fallback, pathname parsing; `ssr-render.node.test.ts` — `/new/cursor` 200 with `<title>Connect Cursor`, unknown agent 404; onboarding tabs/panels tests unchanged.
- E2E `account-navigation.spec.ts`: new test clicks Add connection (single-commit transition, no duplicate fetch), asserts 14 ungreyed cards, picks Claude Code, checks the rail stays current, Change agent returns to the grid. Playwright 17/17 locally.
- `npm run validate`: 23/24 jobs green locally; the e2e job failed only because its miniflare web server could not start beside the running dev server (`Parent environment not initialized`), and passed 17/17 once run alone. CI runs the same gate and is green.
- Dev-server browser pass as `jane@example.com`: list → Add connection → 14-card grid → Claude Code steps → Change agent → Grok.com → Back → keyboard Tab/Enter to Add connection and the Cursor card.
- Preview `kody-pr-2260` as the seeded `me@kentcdodds.com` (`control-kody preview --pr 2260`): `connected-agents.json` → preview MCP URL; `/account/connections`, `/new`, `/new/claude-code` 200; `/new/not-a-client` 404; UI pass: grid of 14, Codex steps with `codex mcp add kody --url …`, Change agent, rail back to Connections.
- Reviews: Bugbot no issues. CodeRabbit's one suggestion (assert zero JSON requests per hop) is not applied: the router runs the destination loader once per navigation by design (same as the existing account-nav spec), so the contract asserted is "no second fetch of the same payload"; the test comment now says so.

![Add connection grid on the PR preview](https://cursor.com/artifacts/c/art-b898c882-7fd8-4f17-80b4-7bbdd0177719)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends an existing primitive</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `f610e6ae` · **Head:** `f0333a7e`

**Classification:** extends — `app-ui` gains two routes under `/account/connections` and reuses the onboarding picker/instructions components on the account shell. No primitive added; `primitives.yaml` unchanged.

### Primitives touched

| Primitive | Group    | Impact                                                                                                                      |
| --------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
| `app-ui`  | surfaces | extends — `/account/connections/new` and `/new/:agent` HTML + client routes, shared `AgentPickerGrid` / `AgentSurfaceInstructions` |

Unmatched paths are the Feature Map (`tools/control-kody`, `.agents/skills/control-kody/references/features`), `docs/use`, and the e2e spec.

### Change flow

Adding a connection stays inside the account shell: one payload, three views, and the host's own steps end in the OAuth authorize the existing mcp-oauth primitive already handles.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant appSessions as app-sessions
	participant mcpOauth as mcp-oauth
	User->>appUi: click Add connection on /account/connections
	appUi->>appSessions: requireAuthenticatedPageUser (shared handler for list, new, new/:agent)
	appUi->>mcpOauth: listUserGrants + lookupClient (unchanged connected list)
	appUi-->>User: /account/connections/new renders AgentPickerGrid, every card viewport both, none greyed
	User->>appUi: pick a card (e.g. claude-code)
	Note over appUi: parseAccountConnectionsPathname validates the agent, unknown is 404
	appUi-->>User: /new/:agent renders AgentSurfaceInstructions and Change agent
	User->>mcpOauth: host runs the install path and opens the Kody authorize window
	mcpOauth-->>appUi: new grant shows in Connected agents on the next load
```

### Before / after

| Surface                                | Before (#2255)                                        | After                                                                         |
| -------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------- |
| `/account/connections`                 | Connect an agent (MCP URL + link to `/onboarding`), Connected agents, Advanced | Connected agents + **Add connection**, MCP URL, Advanced |
| `/account/connections/new`             | —                                                     | Full 14-client grid (no viewport split, none greyed) + generic MCP URL         |
| `/account/connections/new/:agent`      | —                                                     | "Connect {label}" install steps, Change agent; unknown agent 404               |
| `onboarding-mcp-client-tabs.tsx`       | grid/instructions internal                            | `AgentPickerGrid` / `AgentSurfaceInstructions` exported, greyed props optional |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b7ccc30-e6d1-4088-bb8a-f1aeb21931f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b7ccc30-e6d1-4088-bb8a-f1aeb21931f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Add connection flow from Account → Connections.
  * Browse supported agents and view host-specific installation instructions.
  * Added MCP URL access with copy and connection management options.
  * Unrecognized agent links now display a not-found page.
  * Unverified accounts receive verification guidance before connecting.

* **Documentation**
  * Updated connection guidance for the account-based workflow and supported MCP hosts.

* **Tests**
  * Added coverage for navigation, agent selection, installation views, URL handling, and verification states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->