### PR TITLE
Add /account/webhooks: owner UI to mint, reveal, copy, rotate, and disable webhook URLs

### DIFF
--- a/.agents/skills/control-kody/references/features/README.md
+++ b/.agents/skills/control-kody/references/features/README.md
@@ -35,6 +35,7 @@ Then drive the surface with `login`, `request`, `preview`, and `health`. See the
 - [mcp-servers](./mcp-servers.md) — `/account/mcp-servers`
 - [jobs](./jobs.md) — `/account/jobs`
 - [workflows](./workflows.md) — `/account/workflows`
+- [webhooks](./webhooks.md) — `/account/webhooks`
 - [activity](./activity.md) — `/account/activity`
 - [waiting](./waiting.md) — `/account/waiting`
 - [memories](./memories.md) — `/account/memories`

--- a/.agents/skills/control-kody/references/features/webhooks.md
+++ b/.agents/skills/control-kody/references/features/webhooks.md
@@ -1,0 +1,40 @@
+# Webhooks
+
+Owner-only home for inbound webhook URLs: every webhook a saved package declares
+(`package.json#kody.webhooks`) joined with its minted state. Mint, reveal +
+copy, rotate, disable, and enable happen here; MCP never returns the credential
+URL.
+
+## How to get there
+
+`/account/webhooks` (account rail → Webhooks) →
+`/account/webhooks/:packageKodyId/:webhookName` expands one row.
+
+## Drive it
+
+```bash
+node tools/control-kody.ts login
+node tools/control-kody.ts request GET /account/webhooks.json
+node tools/control-kody.ts request POST /account/webhooks.json \
+  --json '{"intent":"mint","packageKodyId":"<kodyId>","webhookName":"<name>"}'
+```
+
+## APIs
+
+- `GET /account/webhooks.json` — `{ ok, username, webhooks[] }`; no URL, no
+  secret. `urlRecoverable` is false for mints that predate encrypted storage.
+- `POST /account/webhooks.json` —
+  `{ intent: 'mint' | 'rotate' | 'reveal' | 'enable' | 'disable', packageKodyId, webhookName }`.
+  `mint`, `rotate`, and `reveal` add `revealed: { id, handle, url }`; the URL
+  origin follows the request so previews show their own host.
+
+## Gotchas
+
+- Seed users own no packages, so the list is empty until a saved package
+  declares a webhook. Publish one with `kody.webhooks` first (the MCP
+  `webhookList` capability sees the same rows).
+- `mint` on an already-minted webhook is a 400 (“Rotate it”); the UI only shows
+  Mint for unminted rows. Rotate and Disable are double-check buttons.
+- `reveal` on a legacy mint without `url_secret_encrypted` is a 400; the page
+  offers Rotate instead.
+- Every intent writes an `account` audit event (`webhook_url_reveal`, …).

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -391,6 +391,11 @@ primitives:
       - packages/worker/src/webhooks/
       - packages/worker/src/mcp/capabilities/webhooks/
       - packages/worker/src/app/handlers/webhook-ingress.ts
+      - packages/worker/src/app/handlers/account-webhooks.ts
+      - packages/worker/src/app/account-webhooks-data.ts
+      - packages/worker/client/routes/account-webhooks.tsx
+      - packages/worker/client/routes/account-webhooks-detail.tsx
+      - packages/worker/client/routes/account-webhooks-shared.ts
       - packages/worker/src/package-registry/
     docs:
       - docs/use/webhooks.md

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -137,9 +137,28 @@ consumer's 15-minute wall-clock limit before later messages are acknowledged.
   Delivery history lives in run records and is covered with the rest of `RunLog`
   export/deletion. Export redacts `url_secret_hash` and `url_secret_encrypted`.
 - Plaintext URL secrets and verification secrets are never logged. URL secrets
-  are hashed for ingress and stored encrypted for `webhookUrlApply`. MCP mint,
-  rotate, list, and apply never return the credential URL. Verification secrets
-  stay in the secrets primitive.
+  are hashed for ingress and stored encrypted for `webhookUrlApply` and the
+  owner reveal on `/account/webhooks`. MCP mint, rotate, list, and apply never
+  return the credential URL. Verification secrets stay in the secrets primitive.
+
+## Owner UI
+
+`/account/webhooks` (`packages/worker/client/routes/account-webhooks.tsx`,
+handlers in `packages/worker/src/app/handlers/account-webhooks.ts`) is the
+signed-in owner's surface for minted URLs. `GET /account/webhooks.json` returns
+`listWebhooksForUser` joined with `urlRecoverable` and never the URL. `POST`
+intents `mint`, `rotate`, and `reveal` return the refreshed list plus a
+`revealed` entry built by `revealWebhookUrlForWebsite` (decrypt
+`url_secret_encrypted`, rebuild the ingress path from the request origin);
+`enable` / `disable` return the list only. Every intent writes an `account`
+audit event (`webhook_url_mint`, `webhook_url_rotate`, `webhook_url_reveal`,
+`webhook_enable`, `webhook_disable`). `mint` refuses an already-minted webhook
+so a stray click cannot rotate a provider's URL; `reveal` refuses mints without
+`url_secret_encrypted` and points at Rotate. The client keeps revealed URLs in
+memory only and drops them on row navigation or Hide.
+
+`revealWebhookUrlForWebsite` is website-only: no MCP capability, execute
+binding, or apply result may return the credential URL.
 
 ## Storage
 

--- a/docs/guides/triggers.md
+++ b/docs/guides/triggers.md
@@ -106,7 +106,9 @@ request to the package export that owns it.
 2. Store the signing secret with `secretSet` under that name.
 3. Mint a handle with `webhookUrlMint` (returns a `handle`, not the credential)
    and register it with `webhookUrlApply`. Treat the URL as a credential; tool
-   output never includes it.
+   output never includes it. For a provider apply does not cover, the owner
+   copies the URL from `/account/webhooks` (account rail → Webhooks), where they
+   can also reveal, rotate, disable, or enable it.
 
 Declaring a webhook does not open ingress; minting does. Deliveries are
 rate-limited per webhook (default 60 per minute, at most 600), and body-only

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -3,8 +3,9 @@
 Kody inbound webhooks are **package-centered**: you declare them in
 `package.json#kody.webhooks`, mint an opaque handle with `webhookUrlMint`, then
 register the credential with `webhookUrlApply` (GitHub repository hooks today)
-or configure another provider through a website-only path. MCP and execute never
-return the credential URL or `url_secret`. Each delivery invokes the bound
+or copy the URL yourself from the
+[Webhooks](#manage-webhook-urls-in-the-account-ui) account page. MCP and execute
+never return the credential URL or `url_secret`. Each delivery invokes the bound
 package export.
 
 This is the HTTP sibling of [email primitives](./email-primitives.md). Webhooks
@@ -17,8 +18,10 @@ There is no `*` / multi-export URL. One declared webhook name binds one export.
 
 Treat every minted URL as a **credential**. Mint and rotate return an opaque
 `handle` (and `url_host`), never the URL or `url_secret`. Register the URL with
-`webhookUrlApply` so the credential stays inside Kody. MCP and execute never
-return the URL.
+`webhookUrlApply` so the credential stays inside Kody, or open
+[`/account/webhooks`](#manage-webhook-urls-in-the-account-ui) and copy it
+yourself for providers without an apply adapter. MCP and execute never return
+the URL; the owner does that from the account UI.
 
 ## Declare a webhook in the package manifest
 
@@ -84,7 +87,9 @@ Use the MCP `webhooks` domain:
    name is not known) and `webhookName`.
 4. Call `webhookUrlApply` with the returned `handle` and a first-class
    destination. GitHub repository hooks use the connected `github` integration
-   (or a host-approved GitHub token).
+   (or a host-approved GitHub token). For any other provider, tell the owner to
+   copy the URL from
+   [`/account/webhooks`](#manage-webhook-urls-in-the-account-ui).
 
 Other capabilities: `webhookList` (declarations joined with minted handle /
 enabled state), `webhookUrlRotate`, `webhookEnable`, `webhookDisable`, and
@@ -92,6 +97,27 @@ enabled state), `webhookUrlRotate`, `webhookEnable`, `webhookDisable`, and
 delivery history also appears under [Activity](./activity.md)
 (`/account/activity` and the `runs` capabilities). List, mint, rotate, and apply
 never return the credential URL.
+
+## Manage webhook URLs in the account UI
+
+The signed-in owner manages webhook URLs at `/account/webhooks` (account rail →
+Webhooks). It lists every webhook declared by a saved package, joined with its
+minted state, and expands one row at a time:
+
+- **Mint URL** issues the first credential for a declared webhook and shows the
+  URL once so you can paste it into the provider.
+- **Reveal URL** shows a minted URL again, with a copy button. Each reveal is
+  written to the account audit log.
+- **Rotate URL** replaces the secret. The previous URL stops working
+  immediately; rerun `webhookUrlApply` (same handle) or paste the new URL into
+  the provider.
+- **Disable** / **Enable** toggle ingress without deleting the mint. Disabled
+  webhooks answer 404.
+
+The URL is the human path. Agents get the handle and `url_host` through MCP and
+either apply the handle to a supported destination or ask the owner to copy the
+URL here. Mints that predate encrypted secret storage cannot be shown; the page
+offers Rotate for those.
 
 ### Apply a handle to a destination
 
@@ -118,7 +144,8 @@ await kody.webhooks.webhookUrlApply({
 Authorize with the user's GitHub OAuth integration (default `github`) or a
 host-approved GitHub token (`secretName`). Additional vendor adapters can follow
 the same pattern (known host + known API). Other providers still POST to the
-minted ingress URL; apply does not register them.
+minted ingress URL; apply does not register them — the owner copies the URL from
+`/account/webhooks` instead.
 
 Returns `{ ok, url_host, http_status, remote_id, error }`. Remote bodies that
 echo the hook URL are stripped.
@@ -299,7 +326,8 @@ Republishing a package that removes or renames a webhook deactivates that
 ingress (unknown name → 404). Disable with `webhookDisable` without deleting the
 mint; re-enable with `webhookEnable`. Rotate the URL secret with
 `webhookUrlRotate` when a credential may have leaked, then call
-`webhookUrlApply` again with the same handle so providers get the new URL.
+`webhookUrlApply` again with the same handle so providers get the new URL. The
+same disable, enable, and rotate actions are on `/account/webhooks`.
 
 ## Related
 

--- a/e2e/account-navigation.spec.ts
+++ b/e2e/account-navigation.spec.ts
@@ -74,6 +74,7 @@ test('account section switches keep the current page on screen (no loading flash
 			{ link: 'Secrets', heading: 'Secrets' },
 			{ link: 'Connections', heading: 'Connections' },
 			{ link: 'Workflows', heading: 'Workflows' },
+			{ link: 'Webhooks', heading: 'Webhooks' },
 			{ link: 'Overview', heading: 'Account' },
 			{ link: 'Jobs', heading: 'Jobs' },
 		],

--- a/packages/worker/client/lazy-route.tsx
+++ b/packages/worker/client/lazy-route.tsx
@@ -287,6 +287,8 @@ registerPreloadPatterns(
 		routePattern(routes.accountJobDetail),
 		routePattern(routes.accountWorkflows),
 		routePattern(routes.accountWorkflowDetail),
+		routePattern(routes.accountWebhooks),
+		routePattern(routes.accountWebhookDetail),
 		routePattern(routes.accountActivity),
 		routePattern(routes.accountActivityDetail),
 		routePattern(routes.accountMemories),

--- a/packages/worker/client/routes/account-area.ts
+++ b/packages/worker/client/routes/account-area.ts
@@ -35,6 +35,8 @@ export {
 	AccountWorkflowsRoute,
 	accountWorkflowsRouteLoader,
 } from './account-workflows.tsx'
+export { AccountWebhooksRoute } from './account-webhooks.tsx'
+export { accountWebhooksRouteLoader } from './account-webhooks-shared.ts'
 export { AccountActivityRoute } from './account-activity.tsx'
 export { accountActivityRouteLoader } from './account-activity-shared.ts'
 export {

--- a/packages/worker/client/routes/account-connections.node.test.ts
+++ b/packages/worker/client/routes/account-connections.node.test.ts
@@ -227,6 +227,7 @@ test('account rail lists Connections and Packages at the same level as the other
 		'Activity',
 		'Jobs',
 		'Workflows',
+		'Webhooks',
 		'Secrets',
 		'Integrations',
 		'MCP servers',

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -377,6 +377,7 @@ export function accountNavItemsFor(input: {
 		{ href: '/account/activity', label: 'Activity' },
 		{ href: '/account/jobs', label: 'Jobs' },
 		{ href: '/account/workflows', label: 'Workflows' },
+		{ href: routes.accountWebhooks.href(), label: 'Webhooks' },
 		{ href: '/account/secrets', label: 'Secrets' },
 		{ href: '/account/integrations', label: 'Integrations' },
 		{ href: '/account/mcp-servers', label: 'MCP servers' },

--- a/packages/worker/client/routes/account-webhooks-detail.tsx
+++ b/packages/worker/client/routes/account-webhooks-detail.tsx
@@ -1,0 +1,356 @@
+import { css } from 'remix/ui'
+import { on } from '#client/event-mixin.ts'
+import { type createDoubleCheck } from '#client/double-check.ts'
+import {
+	AccountManagementMessage,
+	IdValue,
+	MetadataGrid,
+	TimestampValue,
+} from '#client/routes/account-management-components.tsx'
+import {
+	webhookDeliveriesHref,
+	webhookModeLabel,
+	webhookStatusColor,
+	webhookStatusLabel,
+	webhooksDocHref,
+} from '#client/routes/account-webhooks-shared.ts'
+import { CopyCard } from '#client/routes/onboarding-mcp-client-cards.tsx'
+import { recordBodyCss } from '#client/routes/record-table.tsx'
+import { type AccountWebhookListItem } from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
+import {
+	cardTitleCss,
+	descriptionCss,
+	fieldCss,
+	fieldLabelCss,
+	getDangerPillCss,
+	getGhostButtonCss,
+	getPillButtonCss,
+	mutedLinkCss,
+	primaryLinkCss,
+} from '#universal/styles/style-primitives.ts'
+import { colors, spacing, typography } from '#universal/styles/tokens.ts'
+
+const primaryButtonCss = getPillButtonCss({ size: 'sm' })
+const secondaryButtonCss = getGhostButtonCss({ size: 'sm' })
+const dangerButtonCss = getDangerPillCss({ size: 'sm' })
+
+export type WebhookIntent = 'mint' | 'rotate' | 'reveal' | 'enable' | 'disable'
+
+type DoubleCheck = ReturnType<typeof createDoubleCheck>
+
+function packageValue(username: string, webhook: AccountWebhookListItem) {
+	if (!username) return webhook.packageName
+	return (
+		<a
+			href={routes.communityPackage.href({
+				username,
+				kodyId: webhook.packageKodyId,
+			})}
+			mix={css(primaryLinkCss)}
+		>
+			{webhook.packageName}
+		</a>
+	)
+}
+
+function verificationValue(webhook: AccountWebhookListItem) {
+	const verification = webhook.verification
+	if (!verification) return 'URL secret only (no HMAC)'
+	return (
+		<span mix={css({ display: 'grid', gap: spacing.xs })}>
+			<span>
+				{verification.type} · <code>{verification.header}</code>
+			</span>
+			<span mix={css({ color: colors.textMuted })}>
+				secret <code>{verification.secretName}</code>
+				{verification.prefix ? ` · prefix ${verification.prefix}` : ''}
+				{verification.signedPayload === 'timestamp.body'
+					? ' · signs timestamp.body'
+					: ''}
+			</span>
+		</span>
+	)
+}
+
+function replayValue(webhook: AccountWebhookListItem) {
+	const replay = webhook.replay
+	if (!replay) return 'Not configured'
+	const parts: Array<string> = []
+	if (replay.deliveryIdHeader) {
+		parts.push(`delivery id ${replay.deliveryIdHeader}`)
+	}
+	if (replay.timestampHeader) {
+		parts.push(
+			`timestamp ${replay.timestampHeader} (${replay.toleranceSeconds ?? 300}s)`,
+		)
+	}
+	return parts.length > 0 ? parts.join(' · ') : 'Not configured'
+}
+
+export function renderWebhookDetailPlaceholder(title: string, body: string) {
+	return (
+		<div mix={css({ ...recordBodyCss, gap: spacing.sm })}>
+			<h2
+				mix={css({
+					margin: 0,
+					fontSize: typography.fontSize.lg,
+					fontWeight: typography.fontWeight.semibold,
+					color: colors.text,
+				})}
+			>
+				{title}
+			</h2>
+			<p mix={css({ margin: 0, color: colors.textMuted })}>{body}</p>
+		</div>
+	)
+}
+
+export function renderAccountWebhookDetail(input: {
+	username: string
+	webhook: AccountWebhookListItem
+	revealedUrl: string | null
+	isMutating: boolean
+	rotateCheck: DoubleCheck
+	disableCheck: DoubleCheck
+	onIntent: (intent: WebhookIntent) => void
+	onHideUrl: () => void
+}) {
+	const {
+		username,
+		webhook,
+		revealedUrl,
+		isMutating,
+		rotateCheck,
+		disableCheck,
+		onIntent,
+		onHideUrl,
+	} = input
+	const webhookLabel = `${webhook.packageKodyId}/${webhook.name}`
+	return (
+		<section
+			mix={css(recordBodyCss)}
+			data-testid="account-webhook-detail"
+			data-webhook-id={webhook.id}
+		>
+			<div mix={css({ display: 'grid', gap: spacing.xs })}>
+				<h2 mix={css(cardTitleCss)}>{webhook.name}</h2>
+				<p mix={css(descriptionCss)}>
+					{webhook.description ??
+						`Declared by ${webhook.packageName}. Each delivery runs the bound export.`}
+				</p>
+			</div>
+
+			<MetadataGrid
+				items={[
+					{ label: 'Package', value: packageValue(username, webhook) },
+					{
+						label: 'Export',
+						value: <code>{webhook.exportName}</code>,
+					},
+					{
+						label: 'Status',
+						value: (
+							<span mix={css({ color: webhookStatusColor(webhook) })}>
+								{webhookStatusLabel(webhook)}
+							</span>
+						),
+					},
+					{ label: 'Mode', value: webhookModeLabel(webhook) },
+					{
+						label: 'Rate limit',
+						value: `${webhook.rateLimitPerMinute} / min`,
+					},
+					{ label: 'Verification', value: verificationValue(webhook) },
+					{ label: 'Replay protection', value: replayValue(webhook) },
+					{
+						label: 'Handle',
+						value: webhook.handle ? (
+							<IdValue value={webhook.handle} label="webhook handle" />
+						) : (
+							'—'
+						),
+					},
+					{ label: 'URL host', value: webhook.urlHost ?? '—' },
+					{
+						label: 'Minted',
+						value: <TimestampValue value={webhook.createdAt} />,
+					},
+					{
+						label: 'Rotated',
+						value: <TimestampValue value={webhook.rotatedAt} />,
+					},
+				]}
+			/>
+
+			<div mix={css(fieldCss)} data-testid="account-webhook-url">
+				<span mix={css(fieldLabelCss)}>Webhook URL</span>
+				{renderUrlSection({
+					webhook,
+					revealedUrl,
+					isMutating,
+					onIntent,
+					onHideUrl,
+				})}
+			</div>
+
+			{webhook.minted ? (
+				<div
+					mix={css({
+						display: 'flex',
+						gap: spacing.sm,
+						flexWrap: 'wrap',
+						alignItems: 'center',
+					})}
+				>
+					{webhook.enabled ? (
+						<button
+							type="button"
+							disabled={isMutating}
+							aria-label={
+								disableCheck.doubleCheck
+									? `Confirm disable ${webhookLabel}`
+									: `Disable ${webhookLabel}`
+							}
+							mix={[
+								css(secondaryButtonCss),
+								...disableCheck.getButtonMix({
+									on: { click: () => onIntent('disable') },
+								}),
+							]}
+						>
+							{disableCheck.doubleCheck ? 'Confirm disable' : 'Disable'}
+						</button>
+					) : (
+						<button
+							type="button"
+							disabled={isMutating}
+							aria-label={`Enable ${webhookLabel}`}
+							mix={[
+								css(secondaryButtonCss),
+								on('click', () => onIntent('enable')),
+							]}
+						>
+							Enable
+						</button>
+					)}
+					<button
+						type="button"
+						disabled={isMutating}
+						aria-label={
+							rotateCheck.doubleCheck
+								? `Confirm rotate URL for ${webhookLabel}`
+								: `Rotate URL for ${webhookLabel}`
+						}
+						mix={[
+							css(dangerButtonCss),
+							...rotateCheck.getButtonMix({
+								on: { click: () => onIntent('rotate') },
+							}),
+						]}
+					>
+						{rotateCheck.doubleCheck ? 'Confirm rotate' : 'Rotate URL'}
+					</button>
+					<a href={webhookDeliveriesHref} mix={css(mutedLinkCss)}>
+						Recent deliveries
+					</a>
+				</div>
+			) : null}
+
+			{rotateCheck.doubleCheck ? (
+				<AccountManagementMessage tone="info">
+					Rotating replaces the secret immediately. The current URL stops
+					working and every provider that posts to it needs the new one.
+				</AccountManagementMessage>
+			) : null}
+
+			<p mix={css(descriptionCss)}>
+				Disabling answers 404 without deleting the mint; enabling restores the
+				same URL. Removing the declaration from the package manifest retires the
+				ingress.{' '}
+				<a href={webhooksDocHref} mix={css(primaryLinkCss)}>
+					Inbound webhooks docs
+				</a>
+			</p>
+		</section>
+	)
+}
+
+function renderUrlSection(input: {
+	webhook: AccountWebhookListItem
+	revealedUrl: string | null
+	isMutating: boolean
+	onIntent: (intent: WebhookIntent) => void
+	onHideUrl: () => void
+}) {
+	const { webhook, revealedUrl, isMutating, onIntent, onHideUrl } = input
+	if (!webhook.minted) {
+		return (
+			<div mix={css({ display: 'grid', gap: spacing.sm })}>
+				<p mix={css({ margin: 0, color: colors.textMuted })}>
+					No URL yet. Minting opens ingress for this webhook and shows the URL
+					once so you can paste it into the provider. Treat it as a credential:
+					anyone holding it can POST to this export.
+				</p>
+				<div>
+					<button
+						type="button"
+						disabled={isMutating}
+						data-testid="account-webhook-mint"
+						mix={[css(primaryButtonCss), on('click', () => onIntent('mint'))]}
+					>
+						Mint URL
+					</button>
+				</div>
+			</div>
+		)
+	}
+	if (revealedUrl) {
+		return (
+			<div mix={css({ display: 'grid', gap: spacing.sm })}>
+				<CopyCard
+					label="Webhook URL"
+					value={revealedUrl}
+					copyLabel="Copy webhook URL"
+					variant="pill"
+				/>
+				<div>
+					<button
+						type="button"
+						data-testid="account-webhook-hide-url"
+						mix={[css(secondaryButtonCss), on('click', onHideUrl)]}
+					>
+						Hide URL
+					</button>
+				</div>
+			</div>
+		)
+	}
+	if (!webhook.urlRecoverable) {
+		return (
+			<p mix={css({ margin: 0, color: colors.textMuted })}>
+				This URL was minted before Kody kept a recoverable copy of the secret,
+				so it cannot be shown here. Rotate it to get a URL you can copy.
+			</p>
+		)
+	}
+	return (
+		<div mix={css({ display: 'grid', gap: spacing.sm })}>
+			<p mix={css({ margin: 0, color: colors.textMuted })}>
+				Hidden until you reveal it. Only you can see it here; agents connected
+				over MCP never receive this URL. Each reveal is recorded in your account
+				audit log.
+			</p>
+			<div>
+				<button
+					type="button"
+					disabled={isMutating}
+					data-testid="account-webhook-reveal"
+					mix={[css(secondaryButtonCss), on('click', () => onIntent('reveal'))]}
+				>
+					Reveal URL
+				</button>
+			</div>
+		</div>
+	)
+}

--- a/packages/worker/client/routes/account-webhooks-shared.ts
+++ b/packages/worker/client/routes/account-webhooks-shared.ts
@@ -1,0 +1,115 @@
+import { readJson } from '#client/routes/account-approval-shared.ts'
+import {
+	routeLoaderRedirect,
+	type RouteLoaderResult,
+} from '#client/route-loader.ts'
+import {
+	type AccountWebhookListItem,
+	type AccountWebhooksLoaderData,
+} from '#universal/loader-data.ts'
+import { docHref } from '#universal/docs-nav.ts'
+import { routes } from '#universal/routes.ts'
+import { colors } from '#universal/styles/tokens.ts'
+
+export const accountWebhooksApiPath = routes.accountWebhooksApi.href()
+
+/** The triggers guide section on inbound webhooks (`docs/guides/triggers.md`). */
+export const webhooksDocHref = `${docHref('triggers')}#inbound-webhooks-the-external-http-knock`
+
+/** Activity filtered to webhook deliveries (metadata only; bodies are never stored). */
+export const webhookDeliveriesHref = `${routes.accountActivity.href()}?view=recent&status=all&surface=webhook`
+
+const listPath = routes.accountWebhooks.href()
+const detailPrefix = `${listPath}/`
+
+function decodePathSegment(value: string) {
+	try {
+		return decodeURIComponent(value)
+	} catch {
+		return value
+	}
+}
+
+/**
+ * `/account/webhooks/:packageKodyId/:webhookName` selects one declared
+ * webhook. The row id is the same two segments joined with `/`, so the list
+ * payload can answer the detail without a second fetch.
+ */
+export function readWebhookSelection(href: string) {
+	const pathname = new URL(href, 'http://localhost').pathname
+	if (!pathname.startsWith(detailPrefix)) return null
+	const segments = pathname
+		.slice(detailPrefix.length)
+		.split('/')
+		.filter(Boolean)
+	if (segments.length !== 2) return null
+	const [packageKodyId, webhookName] = segments.map(decodePathSegment)
+	if (!packageKodyId || !webhookName) return null
+	return `${packageKodyId}/${webhookName}`
+}
+
+export function buildWebhookDetailHref(
+	webhook: Pick<AccountWebhookListItem, 'packageKodyId' | 'name'>,
+) {
+	return routes.accountWebhookDetail.href({
+		packageKodyId: webhook.packageKodyId,
+		webhookName: webhook.name,
+	})
+}
+
+/** Every webhook route shares the one list payload. */
+export function getWebhooksDataLatchKey(_href: string) {
+	return listPath
+}
+
+export function webhookStatusLabel(
+	webhook: Pick<AccountWebhookListItem, 'minted' | 'enabled'>,
+) {
+	if (!webhook.minted) return 'No URL yet'
+	return webhook.enabled ? 'Active' : 'Disabled'
+}
+
+export function webhookStatusColor(
+	webhook: Pick<AccountWebhookListItem, 'minted' | 'enabled'>,
+) {
+	if (!webhook.minted) return colors.textMuted
+	return webhook.enabled ? colors.primary : colors.error
+}
+
+export function webhookModeLabel(
+	webhook: Pick<AccountWebhookListItem, 'responseMode' | 'inputMode'>,
+) {
+	return `${webhook.responseMode} · ${webhook.inputMode}`
+}
+
+export function webhookVerificationLabel(
+	webhook: Pick<AccountWebhookListItem, 'verification'>,
+) {
+	if (!webhook.verification) return 'URL secret only'
+	return `${webhook.verification.type} · ${webhook.verification.header}`
+}
+
+export async function fetchAccountWebhooks(signal: AbortSignal) {
+	const response = await fetch(accountWebhooksApiPath, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+		signal,
+	})
+	if (response.status === 401) return { kind: 'unauthorized' as const }
+	const payload = await readJson<AccountWebhooksLoaderData>(response)
+	if (!response.ok || !payload?.ok) {
+		throw new Error('Unable to load webhooks.')
+	}
+	return { kind: 'ok' as const, payload }
+}
+
+export async function accountWebhooksRouteLoader(
+	_url: URL,
+	signal: AbortSignal,
+): Promise<RouteLoaderResult> {
+	const result = await fetchAccountWebhooks(signal)
+	if (result.kind === 'unauthorized') {
+		return routeLoaderRedirect('/login')
+	}
+	return { accountWebhooks: result.payload }
+}

--- a/packages/worker/client/routes/account-webhooks.node.test.ts
+++ b/packages/worker/client/routes/account-webhooks.node.test.ts
@@ -1,0 +1,197 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { AppSessionProvider } from '#client/app-session-context.tsx'
+import { AppLoaderDataProvider } from '#client/loader-data-context.tsx'
+import { RouterLocationProvider } from '#client/router-location.tsx'
+import { AccountWebhooksRoute } from '#client/routes/account-webhooks.tsx'
+import {
+	buildWebhookDetailHref,
+	readWebhookSelection,
+	webhookStatusLabel,
+} from '#client/routes/account-webhooks-shared.ts'
+import { type SessionInfo } from '#client/session.ts'
+import {
+	type AccountWebhookListItem,
+	type AccountWebhooksLoaderData,
+} from '#universal/loader-data.ts'
+import { routes } from '#universal/routes.ts'
+
+const session: SessionInfo = {
+	email: 'jane@example.com',
+	emailVerified: true,
+	emailVerificationDelivery: null,
+	username: 'jane',
+	avatarUrl: null,
+	roles: [],
+	permissions: [],
+	featureFlags: {} as SessionInfo['featureFlags'],
+}
+
+const unminted: AccountWebhookListItem = {
+	id: 'sentry-bridge/sentry',
+	packageId: 'pkg-1',
+	packageKodyId: 'sentry-bridge',
+	packageName: '@jane/sentry-bridge',
+	name: 'sentry',
+	exportName: './handle-sentry-webhook',
+	description: 'Forward Sentry alerts into automations',
+	responseMode: 'ack',
+	inputMode: 'request',
+	rateLimitPerMinute: 60,
+	verification: {
+		type: 'hmac-sha256',
+		header: 'sentry-hook-signature',
+		secretName: 'sentryWebhookSecret',
+		encoding: 'hex',
+	},
+	replay: null,
+	minted: false,
+	handle: null,
+	urlHost: null,
+	enabled: null,
+	urlRecoverable: false,
+	createdAt: null,
+	rotatedAt: null,
+}
+
+const minted: AccountWebhookListItem = {
+	id: 'raycast-bridge/launch',
+	packageId: 'pkg-2',
+	packageKodyId: 'raycast-bridge',
+	packageName: '@jane/raycast-bridge',
+	name: 'launch',
+	exportName: './dispatch-launch',
+	description: null,
+	responseMode: 'sync',
+	inputMode: 'params',
+	rateLimitPerMinute: 600,
+	verification: null,
+	replay: { deliveryIdHeader: 'X-Delivery-Id' },
+	minted: true,
+	handle: 'whh_11111111-1111-1111-1111-111111111111',
+	urlHost: 'kody.example',
+	enabled: true,
+	urlRecoverable: true,
+	createdAt: '2026-09-01T10:00:00.000Z',
+	rotatedAt: '2026-09-05T10:00:00.000Z',
+}
+
+function renderWebhooksPage(
+	url: string,
+	accountWebhooks: AccountWebhooksLoaderData,
+) {
+	return renderToString(
+		jsx(RouterLocationProvider, {
+			url,
+			children: jsx(AppSessionProvider, {
+				session,
+				status: 'ready',
+				children: jsx(AppLoaderDataProvider, {
+					loaderData: { accountWebhooks },
+					children: jsx(AccountWebhooksRoute, {}),
+				}),
+			}),
+		}),
+	)
+}
+
+const payload: AccountWebhooksLoaderData = {
+	ok: true,
+	username: 'jane',
+	webhooks: [minted, unminted],
+}
+
+test('webhooks page lists declared webhooks with status and links each row to its detail route', async () => {
+	const html = await renderWebhooksPage(routes.accountWebhooks.href(), payload)
+
+	expect(html).toContain('>Webhooks</h1>')
+	expect(html).toContain('aria-label="Webhooks"')
+	expect(html).toContain('2 declared · 1 minted')
+	expect(html).toContain(`href="${buildWebhookDetailHref(minted)}"`)
+	expect(html).toContain(`href="${buildWebhookDetailHref(unminted)}"`)
+	expect(html).toContain('>Active<')
+	expect(html).toContain('>No URL yet<')
+	expect(html).toContain('URL secret only')
+	expect(html).toContain('hmac-sha256 · sentry-hook-signature')
+	// The rail marks this page current; no cold-path loading copy with SSR data.
+	expect(html).toMatch(/href="\/account\/webhooks"[^>]*aria-current="page"/)
+	expect(html).not.toContain('Loading webhooks')
+	// Nothing on the list page resembles a credential path.
+	expect(html).not.toContain('/@jane/webhooks/')
+})
+
+test('webhooks detail offers Mint for an unminted webhook and Reveal, Rotate, and Disable for a minted one — never the URL itself', async () => {
+	const unmintedHtml = await renderWebhooksPage(
+		buildWebhookDetailHref(unminted),
+		payload,
+	)
+	expect(unmintedHtml).toContain('data-webhook-id="sentry-bridge/sentry"')
+	expect(unmintedHtml).toContain('data-testid="account-webhook-mint"')
+	expect(unmintedHtml).toContain('Forward Sentry alerts into automations')
+	expect(unmintedHtml).toContain('secret <code>sentryWebhookSecret</code>')
+	expect(unmintedHtml).not.toContain('data-testid="account-webhook-reveal"')
+	expect(unmintedHtml).not.toContain('Rotate URL')
+
+	const mintedHtml = await renderWebhooksPage(
+		buildWebhookDetailHref(minted),
+		payload,
+	)
+	expect(mintedHtml).toContain('data-webhook-id="raycast-bridge/launch"')
+	expect(mintedHtml).toContain('data-testid="account-webhook-reveal"')
+	expect(mintedHtml).toContain(
+		'aria-label="Rotate URL for raycast-bridge/launch"',
+	)
+	expect(mintedHtml).toContain('aria-label="Disable raycast-bridge/launch"')
+	expect(mintedHtml).toContain('whh_11111111-1111-1111-1111-111111111111')
+	expect(mintedHtml).toContain('600 / min')
+	expect(mintedHtml).toContain('delivery id X-Delivery-Id')
+	expect(mintedHtml).toContain('surface=webhook')
+	expect(mintedHtml).not.toContain('data-testid="account-webhook-mint"')
+	// The credential is fetched on Reveal, so SSR HTML has no URL to embed.
+	expect(mintedHtml).not.toContain('Copy webhook URL')
+	expect(mintedHtml).not.toContain('/@jane/webhooks/')
+})
+
+test('webhooks detail points legacy mints at Rotate instead of Reveal', async () => {
+	const legacy: AccountWebhookListItem = {
+		...minted,
+		urlRecoverable: false,
+		enabled: false,
+	}
+	const html = await renderWebhooksPage(buildWebhookDetailHref(legacy), {
+		...payload,
+		webhooks: [legacy, unminted],
+	})
+	expect(html).not.toContain('data-testid="account-webhook-reveal"')
+	expect(html).toContain('Rotate it to get a URL you can copy')
+	expect(html).toContain('aria-label="Enable raycast-bridge/launch"')
+	expect(html).toContain('>Disabled<')
+})
+
+test('webhooks detail route renders a not-found record for an undeclared webhook', async () => {
+	const html = await renderWebhooksPage(
+		routes.accountWebhookDetail.href({
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'missing',
+		}),
+		payload,
+	)
+	expect(html).toContain('Webhook not found')
+})
+
+test('webhook selection round-trips through the two-segment detail route', () => {
+	expect(readWebhookSelection('/account/webhooks')).toBeNull()
+	expect(readWebhookSelection('/account/webhooks/only-one')).toBeNull()
+	expect(readWebhookSelection('/account/webhooks/a/b/c')).toBeNull()
+	expect(readWebhookSelection(buildWebhookDetailHref(minted))).toBe(minted.id)
+	expect(
+		readWebhookSelection(
+			buildWebhookDetailHref({ packageKodyId: 'my.pkg', name: 'hook' }),
+		),
+	).toBe('my.pkg/hook')
+	expect(webhookStatusLabel({ minted: false, enabled: null })).toBe(
+		'No URL yet',
+	)
+	expect(webhookStatusLabel({ minted: true, enabled: false })).toBe('Disabled')
+})

--- a/packages/worker/client/routes/account-webhooks.node.test.ts
+++ b/packages/worker/client/routes/account-webhooks.node.test.ts
@@ -114,8 +114,10 @@ test('webhooks page lists declared webhooks with status and links each row to it
 	expect(html).toContain('>No URL yet<')
 	expect(html).toContain('URL secret only')
 	expect(html).toContain('hmac-sha256 · sentry-hook-signature')
-	// The rail marks this page current; no cold-path loading copy with SSR data.
+	// The rail marks this page current and the section explainer is the
+	// webhooks one; no cold-path loading copy with SSR data.
 	expect(html).toMatch(/href="\/account\/webhooks"[^>]*aria-current="page"/)
+	expect(html).toContain('data-entity-explainer="webhooks"')
 	expect(html).not.toContain('Loading webhooks')
 	// Nothing on the list page resembles a credential path.
 	expect(html).not.toContain('/@jane/webhooks/')

--- a/packages/worker/client/routes/account-webhooks.tsx
+++ b/packages/worker/client/routes/account-webhooks.tsx
@@ -1,0 +1,314 @@
+import { type Handle, css } from 'remix/ui'
+import { readCurrentRouterHref } from '#client/client-router.tsx'
+import { createDoubleCheck } from '#client/double-check.ts'
+import { createRouteData, routeDataRedirect } from '#client/route-data.tsx'
+import {
+	type AccountStatus,
+	readJson,
+} from '#client/routes/account-approval-shared.ts'
+import {
+	AccountManagementMessage,
+	AccountManagementShell,
+	AccountPageHeader,
+} from '#client/routes/account-management-components.tsx'
+import {
+	renderAccountWebhookDetail,
+	renderWebhookDetailPlaceholder,
+	type WebhookIntent,
+} from '#client/routes/account-webhooks-detail.tsx'
+import {
+	accountWebhooksApiPath,
+	buildWebhookDetailHref,
+	fetchAccountWebhooks,
+	getWebhooksDataLatchKey,
+	readWebhookSelection,
+	webhookModeLabel,
+	webhookStatusColor,
+	webhookStatusLabel,
+	webhookVerificationLabel,
+	webhooksDocHref,
+} from '#client/routes/account-webhooks-shared.ts'
+import { RecordTable, recordCellClamp } from '#client/routes/record-table.tsx'
+import {
+	type AccountWebhookListItem,
+	type AccountWebhooksActionPayload,
+	type AccountWebhooksLoaderData,
+} from '#universal/loader-data.ts'
+import { colors, spacing } from '#universal/styles/tokens.ts'
+import { primaryLinkCss } from '#universal/styles/style-primitives.ts'
+
+const clampedCellCss = css(recordCellClamp(28))
+
+type MessageTone = 'info' | 'error'
+
+function successMessageFor(intent: WebhookIntent) {
+	switch (intent) {
+		case 'mint':
+			return 'Webhook URL minted. Copy it now and paste it into the provider.'
+		case 'rotate':
+			return 'Webhook URL rotated. The previous URL no longer works.'
+		case 'reveal':
+			return null
+		case 'enable':
+			return 'Webhook enabled.'
+		case 'disable':
+			return 'Webhook disabled. Deliveries now answer 404.'
+		default: {
+			const exhaustive: never = intent
+			return String(exhaustive)
+		}
+	}
+}
+
+function failureMessageFor(intent: WebhookIntent) {
+	switch (intent) {
+		case 'mint':
+			return 'Unable to mint the webhook URL.'
+		case 'rotate':
+			return 'Unable to rotate the webhook URL.'
+		case 'reveal':
+			return 'Unable to reveal the webhook URL.'
+		case 'enable':
+			return 'Unable to enable the webhook.'
+		case 'disable':
+			return 'Unable to disable the webhook.'
+		default: {
+			const exhaustive: never = intent
+			return String(exhaustive)
+		}
+	}
+}
+
+/**
+ * `/account/webhooks` — the owner's home for minted webhook URLs. The list
+ * payload never carries the credential; Reveal (and the reveal that rides
+ * along with Mint / Rotate) fetches it per webhook and keeps it in memory
+ * until the owner hides it or moves to another row.
+ */
+export function AccountWebhooksRoute(handle: Handle) {
+	let actionState: 'idle' | 'busy' = 'idle'
+	let username = ''
+	let webhooks: Array<AccountWebhookListItem> = []
+	let message: string | null = null
+	let messageTone: MessageTone = 'info'
+	/** Revealed credential URLs keyed by row id; never part of the payload. */
+	const revealedUrls = new Map<string, string>()
+	/** Payload last applied to the closure state above. */
+	let appliedPayload: AccountWebhooksLoaderData | null = null
+	let appliedError: Error | null = null
+	const rotateCheck = createDoubleCheck(handle)
+	const disableCheck = createDoubleCheck(handle)
+	const webhooksData = createRouteData({
+		key: 'accountWebhooks',
+		locationKey: getWebhooksDataLatchKey,
+		async load(_href, signal) {
+			const result = await fetchAccountWebhooks(signal)
+			if (result.kind === 'unauthorized') return routeDataRedirect('/login')
+			return result.payload
+		},
+	})
+
+	function setMessage(nextMessage: string | null, tone: MessageTone = 'info') {
+		message = nextMessage
+		messageTone = tone
+	}
+
+	function applyPayload(payload: AccountWebhooksLoaderData) {
+		username = payload.username
+		webhooks = payload.webhooks
+		rotateCheck.reset()
+		disableCheck.reset()
+	}
+
+	function resetChecks() {
+		rotateCheck.reset()
+		disableCheck.reset()
+	}
+
+	async function postIntent(
+		intent: WebhookIntent,
+		webhook: AccountWebhookListItem,
+	) {
+		if (actionState !== 'idle') return
+		actionState = 'busy'
+		setMessage(null)
+		handle.update()
+		try {
+			const response = await fetch(accountWebhooksApiPath, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				credentials: 'include',
+				body: JSON.stringify({
+					intent,
+					packageKodyId: webhook.packageKodyId,
+					webhookName: webhook.name,
+				}),
+			})
+			if (response.status === 401) {
+				window.location.assign('/login')
+				return
+			}
+			const payload = await readJson<
+				AccountWebhooksActionPayload & { error?: string; ok?: boolean }
+			>(response)
+			if (!response.ok || !payload?.ok) {
+				throw new Error(payload?.error || failureMessageFor(intent))
+			}
+			applyPayload(payload)
+			if (intent === 'rotate') revealedUrls.delete(webhook.id)
+			if (payload.revealed) {
+				revealedUrls.set(payload.revealed.id, payload.revealed.url)
+			}
+			actionState = 'idle'
+			setMessage(successMessageFor(intent))
+			handle.update()
+		} catch (error) {
+			actionState = 'idle'
+			setMessage(
+				error instanceof Error ? error.message : failureMessageFor(intent),
+				'error',
+			)
+			handle.update()
+		}
+	}
+
+	return () => {
+		const currentHref = readCurrentRouterHref(handle)
+		const snapshot = webhooksData.read(handle, currentHref)
+		if (snapshot.data && snapshot.data !== appliedPayload) {
+			appliedPayload = snapshot.data
+			applyPayload(snapshot.data)
+			if (messageTone === 'error') setMessage(null)
+		}
+		if (snapshot.error && snapshot.error !== appliedError) {
+			appliedError = snapshot.error
+			setMessage(snapshot.error.message, 'error')
+		}
+		const pending = snapshot.kind === 'pending'
+		const status: AccountStatus =
+			snapshot.kind === 'error'
+				? 'error'
+				: pending && appliedPayload === null
+					? 'loading'
+					: 'ready'
+		const isMutating = actionState !== 'idle'
+		const selectedId = readWebhookSelection(currentHref)
+		const selected =
+			selectedId == null
+				? null
+				: (webhooks.find((webhook) => webhook.id === selectedId) ?? null)
+		const showNotFound =
+			selectedId != null && selected == null && status === 'ready' && !pending
+		const mintedCount = webhooks.filter((webhook) => webhook.minted).length
+
+		return (
+			<AccountManagementShell busy={pending && appliedPayload !== null}>
+				<AccountPageHeader
+					title="Webhooks"
+					description="Inbound webhook URLs declared by your packages. Mint a URL here, copy it into the provider that will POST to it, and rotate or disable it when it leaks or goes unused. Agents connected over MCP can mint and apply handles but never see these URLs."
+					currentHref={currentHref}
+				/>
+
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted, margin: 0 })}>
+						Loading webhooks…
+					</p>
+				) : null}
+				{message ? (
+					<AccountManagementMessage
+						tone={
+							status === 'error' || messageTone === 'error' ? 'error' : 'info'
+						}
+					>
+						{message}
+					</AccountManagementMessage>
+				) : null}
+
+				{status === 'ready' ? (
+					<RecordTable
+						mode="expand"
+						ariaLabel="Webhooks"
+						selectedId={selectedId}
+						recordLoading={false}
+						onNavigate={() => {
+							resetChecks()
+							revealedUrls.clear()
+							setMessage(null)
+						}}
+						countLabel={`${webhooks.length} declared · ${mintedCount} minted`}
+						emptyLabel="No package on this account declares a webhook yet. Add a kody.webhooks entry to a package manifest and publish it."
+						columns={[
+							{ key: 'name', label: 'Webhook', primary: true },
+							{ key: 'package', label: 'Package' },
+							{ key: 'status', label: 'Status' },
+							{ key: 'mode', label: 'Mode', drop: 2 },
+							{ key: 'verification', label: 'Verification', drop: 1 },
+						]}
+						rows={webhooks.map((webhook) => ({
+							id: webhook.id,
+							href: isMutating ? undefined : buildWebhookDetailHref(webhook),
+							cells: {
+								name: <span mix={clampedCellCss}>{webhook.name}</span>,
+								package: (
+									<span mix={clampedCellCss}>{webhook.packageName}</span>
+								),
+								status: (
+									<span mix={css({ color: webhookStatusColor(webhook) })}>
+										{webhookStatusLabel(webhook)}
+									</span>
+								),
+								mode: (
+									<span mix={clampedCellCss}>{webhookModeLabel(webhook)}</span>
+								),
+								verification: (
+									<span mix={clampedCellCss}>
+										{webhookVerificationLabel(webhook)}
+									</span>
+								),
+							},
+						}))}
+						record={
+							selected
+								? renderAccountWebhookDetail({
+										username,
+										webhook: selected,
+										revealedUrl: revealedUrls.get(selected.id) ?? null,
+										isMutating,
+										rotateCheck,
+										disableCheck,
+										onIntent: (intent) => {
+											void postIntent(intent, selected)
+										},
+										onHideUrl: () => {
+											revealedUrls.delete(selected.id)
+											handle.update()
+										},
+									})
+								: showNotFound
+									? renderWebhookDetailPlaceholder(
+											'Webhook not found',
+											'No package on this account declares this webhook, or it was renamed away.',
+										)
+									: null
+						}
+					/>
+				) : null}
+
+				{status === 'ready' ? (
+					<p
+						mix={css({ color: colors.textMuted, margin: `${spacing.md} 0 0` })}
+					>
+						Webhooks are declared in <code>package.json#kody.webhooks</code>;
+						each name binds one export.{' '}
+						<a href={webhooksDocHref} mix={css(primaryLinkCss)}>
+							Inbound webhooks docs
+						</a>
+					</p>
+				) : null}
+			</AccountManagementShell>
+		)
+	}
+}

--- a/packages/worker/client/routes/entity-explainer.tsx
+++ b/packages/worker/client/routes/entity-explainer.tsx
@@ -76,6 +76,21 @@ const entityExplainerDefinitions: Array<EntityExplainerDefinition> = [
 		],
 	},
 	{
+		id: 'webhooks',
+		question: 'What is a webhook?',
+		match: accountSection(routes.accountWebhooks.href()),
+		paragraphs: [
+			'A webhook is an inbound HTTP endpoint a package declares in package.json#kody.webhooks. Each name binds one export; when a provider such as GitHub, Stripe, or Sentry (or your own trusted client) POSTs to the minted URL, Kody runs that export.',
+			'The URL is a credential. Mint, reveal, copy, rotate, and disable it here. Agents connected over MCP can mint an opaque handle and apply it to GitHub on your behalf, but the URL itself only ever shows on this page.',
+		],
+		learnMore: [
+			{
+				href: docHref('triggers'),
+				label: 'Jobs, workflows, and webhooks',
+			},
+		],
+	},
+	{
 		id: 'secrets',
 		question: 'What is a secret?',
 		match: accountSection(routes.accountSecrets.href()),

--- a/packages/worker/client/routes/index.tsx
+++ b/packages/worker/client/routes/index.tsx
@@ -163,6 +163,14 @@ export const clientRouteLoaders: Record<string, RouteLoader> = {
 		accountArea,
 		(m) => m.accountWorkflowsRouteLoader,
 	),
+	[routePattern(routes.accountWebhooks)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountWebhooksRouteLoader,
+	),
+	[routePattern(routes.accountWebhookDetail)]: lazyRouteLoader(
+		accountArea,
+		(m) => m.accountWebhooksRouteLoader,
+	),
 	[routePattern(routes.accountActivity)]: lazyRouteLoader(
 		accountArea,
 		(m) => m.accountActivityRouteLoader,
@@ -473,6 +481,12 @@ export const clientRoutes = {
 	),
 	[routePattern(routes.accountWorkflowDetail)]: (
 		<LazyAccountRoute render={(m) => <m.AccountWorkflowsRoute />} />
+	),
+	[routePattern(routes.accountWebhooks)]: (
+		<LazyAccountRoute render={(m) => <m.AccountWebhooksRoute />} />
+	),
+	[routePattern(routes.accountWebhookDetail)]: (
+		<LazyAccountRoute render={(m) => <m.AccountWebhooksRoute />} />
 	),
 	[routePattern(routes.accountActivity)]: (
 		<LazyAccountRoute render={(m) => <m.AccountActivityRoute />} />

--- a/packages/worker/src/app/account-webhooks-data.ts
+++ b/packages/worker/src/app/account-webhooks-data.ts
@@ -1,0 +1,75 @@
+import { type AuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import {
+	listWebhooksForUser,
+	type ListedWebhook,
+} from '#worker/webhooks/service.ts'
+import {
+	type AccountWebhookListItem,
+	type AccountWebhooksLoaderData,
+} from '#universal/loader-data.ts'
+
+export type AccountWebhooksUser = Pick<
+	AuthenticatedAppUser,
+	'username' | 'mcpUser'
+>
+
+/** Detail route segments joined the same way the client builds row ids. */
+export function accountWebhookItemId(input: {
+	packageKodyId: string
+	name: string
+}) {
+	return `${input.packageKodyId}/${input.name}`
+}
+
+function toAccountWebhookListItem(
+	webhook: ListedWebhook,
+): AccountWebhookListItem {
+	return {
+		id: accountWebhookItemId(webhook),
+		packageId: webhook.packageId,
+		packageKodyId: webhook.packageKodyId,
+		packageName: webhook.packageName,
+		name: webhook.name,
+		exportName: webhook.exportName,
+		description: webhook.description,
+		responseMode: webhook.responseMode,
+		inputMode: webhook.inputMode,
+		rateLimitPerMinute: webhook.rateLimitPerMinute,
+		verification: webhook.verification,
+		replay: webhook.replay,
+		minted: webhook.minted,
+		handle: webhook.handle,
+		urlHost: webhook.urlHost,
+		enabled: webhook.enabled,
+		urlRecoverable: webhook.urlRecoverable,
+		createdAt: webhook.createdAt,
+		rotatedAt: webhook.rotatedAt,
+	}
+}
+
+/**
+ * Declared package webhooks joined with minted URL state for the signed-in
+ * owner. The credential URL is deliberately absent; `/account/webhooks.json`
+ * hands it out only through the explicit `reveal` intent.
+ */
+export async function loadAccountWebhooksData(input: {
+	env: Env
+	requestUrl: string | URL
+	user: AccountWebhooksUser
+}): Promise<AccountWebhooksLoaderData> {
+	const baseUrl = getAppBaseUrl({
+		env: input.env,
+		requestUrl: input.requestUrl,
+	})
+	const webhooks = await listWebhooksForUser({
+		env: input.env,
+		baseUrl,
+		userId: input.user.mcpUser.userId,
+	})
+	return {
+		ok: true,
+		username: input.user.username,
+		webhooks: webhooks.map(toAccountWebhookListItem),
+	}
+}

--- a/packages/worker/src/app/handlers/account-webhooks.node.test.ts
+++ b/packages/worker/src/app/handlers/account-webhooks.node.test.ts
@@ -1,6 +1,9 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test, vi } from 'vitest'
-import { createAccountWebhooksApiHandler } from '#app/handlers/account-webhooks.ts'
+import {
+	createAccountWebhooksApiHandler,
+	createAccountWebhooksHandler,
+} from '#app/handlers/account-webhooks.ts'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { createStableUserIdFromEmail } from '#worker/user-id.ts'
@@ -11,11 +14,22 @@ import {
 
 const mockModule = vi.hoisted(() => ({
 	readAuthenticatedAppUser: vi.fn(),
+	requireAuthenticatedPageUser: vi.fn(),
+	renderAppPage: vi.fn(),
 }))
 
 vi.mock('#app/authenticated-user.ts', () => ({
 	readAuthenticatedAppUser: (...args: Array<unknown>) =>
 		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+vi.mock('#app/page-auth.ts', () => ({
+	requireAuthenticatedPageUser: (...args: Array<unknown>) =>
+		mockModule.requireAuthenticatedPageUser(...args),
+}))
+
+vi.mock('#app/ssr-render.tsx', () => ({
+	renderAppPage: (...args: Array<unknown>) => mockModule.renderAppPage(...args),
 }))
 
 const savedPackage = {
@@ -338,6 +352,49 @@ test('account webhooks API mints, reveals, rotates, and toggles a declared webho
 			result: 'failure',
 		}),
 	)
+})
+
+test('account webhooks page handler embeds the declared list (never a URL) and redirects anonymous visitors', async () => {
+	const userId = await createStableUserIdFromEmail('owner@example.com')
+	const { env } = createEnv()
+	const handler = createAccountWebhooksHandler(env)
+	mockModule.requireAuthenticatedPageUser.mockResolvedValue({
+		email: 'owner@example.com',
+		username: 'owner',
+		mcpUser: { userId },
+	})
+	mockModule.renderAppPage.mockImplementation(async () => new Response('ok'))
+
+	const page = await runHandler(
+		handler,
+		new Request('https://kody.example/account/webhooks/sentry-bridge/sentry'),
+	)
+	expect(page.status).toBe(200)
+	expect(mockModule.renderAppPage).toHaveBeenCalledTimes(1)
+	const renderInput = mockModule.renderAppPage.mock.calls[0]?.[0] as {
+		title: string
+		loaderData: { accountWebhooks: AccountWebhooksLoaderData }
+	}
+	expect(renderInput.title).toBe('Webhooks')
+	expect(renderInput.loaderData.accountWebhooks.username).toBe('owner')
+	expect(
+		renderInput.loaderData.accountWebhooks.webhooks.map(
+			(webhook) => webhook.id,
+		),
+	).toEqual(['sentry-bridge/launcher', 'sentry-bridge/sentry'])
+	expect(JSON.stringify(renderInput.loaderData)).not.toContain('"url"')
+
+	const redirect = new Response(null, {
+		status: 302,
+		headers: { Location: '/login' },
+	})
+	mockModule.requireAuthenticatedPageUser.mockResolvedValue(redirect)
+	const anonymous = await runHandler(
+		handler,
+		new Request('https://kody.example/account/webhooks'),
+	)
+	expect(anonymous.status).toBe(302)
+	expect(mockModule.renderAppPage).toHaveBeenCalledTimes(1)
 })
 
 test('account webhooks API rejects unknown webhooks, bad bodies, and anonymous callers', async () => {

--- a/packages/worker/src/app/handlers/account-webhooks.node.test.ts
+++ b/packages/worker/src/app/handlers/account-webhooks.node.test.ts
@@ -1,0 +1,401 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { createAccountWebhooksApiHandler } from '#app/handlers/account-webhooks.ts'
+import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createStableUserIdFromEmail } from '#worker/user-id.ts'
+import {
+	type AccountWebhooksActionPayload,
+	type AccountWebhooksLoaderData,
+} from '#universal/loader-data.ts'
+
+const mockModule = vi.hoisted(() => ({
+	readAuthenticatedAppUser: vi.fn(),
+}))
+
+vi.mock('#app/authenticated-user.ts', () => ({
+	readAuthenticatedAppUser: (...args: Array<unknown>) =>
+		mockModule.readAuthenticatedAppUser(...args),
+}))
+
+const savedPackage = {
+	id: 'pkg-1',
+	userId: 'set-per-test',
+	name: '@owner/sentry-bridge',
+	kodyId: 'sentry-bridge',
+	description: 'Sentry bridge',
+	tags: [],
+	searchText: null,
+	sourceId: 'src-1',
+	hasApp: false,
+	hidden: false,
+	isPrivate: true,
+	createdAt: '2026-07-24T00:00:00.000Z',
+	updatedAt: '2026-07-24T00:00:00.000Z',
+}
+
+vi.mock('#worker/package-invocations/module-artifacts.ts', () => ({
+	resolveSavedPackage: vi.fn(async (input: { packageIdOrKodyId: string }) =>
+		input.packageIdOrKodyId === 'pkg-1' ||
+		input.packageIdOrKodyId === 'sentry-bridge'
+			? savedPackage
+			: null,
+	),
+}))
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: vi.fn(async () => [savedPackage]),
+	getSavedPackageByKodyId: vi.fn(),
+}))
+
+vi.mock('#worker/package-registry/source.ts', () => ({
+	loadPackageManifestBySourceId: vi.fn(async () => ({
+		manifest: {
+			name: '@owner/sentry-bridge',
+			exports: {
+				'./handle-sentry-webhook': './src/handle-sentry-webhook.ts',
+				'./dispatch-launcher': './src/dispatch-launcher.ts',
+			},
+			kody: {
+				id: 'sentry-bridge',
+				description: 'Sentry bridge',
+				webhooks: [
+					{
+						name: 'sentry',
+						export: './handle-sentry-webhook',
+						responseMode: 'ack',
+						verification: {
+							type: 'hmac-sha256',
+							header: 'sentry-hook-signature',
+							secretName: 'sentryWebhookSecret',
+							encoding: 'hex',
+						},
+					},
+					{
+						name: 'launcher',
+						export: './dispatch-launcher',
+						responseMode: 'sync',
+						inputMode: 'params',
+						rateLimitPerMinute: 600,
+					},
+				],
+			},
+		},
+	})),
+}))
+
+function createEnv() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE webhook_endpoints (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			webhook_name TEXT NOT NULL,
+			url_secret_hash TEXT NOT NULL,
+			url_secret_encrypted TEXT,
+			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+			created_at TEXT NOT NULL,
+			rotated_at TEXT NOT NULL
+		);
+		CREATE UNIQUE INDEX idx_webhook_endpoints_user_package_name
+		ON webhook_endpoints(user_id, package_id, webhook_name);
+	`)
+	const db = createD1FromSqlite(sqlite)
+	return {
+		env: {
+			APP_DB: db,
+			SECRET_STORE_KEY: 'test-secret-store-key-32-chars-minimum',
+			SENTRY_ENVIRONMENT: 'test',
+		} as unknown as Env,
+		db,
+	}
+}
+
+type Handler = {
+	handler(context: never): Promise<Response>
+}
+
+async function runHandler(handler: Handler, request: Request) {
+	return handler.handler({
+		request,
+		url: new URL(request.url),
+		params: {},
+	} as never)
+}
+
+const apiUrl = 'https://kody.example/account/webhooks.json'
+
+function getRequest() {
+	return new Request(apiUrl, { headers: { Accept: 'application/json' } })
+}
+
+function postRequest(body: unknown) {
+	return new Request(apiUrl, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(body),
+	})
+}
+
+function urlSecretOf(url: string) {
+	return url.slice(url.lastIndexOf('/') + 1)
+}
+
+test('account webhooks API mints, reveals, rotates, and toggles a declared webhook without leaking the URL from the list', async () => {
+	const userId = await createStableUserIdFromEmail('owner@example.com')
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		email: 'owner@example.com',
+		username: 'owner',
+		mcpUser: { userId },
+	})
+	const { env, db } = createEnv()
+	const handler = createAccountWebhooksApiHandler(env)
+
+	const listed = await runHandler(handler, getRequest())
+	expect(listed.status).toBe(200)
+	const listBody = (await listed.json()) as AccountWebhooksLoaderData
+	expect(listBody.ok).toBe(true)
+	expect(listBody.username).toBe('owner')
+	expect(listBody.webhooks.map((webhook) => webhook.id)).toEqual([
+		'sentry-bridge/launcher',
+		'sentry-bridge/sentry',
+	])
+	const launcher = listBody.webhooks[0]!
+	expect(launcher.minted).toBe(false)
+	expect(launcher.urlRecoverable).toBe(false)
+	expect(launcher.inputMode).toBe('params')
+	expect(launcher.rateLimitPerMinute).toBe(600)
+	expect(launcher.verification).toBeNull()
+
+	const minted = await runHandler(
+		handler,
+		postRequest({
+			intent: 'mint',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'launcher',
+		}),
+	)
+	expect(minted.status).toBe(200)
+	const mintBody = (await minted.json()) as AccountWebhooksActionPayload
+	expect(mintBody.revealed?.id).toBe('sentry-bridge/launcher')
+	expect(mintBody.revealed?.handle.startsWith('whh_')).toBe(true)
+	// The URL comes from the request origin so previews show their own host,
+	// and the response reveals it exactly once alongside the refreshed list.
+	expect(mintBody.revealed?.url).toMatch(
+		/^https:\/\/kody\.example\/@owner\/webhooks\/sentry-bridge\/launcher\/[A-Za-z0-9_-]+$/,
+	)
+	const mintedUrl = mintBody.revealed!.url
+	const mintedLauncher = mintBody.webhooks.find(
+		(webhook) => webhook.name === 'launcher',
+	)!
+	expect(mintedLauncher.minted).toBe(true)
+	expect(mintedLauncher.enabled).toBe(true)
+	expect(mintedLauncher.urlRecoverable).toBe(true)
+	expect(mintedLauncher.handle).toBe(mintBody.revealed?.handle)
+	expect(JSON.stringify(mintBody.webhooks)).not.toContain(
+		urlSecretOf(mintedUrl),
+	)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'webhook_url_mint',
+			result: 'success',
+			reason: 'package=sentry-bridge webhook=launcher',
+		}),
+	)
+
+	// GET never carries the credential; only an explicit reveal does.
+	const relisted = await runHandler(handler, getRequest())
+	const relistText = await relisted.text()
+	expect(relistText).not.toContain(urlSecretOf(mintedUrl))
+	expect(relistText).not.toContain('"url"')
+
+	const revealed = await runHandler(
+		handler,
+		postRequest({
+			intent: 'reveal',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'launcher',
+		}),
+	)
+	expect(revealed.status).toBe(200)
+	const revealBody = (await revealed.json()) as AccountWebhooksActionPayload
+	expect(revealBody.revealed?.url).toBe(mintedUrl)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			category: 'account',
+			action: 'webhook_url_reveal',
+			result: 'success',
+		}),
+	)
+
+	// Mint is first-issue only; an existing mint must go through Rotate so a
+	// stray click cannot silently invalidate the provider's URL.
+	const remint = await runHandler(
+		handler,
+		postRequest({
+			intent: 'mint',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'launcher',
+		}),
+	)
+	expect(remint.status).toBe(400)
+	expect(((await remint.json()) as { error: string }).error).toContain('Rotate')
+
+	const disabled = await runHandler(
+		handler,
+		postRequest({
+			intent: 'disable',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'launcher',
+		}),
+	)
+	expect(disabled.status).toBe(200)
+	const disableBody = (await disabled.json()) as AccountWebhooksActionPayload
+	expect(disableBody.revealed).toBeUndefined()
+	expect(
+		disableBody.webhooks.find((webhook) => webhook.name === 'launcher')
+			?.enabled,
+	).toBe(false)
+
+	const rotated = await runHandler(
+		handler,
+		postRequest({
+			intent: 'rotate',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'launcher',
+		}),
+	)
+	expect(rotated.status).toBe(200)
+	const rotateBody = (await rotated.json()) as AccountWebhooksActionPayload
+	expect(rotateBody.revealed?.url).not.toBe(mintedUrl)
+	expect(rotateBody.revealed?.handle).toBe(mintBody.revealed?.handle)
+	const rotatedLauncher = rotateBody.webhooks.find(
+		(webhook) => webhook.name === 'launcher',
+	)!
+	// Rotate keeps the disabled state; only Enable flips it back.
+	expect(rotatedLauncher.enabled).toBe(false)
+
+	const enabled = await runHandler(
+		handler,
+		postRequest({
+			intent: 'enable',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'launcher',
+		}),
+	)
+	expect(enabled.status).toBe(200)
+	expect(
+		((await enabled.json()) as AccountWebhooksActionPayload).webhooks.find(
+			(webhook) => webhook.name === 'launcher',
+		)?.enabled,
+	).toBe(true)
+
+	const stored = await db
+		.prepare(
+			`SELECT url_secret_encrypted FROM webhook_endpoints
+			WHERE user_id = ? AND package_id = 'pkg-1' AND webhook_name = 'launcher'`,
+		)
+		.bind(userId)
+		.first<{ url_secret_encrypted: string | null }>()
+	expect(stored?.url_secret_encrypted).toBeTruthy()
+
+	// Legacy mints without a recoverable secret list as such and refuse reveal
+	// with a message that points at Rotate.
+	await db
+		.prepare(
+			`UPDATE webhook_endpoints SET url_secret_encrypted = NULL
+			WHERE user_id = ? AND package_id = 'pkg-1' AND webhook_name = 'launcher'`,
+		)
+		.bind(userId)
+		.run()
+	const legacyList = (await (
+		await runHandler(handler, getRequest())
+	).json()) as AccountWebhooksLoaderData
+	expect(
+		legacyList.webhooks.find((webhook) => webhook.name === 'launcher')
+			?.urlRecoverable,
+	).toBe(false)
+	const legacyReveal = await runHandler(
+		handler,
+		postRequest({
+			intent: 'reveal',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'launcher',
+		}),
+	)
+	expect(legacyReveal.status).toBe(400)
+	expect(((await legacyReveal.json()) as { error: string }).error).toContain(
+		'not recoverable',
+	)
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			action: 'webhook_url_reveal',
+			result: 'failure',
+		}),
+	)
+})
+
+test('account webhooks API rejects unknown webhooks, bad bodies, and anonymous callers', async () => {
+	const userId = await createStableUserIdFromEmail('owner@example.com')
+	mockModule.readAuthenticatedAppUser.mockResolvedValue({
+		email: 'owner@example.com',
+		username: 'owner',
+		mcpUser: { userId },
+	})
+	const { env } = createEnv()
+	const handler = createAccountWebhooksApiHandler(env)
+
+	const undeclared = await runHandler(
+		handler,
+		postRequest({
+			intent: 'mint',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'nope',
+		}),
+	)
+	expect(undeclared.status).toBe(400)
+	expect(((await undeclared.json()) as { error: string }).error).toContain(
+		'does not declare webhook',
+	)
+
+	const unminted = await runHandler(
+		handler,
+		postRequest({
+			intent: 'reveal',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'sentry',
+		}),
+	)
+	expect(unminted.status).toBe(400)
+
+	const badIntent = await runHandler(
+		handler,
+		postRequest({
+			intent: 'delete',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'sentry',
+		}),
+	)
+	expect(badIntent.status).toBe(400)
+
+	const blank = await runHandler(
+		handler,
+		postRequest({ intent: 'mint', packageKodyId: ' ', webhookName: 'sentry' }),
+	)
+	expect(blank.status).toBe(400)
+
+	const wrongMethod = await runHandler(
+		handler,
+		new Request(apiUrl, { method: 'DELETE' }),
+	)
+	expect(wrongMethod.status).toBe(405)
+
+	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
+	const unauthorized = await runHandler(handler, getRequest())
+	expect(unauthorized.status).toBe(401)
+})

--- a/packages/worker/src/app/handlers/account-webhooks.node.test.ts
+++ b/packages/worker/src/app/handlers/account-webhooks.node.test.ts
@@ -404,7 +404,7 @@ test('account webhooks API rejects unknown webhooks, bad bodies, and anonymous c
 		username: 'owner',
 		mcpUser: { userId },
 	})
-	const { env } = createEnv()
+	const { env, db } = createEnv()
 	const handler = createAccountWebhooksApiHandler(env)
 
 	const undeclared = await runHandler(
@@ -451,6 +451,33 @@ test('account webhooks API rejects unknown webhooks, bad bodies, and anonymous c
 		new Request(apiUrl, { method: 'DELETE' }),
 	)
 	expect(wrongMethod.status).toBe(405)
+
+	// Infrastructure failures are audited with their detail but reach the
+	// browser only as the generic per-intent message.
+	await db.prepare('DROP TABLE webhook_endpoints').run()
+	const consoleError = vi
+		.spyOn(console, 'error')
+		.mockImplementation(() => undefined)
+	const broken = await runHandler(
+		handler,
+		postRequest({
+			intent: 'mint',
+			packageKodyId: 'sentry-bridge',
+			webhookName: 'sentry',
+		}),
+	)
+	consoleError.mockRestore()
+	expect(broken.status).toBe(500)
+	const brokenBody = (await broken.json()) as { error: string }
+	expect(brokenBody.error).toBe('Unable to mint the webhook URL.')
+	expect(brokenBody.error).not.toContain('no such table')
+	expect(logAuditEventSpy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			action: 'webhook_url_mint',
+			result: 'failure',
+			reason: expect.stringContaining('no such table'),
+		}),
+	)
 
 	mockModule.readAuthenticatedAppUser.mockResolvedValue(null)
 	const unauthorized = await runHandler(handler, getRequest())

--- a/packages/worker/src/app/handlers/account-webhooks.ts
+++ b/packages/worker/src/app/handlers/account-webhooks.ts
@@ -1,0 +1,288 @@
+import { type Action } from 'remix/router'
+import { enum_, object, parseSafe, string } from 'remix/data-schema'
+import {
+	accountWebhookItemId,
+	loadAccountWebhooksData,
+	type AccountWebhooksUser,
+} from '#app/account-webhooks-data.ts'
+import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
+import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { renderAppPage } from '#app/ssr-render.tsx'
+import {
+	auditDatabaseFromEnv,
+	getRequestIp,
+	logAuditEvent,
+} from '#worker/audit-log.ts'
+import { jsonResponse } from '#worker/json-response.ts'
+import {
+	isWebhookUrlMinted,
+	mintWebhookUrlForUser,
+	revealWebhookUrlForWebsite,
+	rotateWebhookUrlForUser,
+	setWebhookEnabledForUser,
+} from '#worker/webhooks/service.ts'
+import {
+	type AccountWebhookRevealedUrl,
+	type AccountWebhooksActionPayload,
+} from '#universal/loader-data.ts'
+import { type routes } from '#universal/routes.ts'
+
+const webhookActionIntents = [
+	'mint',
+	'rotate',
+	'reveal',
+	'enable',
+	'disable',
+] as const
+
+type WebhookActionIntent = (typeof webhookActionIntents)[number]
+
+const webhookActionSchema = object({
+	intent: enum_(webhookActionIntents),
+	packageKodyId: string(),
+	webhookName: string(),
+})
+
+type AuthenticatedUser = AccountWebhooksUser &
+	Pick<
+		NonNullable<Awaited<ReturnType<typeof readAuthenticatedAppUser>>>,
+		'email'
+	>
+
+/**
+ * Page handler for `/account/webhooks` and
+ * `/account/webhooks/:packageKodyId/:webhookName`.
+ */
+export function createAccountWebhooksHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request }) {
+			const user = await requireAuthenticatedPageUser(request, env)
+			if (user instanceof Response) {
+				return user
+			}
+			const accountWebhooks = await loadAccountWebhooksData({
+				env,
+				requestUrl: request.url,
+				user,
+			})
+			return renderAppPage({
+				request,
+				env,
+				title: 'Webhooks',
+				loaderData: { accountWebhooks },
+			})
+		},
+	} satisfies Action<
+		typeof routes.accountWebhooks | typeof routes.accountWebhookDetail
+	>
+}
+
+/**
+ * JSON API for `/account/webhooks.json`: GET lists declared webhooks with
+ * minted state; POST mints, rotates, reveals, enables, or disables one.
+ *
+ * `reveal` (and the reveal that rides along with mint / rotate) is the only
+ * place the credential URL leaves the server. It is owner-session gated and
+ * audited; the MCP `webhooks` capabilities never return it.
+ */
+export function createAccountWebhooksApiHandler(env: Env) {
+	return {
+		middleware: [],
+		async handler({ request, url }) {
+			const user = await readAuthenticatedAppUser(request, env)
+			if (!user) {
+				return jsonResponse({ ok: false, error: 'Unauthorized.' }, 401)
+			}
+
+			if (request.method === 'GET') {
+				return jsonResponse(
+					await loadAccountWebhooksData({
+						env,
+						requestUrl: request.url,
+						user,
+					}),
+				)
+			}
+
+			if (request.method !== 'POST') {
+				return jsonResponse({ ok: false, error: 'Method not allowed.' }, 405)
+			}
+
+			const body = await request.json().catch(() => null)
+			const parsed = parseSafe(webhookActionSchema, body)
+			if (!parsed.success) {
+				return jsonResponse({ ok: false, error: 'Invalid request body.' }, 400)
+			}
+			const packageKodyId = parsed.value.packageKodyId.trim()
+			const webhookName = parsed.value.webhookName.trim()
+			if (!packageKodyId || !webhookName) {
+				return jsonResponse(
+					{ ok: false, error: 'packageKodyId and webhookName are required.' },
+					400,
+				)
+			}
+
+			const intent = parsed.value.intent
+			const audit = (result: 'success' | 'failure', reason?: string) => {
+				void logAuditEvent({
+					db: auditDatabaseFromEnv(env),
+					category: 'account',
+					action: auditActionFor(intent),
+					result,
+					email: user.email,
+					ip: getRequestIp(request) ?? undefined,
+					path: url.pathname,
+					reason: [
+						`package=${packageKodyId}`,
+						`webhook=${webhookName}`,
+						...(reason ? [reason] : []),
+					].join(' '),
+				})
+			}
+
+			try {
+				const revealed = await runWebhookAction({
+					env,
+					request,
+					user,
+					intent,
+					packageKodyId,
+					webhookName,
+				})
+				audit('success')
+				const payload: AccountWebhooksActionPayload = {
+					...(await loadAccountWebhooksData({
+						env,
+						requestUrl: request.url,
+						user,
+					})),
+					...(revealed ? { revealed } : {}),
+				}
+				return jsonResponse(payload)
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : failureMessageFor(intent)
+				audit('failure', message)
+				return jsonResponse({ ok: false, error: message }, 400)
+			}
+		},
+	} satisfies Action<typeof routes.accountWebhooksApi>
+}
+
+async function runWebhookAction(input: {
+	env: Env
+	request: Request
+	user: AuthenticatedUser
+	intent: WebhookActionIntent
+	packageKodyId: string
+	webhookName: string
+}): Promise<AccountWebhookRevealedUrl | null> {
+	const { env, request, user, intent, packageKodyId, webhookName } = input
+	const shared = {
+		env,
+		userId: user.mcpUser.userId,
+		email: user.email,
+		username: user.username,
+		kodyId: packageKodyId,
+		webhookName,
+		requestUrl: request.url,
+	}
+	switch (intent) {
+		case 'mint': {
+			// Mint on an existing row would silently rotate (and re-enable) the
+			// credential; make the owner choose Rotate for that.
+			if (await isWebhookUrlMinted(shared)) {
+				throw new Error(
+					'This webhook already has a URL. Rotate it to issue a new one.',
+				)
+			}
+			await mintWebhookUrlForUser(shared)
+			return revealForUi({ ...shared, packageKodyId })
+		}
+		case 'rotate': {
+			await rotateWebhookUrlForUser(shared)
+			return revealForUi({ ...shared, packageKodyId })
+		}
+		case 'reveal': {
+			return revealForUi({ ...shared, packageKodyId })
+		}
+		case 'enable': {
+			await setWebhookEnabledForUser({ ...shared, enabled: true })
+			return null
+		}
+		case 'disable': {
+			await setWebhookEnabledForUser({ ...shared, enabled: false })
+			return null
+		}
+		default: {
+			const exhaustive: never = intent
+			throw new Error(`Unhandled webhook intent: ${String(exhaustive)}`)
+		}
+	}
+}
+
+async function revealForUi(input: {
+	env: Env
+	userId: string
+	email: string
+	username: string
+	packageKodyId: string
+	webhookName: string
+	requestUrl: string
+}): Promise<AccountWebhookRevealedUrl> {
+	const revealed = await revealWebhookUrlForWebsite({
+		env: input.env,
+		userId: input.userId,
+		email: input.email,
+		username: input.username,
+		requestUrl: input.requestUrl,
+		target: { kodyId: input.packageKodyId, webhookName: input.webhookName },
+	})
+	return {
+		id: accountWebhookItemId({
+			packageKodyId: input.packageKodyId,
+			name: input.webhookName,
+		}),
+		handle: revealed.handle,
+		url: revealed.url,
+	}
+}
+
+function auditActionFor(intent: WebhookActionIntent) {
+	switch (intent) {
+		case 'mint':
+			return 'webhook_url_mint'
+		case 'rotate':
+			return 'webhook_url_rotate'
+		case 'reveal':
+			return 'webhook_url_reveal'
+		case 'enable':
+			return 'webhook_enable'
+		case 'disable':
+			return 'webhook_disable'
+		default: {
+			const exhaustive: never = intent
+			return String(exhaustive)
+		}
+	}
+}
+
+function failureMessageFor(intent: WebhookActionIntent) {
+	switch (intent) {
+		case 'mint':
+			return 'Unable to mint the webhook URL.'
+		case 'rotate':
+			return 'Unable to rotate the webhook URL.'
+		case 'reveal':
+			return 'Unable to reveal the webhook URL.'
+		case 'enable':
+			return 'Unable to enable the webhook.'
+		case 'disable':
+			return 'Unable to disable the webhook.'
+		default: {
+			const exhaustive: never = intent
+			return String(exhaustive)
+		}
+	}
+}

--- a/packages/worker/src/app/handlers/account-webhooks.ts
+++ b/packages/worker/src/app/handlers/account-webhooks.ts
@@ -7,6 +7,7 @@ import {
 } from '#app/account-webhooks-data.ts'
 import { readAuthenticatedAppUser } from '#app/authenticated-user.ts'
 import { requireAuthenticatedPageUser } from '#app/page-auth.ts'
+import { isMcpCallerError, McpCallerError } from '#mcp/caller-error.ts'
 import { renderAppPage } from '#app/ssr-render.tsx'
 import {
 	auditDatabaseFromEnv,
@@ -161,10 +162,25 @@ export function createAccountWebhooksApiHandler(env: Env) {
 				}
 				return jsonResponse(payload)
 			} catch (error) {
-				const message =
+				const detail =
 					error instanceof Error ? error.message : failureMessageFor(intent)
-				audit('failure', message)
-				return jsonResponse({ ok: false, error: message }, 400)
+				audit('failure', detail)
+				// Caller mistakes (unknown package, undeclared webhook, not minted,
+				// legacy secret) carry safe messages. Anything else is an
+				// infrastructure failure whose text must not reach the browser.
+				if (isMcpCallerError(error)) {
+					return jsonResponse({ ok: false, error: detail }, 400)
+				}
+				console.error('account webhooks action failed', {
+					intent,
+					packageKodyId,
+					webhookName,
+					error,
+				})
+				return jsonResponse(
+					{ ok: false, error: failureMessageFor(intent) },
+					500,
+				)
 			}
 		},
 	} satisfies Action<typeof routes.accountWebhooksApi>
@@ -193,7 +209,7 @@ async function runWebhookAction(input: {
 			// Mint on an existing row would silently rotate (and re-enable) the
 			// credential; make the owner choose Rotate for that.
 			if (await isWebhookUrlMinted(shared)) {
-				throw new Error(
+				throw new McpCallerError(
 					'This webhook already has a URL. Rotate it to issue a new one.',
 				)
 			}

--- a/packages/worker/src/app/router.ts
+++ b/packages/worker/src/app/router.ts
@@ -80,6 +80,10 @@ import {
 	createAccountWorkflowsHandler,
 } from '#app/handlers/account-workflows.ts'
 import {
+	createAccountWebhooksApiHandler,
+	createAccountWebhooksHandler,
+} from '#app/handlers/account-webhooks.ts'
+import {
 	createAccountMcpServersApiHandler,
 	createAccountMcpServersHandler,
 	createAccountMcpServersOauthCallbackHandler,
@@ -470,6 +474,10 @@ export function createAppRouter(env: Env) {
 			accountWorkflowDetail: createAccountWorkflowsHandler(env),
 			accountWorkflowsApi: createAccountWorkflowsApiHandler(env),
 			accountWorkflowsApiPost: createAccountWorkflowsApiHandler(env),
+			accountWebhooks: createAccountWebhooksHandler(env),
+			accountWebhookDetail: createAccountWebhooksHandler(env),
+			accountWebhooksApi: createAccountWebhooksApiHandler(env),
+			accountWebhooksApiPost: createAccountWebhooksApiHandler(env),
 			accountActivity: createAccountActivityHandler(env),
 			accountActivityDetail: createAccountActivityHandler(env),
 			accountActivityApi: createAccountActivityApiHandler(env),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -12,7 +12,6 @@ import { createAccountPasskeysHandler } from '#app/handlers/account-passkeys.ts'
 import { createAccountMcpOauthClientsHandler } from '#app/handlers/account-mcp-oauth-clients.ts'
 import { createAccountTwoFactorHandler } from '#app/handlers/account-two-factor.ts'
 import { createAccountWaitingHandler } from '#app/handlers/account-waiting.ts'
-import { createAccountWebhooksHandler } from '#app/handlers/account-webhooks.ts'
 import { createCommunityHandler } from '#app/handlers/community.tsx'
 import {
 	createCommunityDetailHandler,
@@ -567,30 +566,6 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		}),
 	)
 	expect(unknownAgentResponse.status).toBe(404)
-
-	// The Webhooks page embeds the declared-webhook list (empty here: the
-	// fixture owns no packages) and never a credential URL.
-	const webhooksResponse = await runHtmlHandler(
-		createAccountWebhooksHandler(env),
-		new Request('https://example.com/account/webhooks', {
-			headers: { Cookie: accountCookie },
-		}),
-	)
-	expect(webhooksResponse.status).toBe(200)
-	const webhooksHtml = await readResponseText(webhooksResponse)
-	expect(webhooksHtml).toContain('<title>Webhooks')
-	expect(webhooksHtml).toContain('>Webhooks</h1>')
-	expect(webhooksHtml).toMatch(
-		/href="\/account\/webhooks"[^>]*aria-current="page"/,
-	)
-	expect(webhooksHtml).toContain('aria-label="Webhooks"')
-	expect(webhooksHtml).toContain('data-entity-explainer="webhooks"')
-	expect(webhooksHtml).toContain('declares a webhook yet')
-	expect(readAppRootProps(webhooksHtml).loaderData?.accountWebhooks).toEqual({
-		ok: true,
-		username: 'account-user',
-		webhooks: [],
-	})
 
 	const mcpOauthClientsResponse = await runHtmlHandler(
 		createAccountMcpOauthClientsHandler(env),

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -12,6 +12,7 @@ import { createAccountPasskeysHandler } from '#app/handlers/account-passkeys.ts'
 import { createAccountMcpOauthClientsHandler } from '#app/handlers/account-mcp-oauth-clients.ts'
 import { createAccountTwoFactorHandler } from '#app/handlers/account-two-factor.ts'
 import { createAccountWaitingHandler } from '#app/handlers/account-waiting.ts'
+import { createAccountWebhooksHandler } from '#app/handlers/account-webhooks.ts'
 import { createCommunityHandler } from '#app/handlers/community.tsx'
 import {
 	createCommunityDetailHandler,
@@ -566,6 +567,30 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 		}),
 	)
 	expect(unknownAgentResponse.status).toBe(404)
+
+	// The Webhooks page embeds the declared-webhook list (empty here: the
+	// fixture owns no packages) and never a credential URL.
+	const webhooksResponse = await runHtmlHandler(
+		createAccountWebhooksHandler(env),
+		new Request('https://example.com/account/webhooks', {
+			headers: { Cookie: accountCookie },
+		}),
+	)
+	expect(webhooksResponse.status).toBe(200)
+	const webhooksHtml = await readResponseText(webhooksResponse)
+	expect(webhooksHtml).toContain('<title>Webhooks')
+	expect(webhooksHtml).toContain('>Webhooks</h1>')
+	expect(webhooksHtml).toMatch(
+		/href="\/account\/webhooks"[^>]*aria-current="page"/,
+	)
+	expect(webhooksHtml).toContain('aria-label="Webhooks"')
+	expect(webhooksHtml).toContain('data-entity-explainer="webhooks"')
+	expect(webhooksHtml).toContain('declares a webhook yet')
+	expect(readAppRootProps(webhooksHtml).loaderData?.accountWebhooks).toEqual({
+		ok: true,
+		username: 'account-user',
+		webhooks: [],
+	})
 
 	const mcpOauthClientsResponse = await runHtmlHandler(
 		createAccountMcpOauthClientsHandler(env),

--- a/packages/worker/src/webhooks/apply.node.test.ts
+++ b/packages/worker/src/webhooks/apply.node.test.ts
@@ -170,7 +170,7 @@ test('webhookUrlApply registers a GitHub hook from a handle without exposing the
 		env,
 		userId,
 		username: 'owner',
-		handle: minted.handle,
+		target: { handle: minted.handle },
 	})
 	mockGithubIntegration()
 

--- a/packages/worker/src/webhooks/service.node.test.ts
+++ b/packages/worker/src/webhooks/service.node.test.ts
@@ -146,6 +146,7 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	})
 	expect(listedBefore).toHaveLength(1)
 	expect(listedBefore[0]?.minted).toBe(false)
+	expect(listedBefore[0]?.urlRecoverable).toBe(false)
 	expect(listedBefore[0]?.verification?.secretName).toBe('sentryWebhookSecret')
 	expect(listedBefore[0]?.inputMode).toBe('request')
 	expect(listedBefore[0]?.rateLimitPerMinute).toBe(60)
@@ -168,10 +169,20 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 		env,
 		userId,
 		username: 'owner',
-		handle: minted.handle,
+		target: { handle: minted.handle },
 	})
 	expect(revealed.url).toContain('/@owner/webhooks/sentry-bridge/sentry/')
 	expect(revealed.urlHost).toBe('heykody.dev')
+	// The account UI addresses a webhook by package + name rather than by
+	// handle; both paths resolve the same minted URL.
+	const revealedByName = await revealWebhookUrlForWebsite({
+		env,
+		userId,
+		username: 'owner',
+		target: { kodyId: 'sentry-bridge', webhookName: 'sentry' },
+	})
+	expect(revealedByName.url).toBe(revealed.url)
+	expect(revealedByName.handle).toBe(minted.handle)
 
 	const listed = await listWebhooksForUser({
 		env,
@@ -182,6 +193,7 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	expect(listed[0]?.enabled).toBe(true)
 	expect(listed[0]?.handle).toBe(minted.handle)
 	expect(listed[0]?.urlHost).toBe('heykody.dev')
+	expect(listed[0]?.urlRecoverable).toBe(true)
 	expect(listed[0]).not.toHaveProperty('url')
 	expect(JSON.stringify(listed)).not.toContain(revealed.url)
 	expect(JSON.stringify(listed)).not.toContain(

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -109,7 +109,7 @@ async function resolveOwnedPackage(input: {
 }): Promise<SavedPackageRecord> {
 	const packageIdOrKodyId = (input.packageId ?? input.kodyId ?? '').trim()
 	if (!packageIdOrKodyId) {
-		throw new Error('packageId or kodyId is required.')
+		throw new McpCallerError('packageId or kodyId is required.')
 	}
 	const savedPackage = await resolveSavedPackage({
 		db: input.db,
@@ -117,7 +117,7 @@ async function resolveOwnedPackage(input: {
 		packageIdOrKodyId,
 	})
 	if (!savedPackage) {
-		throw new Error(
+		throw new McpCallerError(
 			`Saved package "${packageIdOrKodyId}" was not found for this user.`,
 		)
 	}
@@ -141,7 +141,7 @@ async function loadDeclaredWebhook(input: {
 		(webhook) => webhook.name === input.webhookName,
 	)
 	if (!declared) {
-		throw new Error(
+		throw new McpCallerError(
 			`Package "${input.savedPackage.kodyId}" does not declare webhook "${input.webhookName}".`,
 		)
 	}
@@ -235,7 +235,7 @@ export async function mintWebhookUrlForUser(input: {
 	activate?: boolean
 }): Promise<MintedWebhookHandle> {
 	const webhookName = input.webhookName.trim()
-	if (!webhookName) throw new Error('webhookName is required.')
+	if (!webhookName) throw new McpCallerError('webhookName is required.')
 	const activate = input.activate !== false
 	const baseUrl = getAppBaseUrl({
 		env: input.env,
@@ -326,7 +326,7 @@ export async function isWebhookUrlMinted(input: {
 	webhookName: string
 }) {
 	const webhookName = input.webhookName.trim()
-	if (!webhookName) throw new Error('webhookName is required.')
+	if (!webhookName) throw new McpCallerError('webhookName is required.')
 	const savedPackage = await resolveOwnedPackage({
 		db: input.env.APP_DB,
 		userId: input.userId,
@@ -353,7 +353,7 @@ export async function rotateWebhookUrlForUser(input: {
 	requestUrl?: string | null
 }): Promise<MintedWebhookHandle> {
 	const webhookName = input.webhookName.trim()
-	if (!webhookName) throw new Error('webhookName is required.')
+	if (!webhookName) throw new McpCallerError('webhookName is required.')
 	const savedPackage = await resolveOwnedPackage({
 		db: input.env.APP_DB,
 		userId: input.userId,
@@ -367,7 +367,7 @@ export async function rotateWebhookUrlForUser(input: {
 		webhookName,
 	})
 	if (!existing) {
-		throw new Error(
+		throw new McpCallerError(
 			'Webhook URL has not been minted. Call webhookUrlMint first.',
 		)
 	}
@@ -386,7 +386,7 @@ export async function setWebhookEnabledForUser(input: {
 	enabled: boolean
 }): Promise<WebhookEndpointRecord> {
 	const webhookName = input.webhookName.trim()
-	if (!webhookName) throw new Error('webhookName is required.')
+	if (!webhookName) throw new McpCallerError('webhookName is required.')
 	const savedPackage = await resolveOwnedPackage({
 		db: input.env.APP_DB,
 		userId: input.userId,
@@ -401,7 +401,7 @@ export async function setWebhookEnabledForUser(input: {
 		enabled: input.enabled,
 	})
 	if (!updated) {
-		throw new Error(
+		throw new McpCallerError(
 			'Webhook URL has not been minted. Call webhookUrlMint first.',
 		)
 	}
@@ -517,7 +517,7 @@ async function resolveRevealHandle(input: {
 }) {
 	if ('handle' in input.target) return input.target.handle
 	const webhookName = input.target.webhookName.trim()
-	if (!webhookName) throw new Error('webhookName is required.')
+	if (!webhookName) throw new McpCallerError('webhookName is required.')
 	const savedPackage = await resolveOwnedPackage({
 		db: input.db,
 		userId: input.userId,
@@ -531,7 +531,7 @@ async function resolveRevealHandle(input: {
 		webhookName,
 	})
 	if (!existing) {
-		throw new Error('Webhook URL has not been minted yet.')
+		throw new McpCallerError('Webhook URL has not been minted yet.')
 	}
 	return formatWebhookUrlHandle(existing.id)
 }

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -57,6 +57,11 @@ export type ListedWebhook = {
 	handle: string | null
 	urlHost: string | null
 	enabled: boolean | null
+	/**
+	 * False for mints that predate encrypted secret storage: the hash alone
+	 * cannot rebuild the URL, so apply / reveal need a rotate first.
+	 */
+	urlRecoverable: boolean
 	createdAt: string | null
 	rotatedAt: string | null
 }
@@ -203,6 +208,7 @@ export async function listWebhooksForUser(input: {
 				handle: mint ? formatWebhookUrlHandle(mint.id) : null,
 				urlHost: mint ? urlHost : null,
 				enabled: mint?.enabled ?? null,
+				urlRecoverable: mint?.urlSecretEncrypted != null,
 				createdAt: mint?.createdAt ?? null,
 				rotatedAt: mint?.rotatedAt ?? null,
 			})
@@ -309,6 +315,31 @@ export async function mintWebhookUrlForUser(input: {
 		createdAt: stored.createdAt,
 		rotatedAt: stored.rotatedAt,
 	}
+}
+
+/** Whether a URL secret already exists for this declared webhook. */
+export async function isWebhookUrlMinted(input: {
+	env: Env
+	userId: string
+	packageId?: string
+	kodyId?: string
+	webhookName: string
+}) {
+	const webhookName = input.webhookName.trim()
+	if (!webhookName) throw new Error('webhookName is required.')
+	const savedPackage = await resolveOwnedPackage({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		packageId: input.packageId,
+		kodyId: input.kodyId,
+	})
+	const existing = await getWebhookEndpointByKey({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		packageId: savedPackage.id,
+		webhookName,
+	})
+	return existing !== null
 }
 
 export async function rotateWebhookUrlForUser(input: {
@@ -475,18 +506,55 @@ export async function applyWebhookUrlForUser(input: {
 	})
 }
 
+type WebhookUrlRevealTarget =
+	| { handle: string }
+	| { packageId?: string; kodyId?: string; webhookName: string }
+
+async function resolveRevealHandle(input: {
+	db: D1Database
+	userId: string
+	target: WebhookUrlRevealTarget
+}) {
+	if ('handle' in input.target) return input.target.handle
+	const webhookName = input.target.webhookName.trim()
+	if (!webhookName) throw new Error('webhookName is required.')
+	const savedPackage = await resolveOwnedPackage({
+		db: input.db,
+		userId: input.userId,
+		packageId: input.target.packageId,
+		kodyId: input.target.kodyId,
+	})
+	const existing = await getWebhookEndpointByKey({
+		db: input.db,
+		userId: input.userId,
+		packageId: savedPackage.id,
+		webhookName,
+	})
+	if (!existing) {
+		throw new Error('Webhook URL has not been minted yet.')
+	}
+	return formatWebhookUrlHandle(existing.id)
+}
+
 /**
- * Website-only debug reveal. Do not expose this through MCP or execute.
+ * Owner-only reveal for the signed-in account UI (`/account/webhooks`). The
+ * credential URL is the human path: do not expose this through MCP or
+ * execute, and do not return it from mint / rotate / list capabilities.
  */
 export async function revealWebhookUrlForWebsite(input: {
 	env: Env
 	userId: string
 	email?: string | null
 	username?: string | null
-	handle: string
+	target: WebhookUrlRevealTarget
 	requestUrl?: string | null
 }) {
-	const resolved = await resolveMintedWebhookUrl(input)
+	const handle = await resolveRevealHandle({
+		db: input.env.APP_DB,
+		userId: input.userId,
+		target: input.target,
+	})
+	const resolved = await resolveMintedWebhookUrl({ ...input, handle })
 	return {
 		handle: formatWebhookUrlHandle(resolved.endpoint.id),
 		urlHost: resolved.urlHost,

--- a/packages/worker/universal/document-head.ts
+++ b/packages/worker/universal/document-head.ts
@@ -223,6 +223,8 @@ const routeDocumentHeads = {
 	[routePattern(routes.accountJobDetail)]: titleOnly('Jobs'),
 	[routePattern(routes.accountWorkflows)]: titleOnly('Workflows'),
 	[routePattern(routes.accountWorkflowDetail)]: titleOnly('Workflows'),
+	[routePattern(routes.accountWebhooks)]: titleOnly('Webhooks'),
+	[routePattern(routes.accountWebhookDetail)]: titleOnly('Webhooks'),
 	[routePattern(routes.accountActivity)]: titleOnly('Activity'),
 	[routePattern(routes.accountActivityDetail)]: titleOnly('Activity'),
 	[routePattern(routes.accountMemories)]: titleOnly('Memories'),

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1176,6 +1176,77 @@ export type AccountConnectedAgentsLoaderData = {
 	mcpServerUrl: string
 }
 
+type AccountWebhookVerification = {
+	type: 'hmac-sha256' | 'hmac-sha1'
+	header: string
+	secretName: string
+	encoding: 'hex' | 'base64'
+	prefix?: string
+	signedPayload?: 'body' | 'timestamp.body'
+} | null
+
+type AccountWebhookReplay = {
+	timestampHeader?: string
+	timestampFormat?:
+		| 'unix-seconds'
+		| 'unix-millis'
+		| 'iso-8601'
+		| 'stripe-signature'
+	toleranceSeconds?: number
+	deliveryIdHeader?: string
+} | null
+
+/**
+ * One declared package webhook joined with its minted URL state. Never
+ * carries the credential URL or `url_secret`: the page fetches those on
+ * demand through the `reveal` intent so they are not embedded in SSR HTML
+ * or the list payload.
+ */
+export type AccountWebhookListItem = {
+	/** `${packageKodyId}/${name}` — the detail route segments. */
+	id: string
+	packageId: string
+	packageKodyId: string
+	packageName: string
+	name: string
+	exportName: string
+	description: string | null
+	responseMode: 'ack' | 'sync'
+	inputMode: 'request' | 'params'
+	rateLimitPerMinute: number
+	verification: AccountWebhookVerification
+	replay: AccountWebhookReplay
+	minted: boolean
+	handle: string | null
+	urlHost: string | null
+	enabled: boolean | null
+	/**
+	 * False for mints that predate encrypted secret storage. The UI offers
+	 * Rotate instead of Reveal for those, since the hash cannot rebuild the
+	 * URL.
+	 */
+	urlRecoverable: boolean
+	createdAt: string | null
+	rotatedAt: string | null
+}
+
+export type AccountWebhooksLoaderData = {
+	ok: true
+	username: string
+	webhooks: Array<AccountWebhookListItem>
+}
+
+/** Owner-only reveal result attached to mint / rotate / reveal responses. */
+export type AccountWebhookRevealedUrl = {
+	id: string
+	handle: string
+	url: string
+}
+
+export type AccountWebhooksActionPayload = AccountWebhooksLoaderData & {
+	revealed?: AccountWebhookRevealedUrl
+}
+
 export type PendingVerificationLoaderData = {
 	ok: true
 	email: string
@@ -2003,6 +2074,7 @@ export type AppLoaderData = {
 	accountProfile?: AccountProfileLoaderData
 	accountConnections?: AccountConnectionsLoaderData
 	accountConnectedAgents?: AccountConnectedAgentsLoaderData
+	accountWebhooks?: AccountWebhooksLoaderData
 	onboarding?: OnboardingLoaderData
 	connectOauth?: ConnectOauthLoaderData
 	pendingVerification?: PendingVerificationLoaderData

--- a/packages/worker/universal/routes.ts
+++ b/packages/worker/universal/routes.ts
@@ -67,6 +67,13 @@ export const routes = route({
 	accountWorkflowDetail: '/account/workflows/:workflowId',
 	accountWorkflowsApi: '/account/workflows.json',
 	accountWorkflowsApiPost: post('/account/workflows.json'),
+	// Owner-only home for minted webhook URLs: list, mint, reveal + copy,
+	// rotate, enable / disable. The credential URL only ever leaves the
+	// server through this page's `reveal` intent, never through MCP.
+	accountWebhooks: '/account/webhooks',
+	accountWebhookDetail: '/account/webhooks/:packageKodyId/:webhookName',
+	accountWebhooksApi: '/account/webhooks.json',
+	accountWebhooksApiPost: post('/account/webhooks.json'),
 	accountActivity: '/account/activity',
 	accountActivityDetail: '/account/activity/:runId',
 	accountActivityApi: '/account/activity.json',

--- a/tools/control-kody/feature-catalog.ts
+++ b/tools/control-kody/feature-catalog.ts
@@ -174,6 +174,13 @@ export const featureCatalog: ReadonlyArray<Feature> = [
 		apis: ['/account/workflows.json'],
 	},
 	{
+		id: 'webhooks',
+		title: 'Webhooks (minted URLs)',
+		file: 'webhooks.md',
+		paths: ['/account/webhooks'],
+		apis: ['/account/webhooks.json'],
+	},
+	{
 		id: 'activity',
 		title: 'Activity',
 		file: 'activity.md',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give the signed-in owner a first-class place to see and manage minted webhook URLs, so the credential URL has a human path without ever becoming an agent-side reveal.

## Why

`webhookUrlMint` / `webhookList` / `webhookUrlApply` deliberately never return the credential URL to agents, and only the GitHub apply adapter can inject it. Any provider without an adapter (Raycast, a launcher, a CLI, Stripe, Sentry) left the owner with no way to read the URL at all. Kent: "I want a UI to see and manage webhook URLs. The agent reveal is probably not good." This PR ships the UI and explicitly does **not** add `webhookUrlReveal`, mint-returns-URL, or an apply→localConfig path for agents.

## Summary

- **`/account/webhooks`** (account rail → Webhooks, between Workflows and Secrets): lists every webhook a saved package declares, joined with minted state (status, mode, verification, handle, minted/rotated timestamps). Rows expand in place (`RecordTable mode="expand"`, decision 0028) at `/account/webhooks/:packageKodyId/:webhookName`.
- Per webhook the owner can **Mint URL** (first issue, URL shown once), **Reveal URL** (copy card with `Copy webhook URL` + `Hide URL`), **Rotate URL** (double-check; previous URL stops working), **Disable** / **Enable**, and jump to `Recent deliveries` in Activity.
- **`GET|POST /account/webhooks.json`** — GET never carries a URL or secret; POST intents `mint`, `rotate`, `reveal` return the refreshed list plus `revealed: { id, handle, url }`, `enable`/`disable` return the list only. Every intent writes an `account` audit event (`webhook_url_mint`, `webhook_url_rotate`, `webhook_url_reveal`, `webhook_enable`, `webhook_disable`). `mint` refuses an already-minted webhook (Rotate instead); `reveal` refuses pre-0057 mints without `url_secret_encrypted` and the page offers Rotate for those (`urlRecoverable: false`). Caller mistakes are `McpCallerError` → 400 with message; any other failure is audited, logged, and answered with a generic per-intent message as 500.
- Client keeps revealed URLs in memory only and drops them on Hide or on navigating to another row; SSR HTML and the loader payload are URL-free.
- Service: `ListedWebhook.urlRecoverable`; `revealWebhookUrlForWebsite` stays website-only and now accepts `target: { handle } | { kodyId | packageId, webhookName }`; new `isWebhookUrlMinted`; caller-facing service errors are `McpCallerError`. MCP `webhooks` domain output is unchanged (the mapper picks fields explicitly).
- Wiring: routes, router, lazy-route preload, document head, account area barrel, entity explainer ("What is a webhook?"), Feature Map entry + `features/webhooks.md`, `primitives.yaml` code roots.
- Docs: `docs/use/webhooks.md` gains "Manage webhook URLs in the account UI" and points non-GitHub providers there; architecture doc gains an "Owner UI" section; triggers guide mentions the page. No agent reveal is documented.

## Testing

- `npm run validate`: format, lint, typecheck, knip, primitives, migrations, docs, mermaid, slop-ratchet, builds, startup all green; `test-node` 961 files / 3115 tests, `test-workers` 96 / 345, `mcp` 3 / 5, `e2e` 17 passed (includes the new Webhooks hop in `account-navigation.spec.ts`). The e2e leg needed the manual Playwright Chromium install documented in `cloud-agents.md`.
- New tests: `handlers/account-webhooks.node.test.ts` (mint → reveal → remint 400 → disable → rotate → enable against a real in-memory `webhook_endpoints` table; GET/list never contain the secret; legacy-mint reveal 400; audit events; page handler embeds the list; 401/405/400 paths; generic 500 on a dropped table), `client/routes/account-webhooks.node.test.ts` (SSR list, detail states for unminted / minted / legacy / not-found, no URL in HTML, two-segment route selection), plus `service.node.test.ts` for reveal-by-name and `urlRecoverable`.
- Manual on the local dev server as `jane@example.com` with a seeded package declaring two webhooks: minted `launcher`, copied the URL (clipboard verified by pasting into the address bar), hid, revealed, rotated (secret changed), disabled, enabled. Audit DB shows the five `webhook_*` events. Recording and screenshots below.

<a href="https://cursor.com/agents/bc-efa25d96-bc35-4056-844b-f0e7a8dc80fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccount_webhooks_mint_copy_hide_reveal_rotate_disable_enable.mp4"><img src="https://cursor.com/artifacts/c/art-d5644fff-1c9f-4ddc-9b8c-5f75387cf41a" alt="account_webhooks_mint_copy_hide_reveal_rotate_disable_enable.mp4" /></a>

![Webhooks list page](https://cursor.com/artifacts/c/art-34aa112b-fa65-4f6f-a03e-dd4fe5e78599)

![Webhook detail with revealed URL and copy button](https://cursor.com/artifacts/c/art-c00e7982-34d0-4c3c-b21a-aa4ae6c821fd)

### Preview manual test (medium risk)

Preview `kody-pr-2262` as the seed user `me@kentcdodds.com` (`user-me`), who starts with no packages:

- Created `@user-me/sentry-bridge` through the real MCP `packageSave` publish path (declares `sentry` with HMAC verification and `launcher` with `inputMode: params`, `rateLimitPerMinute: 600`, `replay.deliveryIdHeader`).
- `GET /account/webhooks.json` lists both, no `url` key. `mint` on `launcher` returned the revealed `https://kody-pr-2262…/@user-me/webhooks/sentry-bridge/launcher/<secret>` plus `whh_…` handle; a second `mint` was 400 ("Rotate it"); the secret never appears in a later GET; `reveal` returned the identical URL; anonymous GET is 401.
- The URL copied from the UI works end to end: `POST` with `Idempotency-Key` + `X-Delivery-Id` ran `./dispatch-launcher` and returned `{ ok: true, result: { params: { hello: "raycast" } } }` (200); a wrong secret is 404; a missing `X-Delivery-Id` is the generic 401.
- UI pass on the preview origin: minted `sentry` from the expanded row, hid and revealed the URL, disabled (status "Disabled") and re-enabled; keyboard: the row link is a normal tab stop after the account rail, Enter expands it, and the panel tabs Package → Copy handle → Reveal URL → Disable → Rotate URL → Recent deliveries, with Enter on Reveal showing the card.

### Review dispositions

- CodeRabbit "return safe responses for unexpected failures" — addressed in `426a7158`: caller mistakes from the webhook service are `McpCallerError` (400 with message); anything else is audited with its detail, logged, and answered with the generic per-intent message as 500. Test covers a dropped table.
- CodeRabbit "await the audit write" — left as `void logAuditEvent(...)`, the convention in every other account handler (connections, connected agents, jobs).
- CodeRabbit "add the detail route to the feature catalog" — `map --check` passes; the catalog lists base paths only, matching Jobs and Workflows.
- Bugbot: no issues.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends webhooks</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e2e42cd9` · **Head:** `426a7158`

**Classification:** extends — the `webhooks` primitive gains an owner-only web surface (`/account/webhooks` + `/account/webhooks.json`) and its service exposes `urlRecoverable` and reveal-by-name. No new primitive, no schema change, no new MCP capability.

### Primitives touched

| Primitive  | Group     | Impact                                                                                                                                                              |
| ---------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `webhooks` | assistant | extends — account page + JSON API (`mint`, `rotate`, `reveal`, `enable`, `disable`), `ListedWebhook.urlRecoverable`, `revealWebhookUrlForWebsite` by package + name |
| `app-ui`   | surfaces  | composes — new account route, rail item, entity explainer, document head, lazy-route preload                                                                        |

### Change flow

The owner mints or reveals a webhook URL from the account page; the credential leaves the server only through that owner-session POST, never through MCP.

```mermaid
sequenceDiagram
	actor Owner
	participant appUi as app-ui
	participant webhooks as webhooks
	participant d1AppDb as d1-app-db
	Owner->>appUi: open /account/webhooks (rail → Webhooks)
	appUi->>webhooks: GET /account/webhooks.json
	webhooks->>d1AppDb: listWebhooksForUser joins manifests with webhook_endpoints
	webhooks-->>appUi: declared list + handle, enabled, urlRecoverable (no URL)
	Owner->>appUi: Mint URL / Reveal URL / Rotate URL
	appUi->>webhooks: POST /account/webhooks.json { intent, packageKodyId, webhookName }
	webhooks->>d1AppDb: mint or rotate writes url_secret_hash and url_secret_encrypted
	webhooks->>webhooks: revealWebhookUrlForWebsite decrypts and rebuilds the ingress URL
	Note over webhooks: account audit event webhook_url_mint / rotate / reveal
	webhooks-->>appUi: refreshed list + revealed { id, handle, url }
	appUi-->>Owner: copy card with Copy webhook URL, Hide URL
	Note over appUi: revealed URL kept in memory only, dropped on Hide or row change
```

### Before / after

| Path                               | Before                                                   | After                                                                            |
| ---------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
| Owner sees a webhook URL           | Only via `webhookUrlApply` → GitHub (no human path)      | `/account/webhooks` → Reveal / Mint / Rotate shows the URL with a copy button    |
| `revealWebhookUrlForWebsite` input | `{ handle }`                                             | `{ target: { handle } \| { kodyId \| packageId, webhookName } }`                 |
| `ListedWebhook`                    | no recoverability signal                                 | `urlRecoverable` (false for pre-0057 mints; page offers Rotate instead)          |
| MCP `webhooks` domain              | handle + `url_host` only                                 | unchanged — still never returns the URL                                          |

### Invariants

- Per-user isolation: every handler call binds `user.mcpUser.userId`; the reveal resolves the package through `resolveSavedPackage` for that user before decrypting.
- Credential containment: the list payload, SSR HTML, and every MCP capability stay URL-free; only the owner-session `reveal` (and the reveal that rides with mint / rotate) returns it, and each is audited.

</details>

<!-- system-recap:end -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efa25d96-bc35-4056-844b-f0e7a8dc80fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efa25d96-bc35-4056-844b-f0e7a8dc80fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an owner-only Webhooks page under Account for viewing and managing inbound webhooks.
  * Added webhook detail views with status, verification, and replay-protection information.
  * Owners can mint, reveal, copy, rotate, enable, and disable webhook URLs with confirmation safeguards.
  * Webhook credentials are revealed only through the account page and excluded from tool output.

* **Documentation**
  * Added guidance for account webhook setup, management, lifecycle actions, and provider configuration.

* **Tests**
  * Added coverage for navigation, webhook actions, access control, URL protection, and legacy states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->