### PR TITLE
Add Iconic icons to account and admin left nav

### DIFF
--- a/packages/worker/client/combobox.tsx
+++ b/packages/worker/client/combobox.tsx
@@ -1,5 +1,6 @@
 import { type Handle, css } from 'remix/ui'
 import * as combobox from 'remix/ui/combobox/primitives'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	colors,
 	radius,
@@ -106,20 +107,9 @@ export function Combobox(handle: Handle<ComboboxProps>) {
 											}),
 										]}
 									>
-										<svg
-											aria-hidden="true"
-											viewBox="0 0 16 16"
-											mix={css(comboboxCheckCss)}
-										>
-											<path
-												d="M3 8.5l3 3 7-7"
-												fill="none"
-												stroke="currentColor"
-												stroke-width="2"
-												stroke-linecap="round"
-												stroke-linejoin="round"
-											/>
-										</svg>
+										<span mix={css(comboboxCheckCss)}>
+											{renderIcon('check', { size: '1rem' })}
+										</span>
 										<span mix={css(comboboxOptionLabelCss)}>
 											{option.label}
 										</span>

--- a/packages/worker/client/markdown-heading-anchor.tsx
+++ b/packages/worker/client/markdown-heading-anchor.tsx
@@ -1,24 +1,9 @@
 import { type RemixNode } from 'remix/ui'
+import { renderIcon } from '#universal/icon.tsx'
 
 /** Decorative link icon for prose heading permalinks. */
 function renderHeadingAnchorIcon() {
-	return (
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			width="16"
-			height="16"
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-			<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-		</svg>
-	)
+	return renderIcon('link', { size: '16' })
 }
 
 const headingPermalinkAriaLabel = 'Link to this section'

--- a/packages/worker/client/package-files-explorer.tsx
+++ b/packages/worker/client/package-files-explorer.tsx
@@ -21,6 +21,7 @@ import {
 } from '#universal/package-files.ts'
 import { directoryOfPackageFilePath } from '#universal/package-readme-images.ts'
 import { renderPackageRepoChrome } from '#universal/package-repo-nav.tsx'
+import { renderIcon } from '#universal/icon.tsx'
 import { type PackageFilesLoaderData } from '#universal/loader-data.ts'
 import {
 	colors,
@@ -502,96 +503,23 @@ function renderFilePreview(
 }
 
 function arrowLeftIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="14"
-			height="14"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M19 12H5" />
-			<path d="m12 19-7-7 7-7" />
-		</svg>
-	)
+	return renderIcon('arrow-left', { size: '14' })
 }
 
 function chevronIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="12"
-			height="12"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2.5"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			aria-hidden="true"
-		>
-			<path d="m9 18 6-6-6-6" />
-		</svg>
-	)
+	return renderIcon('chevron-right', { size: '12' })
 }
 
 function directoryIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="15"
-			height="15"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="1.8"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M4 20V6a1 1 0 0 1 1-1h4.6a1 1 0 0 1 .8.4l1.2 1.6H19a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1Z" />
-		</svg>
-	)
+	return renderIcon('folder', { size: '15' })
 }
 
 function fileIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="15"
-			height="15"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="1.8"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M14 3v5h5" />
-			<path d="M15 3H7a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V6Z" />
-		</svg>
-	)
+	return renderIcon('file', { size: '15' })
 }
 
 function searchIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="14"
-			height="14"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			aria-hidden="true"
-		>
-			<circle cx="11" cy="11" r="7" />
-			<path d="m21 21-4.3-4.3" />
-		</svg>
-	)
+	return renderIcon('search', { size: '14' })
 }
 
 // Same box as the site header (`navCss`): `layoutMaxWidths.extended` centered,

--- a/packages/worker/client/routes/account-connected-agents-panel.tsx
+++ b/packages/worker/client/routes/account-connected-agents-panel.tsx
@@ -15,6 +15,7 @@ import {
 	type AccountConnectedAgentListItem,
 	type AccountConnectedAgentsLoaderData,
 } from '#universal/loader-data.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	colors,
 	radius,
@@ -284,17 +285,7 @@ function ConnectedAgentMark(handle: Handle<{ icon: string | null }>) {
 						color: colors.textMuted,
 					})}
 				>
-					<svg
-						viewBox="0 0 24 24"
-						width="18"
-						height="18"
-						fill="currentColor"
-						aria-hidden="true"
-					>
-						<circle cx="6" cy="12" r="1.6" />
-						<circle cx="12" cy="12" r="1.6" />
-						<circle cx="18" cy="12" r="1.6" />
-					</svg>
+					{renderIcon('dots-horizontal', { size: '18' })}
 				</span>
 			)
 		}

--- a/packages/worker/client/routes/account-connections.node.test.ts
+++ b/packages/worker/client/routes/account-connections.node.test.ts
@@ -86,7 +86,8 @@ test('connections page renders the connected list with Add connection, the MCP U
 	expect(html).not.toContain('Loading connections')
 	// The rail marks this page current and links Packages to the profile.
 	expect(html).toMatch(/href="\/account\/connections"[^>]*aria-current="page"/)
-	expect(html).toMatch(/href="\/@jane"[^>]*>Packages<\/a>/)
+	expect(html).toMatch(/href="\/@jane"[^>]*>[\s\S]*?Packages<\/a>/)
+	expect(html).toContain('data-icon="box"')
 })
 
 test('Add connection shows every named client on every viewport with none greyed or folded away', async () => {

--- a/packages/worker/client/routes/account-connections.node.test.ts
+++ b/packages/worker/client/routes/account-connections.node.test.ts
@@ -247,3 +247,25 @@ test('account rail lists Connections and Packages at the same level as the other
 	)
 	expect(accountPackagesNavHref(null)).toBe('/account/packages')
 })
+
+test('account rail items carry Iconic glyph names', () => {
+	const items = accountNavItemsFor({ username: 'jane', showShared: true })
+	expect(items.map((item) => [item.label, item.icon])).toEqual([
+		['Overview', 'home'],
+		['Waiting', 'clock'],
+		['Connections', 'link'],
+		['Packages', 'box'],
+		['Shared', 'share'],
+		['Billing', 'wallet'],
+		['Usage', 'chart'],
+		['Activity', 'trending-up'],
+		['Jobs', 'briefcase'],
+		['Workflows', 'refresh'],
+		['Webhooks', 'cloud'],
+		['Secrets', 'key'],
+		['Integrations', 'plug'],
+		['MCP servers', 'server'],
+		['Memories', 'book'],
+		['Email', 'mail'],
+	])
+})

--- a/packages/worker/client/routes/account-integrations-detail.tsx
+++ b/packages/worker/client/routes/account-integrations-detail.tsx
@@ -7,6 +7,7 @@ import { type RemixNode, css } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { type createDoubleCheck } from '#client/double-check.ts'
 import { ProviderMark } from '#client/provider-icons.tsx'
+import { renderIcon } from '#universal/icon.tsx'
 import { accountDisclosureCss } from '#client/routes/account-management-components.tsx'
 import { recordBodyCss, recordCellClamp } from '#client/routes/record-table.tsx'
 import {
@@ -74,22 +75,7 @@ function renderIntegrationDetail(label: string, value: string) {
 }
 
 function BuiltInIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="100%"
-			height="100%"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="1.5"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<path d="M15 13.25C17.3472 13.25 19.25 11.3472 19.25 9C19.25 6.65279 17.3472 4.75 15 4.75C12.6528 4.75 10.75 6.65279 10.75 9C10.75 9.31012 10.7832 9.61248 10.8463 9.90372L4.75 16V19.25H8L8.75 18.5V16.75H10.5L11.75 15.5V13.75H13.5L14.0963 13.1537C14.3875 13.2168 14.6899 13.25 15 13.25Z" />
-			<path d="M16.5 8C16.5 8.27614 16.2761 8.5 16 8.5C15.7239 8.5 15.5 8.27614 15.5 8C15.5 7.72386 15.7239 7.5 16 7.5C16.2761 7.5 16.5 7.72386 16.5 8Z" />
-		</svg>
-	)
+	return renderIcon('key', { size: '100%' })
 }
 
 function renderBuiltInIndicator(input?: { tooltipId?: string }) {

--- a/packages/worker/client/routes/account-integrations-sections.tsx
+++ b/packages/worker/client/routes/account-integrations-sections.tsx
@@ -5,6 +5,7 @@ import { css } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { on } from '#client/event-mixin.ts'
 import { ProviderIcon } from '#client/provider-icons.tsx'
+import { renderIcon } from '#universal/icon.tsx'
 import { renderByokExplainer } from '#client/routes/byok-explainer.tsx'
 import { recordBodyCss } from '#client/routes/record-table.tsx'
 import {
@@ -35,24 +36,7 @@ const providerCatalogGridCss = {
 }
 
 function PlugIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1.25em"
-			height="1.25em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<path d="M12 22v-5" />
-			<path d="M9 8V2" />
-			<path d="M15 8V2" />
-			<path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
-		</svg>
-	)
+	return renderIcon('plug', { size: '1.25em' })
 }
 
 export function renderApprovalCard(props: {

--- a/packages/worker/client/routes/account-management-components.tsx
+++ b/packages/worker/client/routes/account-management-components.tsx
@@ -20,9 +20,9 @@ import { readAppSession } from '#client/app-session-context.tsx'
 import { isFeatureFlagEnabled } from '#client/feature-flags.ts'
 import { renderRoutePendingStatus } from '#client/route-data.tsx'
 import { packageShareGrantsFlagKey } from '#universal/feature-flags/registry.ts'
+import { type IconName } from '#universal/icon.tsx'
 import { EntityExplainer, resolveEntityExplainer } from './entity-explainer.tsx'
 import {
-	AccountManagementInlineLinkNav,
 	AccountManagementLinkNav,
 	accountManagementNarrowMq,
 } from './account-management-link-nav.tsx'
@@ -295,55 +295,84 @@ export function AccountManagementHeader(
 }
 
 const adminNavItems = [
-	{ href: '/admin/users', label: 'Users', paths: ['/admin', '/admin/users'] },
-	{ href: '/admin/insights', label: 'Insights', paths: ['/admin/insights'] },
+	{
+		href: '/admin/users',
+		label: 'Users',
+		icon: 'users',
+		paths: ['/admin', '/admin/users'],
+	},
+	{
+		href: '/admin/insights',
+		label: 'Insights',
+		icon: 'pie-chart',
+		paths: ['/admin/insights'],
+	},
 	{
 		href: '/admin/reserved-usernames',
 		label: 'Reserved usernames',
+		icon: 'user-cross',
 		paths: ['/admin/reserved-usernames'],
 	},
 	{
 		href: '/admin/feature-flags',
 		label: 'Feature flags',
+		icon: 'flag',
 		paths: ['/admin/feature-flags'],
 	},
 	{
 		href: '/admin/banners',
 		label: 'Banners',
+		icon: 'announcement',
 		paths: ['/admin/banners'],
 	},
 	{
 		href: '/admin/platform-integrations',
 		label: 'Platform integrations',
+		icon: 'globe',
 		paths: ['/admin/platform-integrations'],
 	},
 	{
 		href: '/admin/provider-marks',
 		label: 'Provider marks',
+		icon: 'photo',
 		paths: ['/admin/provider-marks'],
 	},
 	{
 		href: '/admin/codemods',
 		label: 'Codemods',
+		icon: 'code',
 		paths: ['/admin/codemods'],
 	},
-	{ href: '/admin/roles', label: 'Roles', paths: ['/admin/roles'] },
+	{
+		href: '/admin/roles',
+		label: 'Roles',
+		icon: 'shield',
+		paths: ['/admin/roles'],
+	},
 	{
 		href: '/admin/community-reports',
 		label: 'Community reports',
+		icon: 'warning-triangle',
 		paths: ['/admin/community-reports'],
 	},
 	{
 		href: routes.adminPlatformFeedback.href(),
 		label: 'Platform feedback',
+		icon: 'message',
 		paths: [routes.adminPlatformFeedback.href()],
 	},
 	{
 		href: '/admin/system-email',
 		label: 'System email',
+		icon: 'inbox',
 		paths: ['/admin/system-email'],
 	},
-] as const
+] as const satisfies ReadonlyArray<{
+	href: string
+	label: string
+	icon: IconName
+	paths: ReadonlyArray<string>
+}>
 
 /**
  * Packages live on the signed-in user's public profile (`/@username`);
@@ -357,7 +386,7 @@ export function accountPackagesNavHref(username: string | null | undefined) {
 		: routes.accountPackages.href()
 }
 
-type AccountNavItem = { href: string; label: string }
+type AccountNavItem = { href: string; label: string; icon: IconName }
 
 /** Account rail items in display order for the signed-in session. */
 export function accountNavItemsFor(input: {
@@ -365,24 +394,38 @@ export function accountNavItemsFor(input: {
 	showShared: boolean
 }): Array<AccountNavItem> {
 	return [
-		{ href: '/account', label: 'Overview' },
-		{ href: '/account/waiting', label: 'Waiting' },
-		{ href: routes.accountConnections.href(), label: 'Connections' },
-		{ href: accountPackagesNavHref(input.username), label: 'Packages' },
+		{ href: '/account', label: 'Overview', icon: 'home' },
+		{ href: '/account/waiting', label: 'Waiting', icon: 'clock' },
+		{
+			href: routes.accountConnections.href(),
+			label: 'Connections',
+			icon: 'link',
+		},
+		{
+			href: accountPackagesNavHref(input.username),
+			label: 'Packages',
+			icon: 'box',
+		},
 		...(input.showShared
-			? [{ href: routes.accountShared.href(), label: 'Shared' }]
+			? [
+					{
+						href: routes.accountShared.href(),
+						label: 'Shared',
+						icon: 'share' as const,
+					},
+				]
 			: []),
-		{ href: '/account/billing', label: 'Billing' },
-		{ href: '/account/usage', label: 'Usage' },
-		{ href: '/account/activity', label: 'Activity' },
-		{ href: '/account/jobs', label: 'Jobs' },
-		{ href: '/account/workflows', label: 'Workflows' },
-		{ href: routes.accountWebhooks.href(), label: 'Webhooks' },
-		{ href: '/account/secrets', label: 'Secrets' },
-		{ href: '/account/integrations', label: 'Integrations' },
-		{ href: '/account/mcp-servers', label: 'MCP servers' },
-		{ href: '/account/memories', label: 'Memories' },
-		{ href: '/account/email', label: 'Email' },
+		{ href: '/account/billing', label: 'Billing', icon: 'wallet' },
+		{ href: '/account/usage', label: 'Usage', icon: 'chart' },
+		{ href: '/account/activity', label: 'Activity', icon: 'trending-up' },
+		{ href: '/account/jobs', label: 'Jobs', icon: 'briefcase' },
+		{ href: '/account/workflows', label: 'Workflows', icon: 'refresh' },
+		{ href: routes.accountWebhooks.href(), label: 'Webhooks', icon: 'cloud' },
+		{ href: '/account/secrets', label: 'Secrets', icon: 'key' },
+		{ href: '/account/integrations', label: 'Integrations', icon: 'plug' },
+		{ href: '/account/mcp-servers', label: 'MCP servers', icon: 'server' },
+		{ href: '/account/memories', label: 'Memories', icon: 'book' },
+		{ href: '/account/email', label: 'Email', icon: 'mail' },
 	]
 }
 
@@ -431,6 +474,7 @@ export function AccountPageHeader(handle: Handle<AccountPageHeaderProps>) {
 					items={navItems.map((item) => ({
 						href: item.href,
 						label: item.label,
+						icon: item.icon,
 						active: isAccountNavItemActive(item.href, currentPath),
 					}))}
 				/>
@@ -461,6 +505,7 @@ export function AdminPageHeader(handle: Handle<AdminPageHeaderProps>) {
 					items={adminNavItems.map((item) => ({
 						href: item.href,
 						label: item.label,
+						icon: item.icon,
 						// Prefix-aware like account nav so `/admin/users/42`
 						// keeps Users highlighted. `/admin` stays exact-only
 						// so sibling pages (`/admin/roles`, …) are unaffected.

--- a/packages/worker/client/routes/account-management-link-nav.tsx
+++ b/packages/worker/client/routes/account-management-link-nav.tsx
@@ -1,5 +1,6 @@
 import { css, ref, type Handle } from 'remix/ui'
 import { routerEvents } from '#client/client-router.tsx'
+import { renderIcon, type IconName } from '#universal/icon.tsx'
 import { colors, transitions } from '#universal/styles/tokens.ts'
 import { hoverMq, pageGutter } from '#universal/styles/style-primitives.ts'
 
@@ -10,6 +11,7 @@ type AccountManagementLinkNavItem = {
 	href: string
 	label: string
 	active: boolean
+	icon?: IconName
 }
 
 type AccountManagementLinkNavProps = {
@@ -19,13 +21,19 @@ type AccountManagementLinkNavProps = {
 
 /** `.account-nav a` — quiet link pills; only the current one goes green. */
 const accountNavLinkCss = {
-	padding: '0.5rem 0.9rem',
+	display: 'flex',
+	alignItems: 'center',
+	gap: '0.5rem',
+	padding: '0.5rem 0.7rem',
 	borderRadius: '10px',
 	color: colors.textMuted,
 	fontWeight: 550,
 	fontSize: '0.98rem',
 	textDecoration: 'none',
 	transition: `color ${transitions.fast}, background-color ${transitions.fast}`,
+	'& [data-icon]': {
+		flex: 'none',
+	},
 	[hoverMq]: {
 		'&:hover': { color: colors.text, backgroundColor: colors.surface },
 	},
@@ -62,10 +70,9 @@ const accountMobileMenuCss = {
 	},
 	'& > summary::-webkit-details-marker': { display: 'none' },
 	'& > summary::marker': { content: '""' },
-	'& > summary::before': {
-		content: '"☰"',
+	'& > summary [data-icon]': {
+		flex: 'none',
 		color: colors.textMuted,
-		fontSize: '0.95rem',
 	},
 	'& > nav': {
 		display: 'grid',
@@ -95,6 +102,7 @@ function renderAccountNavLinks(
 			aria-current={item.active ? 'page' : undefined}
 			mix={css(linkCss)}
 		>
+			{item.icon ? renderIcon(item.icon, { size: '1.05em' }) : null}
 			{item.label}
 		</a>
 	))
@@ -159,6 +167,7 @@ export function AccountManagementLinkNav(
 					]}
 				>
 					<summary>
+						{renderIcon('menu', { size: '1.05em' })}
 						<span>{handle.props.label}</span>
 						{current ? (
 							<span mix={css(accountMobileMenuCurrentCss)}>

--- a/packages/worker/client/routes/account-management-metadata.node.test.ts
+++ b/packages/worker/client/routes/account-management-metadata.node.test.ts
@@ -78,11 +78,17 @@ test('metadata band auto-fits columns and keeps id/timestamp values copyable and
 
 test('inline link nav stays in flow and is not a second account rail', async () => {
 	const items = [
-		{ href: '/admin/community-reports', label: 'Open', active: true },
+		{
+			href: '/admin/community-reports',
+			label: 'Open',
+			active: true,
+			icon: 'warning-triangle' as const,
+		},
 		{
 			href: '/admin/community-reports?status=resolved',
 			label: 'Resolved',
 			active: false,
+			icon: 'check' as const,
 		},
 	]
 
@@ -96,7 +102,10 @@ test('inline link nav stays in flow and is not a second account rail', async () 
 	expect(readRulesFor(railHtml, 'nav')).toContain('position: absolute')
 	expect(railHtml).toContain('<details')
 	expect(railHtml).toContain('>Admin sections</span>')
+	expect(railHtml).toContain('data-icon="menu"')
+	expect(railHtml).toContain('data-icon="warning-triangle"')
 	expect(railHtml).toContain('>Open</span>')
+	expect(railHtml).toContain('>Open</a>')
 	expect(railHtml).toContain('min-height: 44px')
 	expect(railHtml).toContain('@media (max-width: 860px)')
 

--- a/packages/worker/client/routes/account-package-owner-details.tsx
+++ b/packages/worker/client/routes/account-package-owner-details.tsx
@@ -12,6 +12,7 @@ import {
 	ForkAheadLink,
 	ForkOutdatedCopyButton,
 } from '#universal/fork-outdated-copy-button.tsx'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	getAccentCalloutCss,
 	getGhostButtonCss,
@@ -366,27 +367,7 @@ export function AccountPackageOwnerDetails(
 }
 
 function packageLockGlyph(locked: boolean) {
-	return (
-		<svg
-			viewBox="0 0 16 16"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			focusable={false}
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		>
-			{locked ? (
-				<path d="M5.2 7.4V5.8a2.8 2.8 0 0 1 5.6 0v1.6" />
-			) : (
-				<path d="M5.2 7.4V5.6a2.8 2.8 0 0 1 5.2-1.4" />
-			)}
-			<rect x="3.6" y="7.4" width="8.8" height="6.4" rx="1.3" />
-		</svg>
-	)
+	return renderIcon(locked ? 'lock' : 'lock-unlocked', { size: '1em' })
 }
 
 const packageLockToggleCss = {

--- a/packages/worker/client/routes/account-profile-panel.tsx
+++ b/packages/worker/client/routes/account-profile-panel.tsx
@@ -4,6 +4,7 @@ import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
 import { type ProfileVisibility } from '#universal/loader-data.ts'
 import { routes } from '#universal/routes.ts'
 import { UserAvatar } from '#universal/user-avatar.tsx'
+import { renderIcon } from '#universal/icon.tsx'
 import { colors, radius, shadows, spacing } from '#universal/styles/tokens.ts'
 import {
 	getGhostButtonCss,
@@ -440,20 +441,5 @@ const avatarEditAffordanceCss = {
 }
 
 function avatarEditIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="16"
-			height="16"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M12 20h9" />
-			<path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
-		</svg>
-	)
+	return renderIcon('edit', { size: '16' })
 }

--- a/packages/worker/client/routes/docs-shell.tsx
+++ b/packages/worker/client/routes/docs-shell.tsx
@@ -10,6 +10,7 @@ import {
 	resolveDocsNavSection,
 	type DocsNavSection,
 } from '#universal/docs-nav.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import { routes } from '#universal/routes.ts'
 import { colors, mq, transitions } from '#universal/styles/tokens.ts'
 import {
@@ -56,6 +57,7 @@ export function renderDocsShell(input: {
 				]}
 			>
 				<summary>
+					{renderIcon('menu', { size: '1.05em' })}
 					<span>Docs</span>
 					<span mix={css(docsMobileMenuCurrentCss)}>
 						{docsCurrentPageLabel(current)}
@@ -310,10 +312,9 @@ const docsMobileMenuCss = {
 	},
 	'& > summary::-webkit-details-marker': { display: 'none' },
 	'& > summary::marker': { content: '""' },
-	'& > summary::before': {
-		content: '"☰"',
+	'& > summary [data-icon]': {
+		flex: 'none',
 		color: colors.textMuted,
-		fontSize: '0.95rem',
 	},
 	overflow: 'visible' as const,
 	'& > nav': {

--- a/packages/worker/client/routes/home.tsx
+++ b/packages/worker/client/routes/home.tsx
@@ -1,4 +1,4 @@
-import { type Handle, type RemixNode } from 'remix/ui'
+import { type Handle } from 'remix/ui'
 import { CopyTextButton } from '#client/copy-text-button.tsx'
 import { readCurrentRouterHref } from '#client/client-router.tsx'
 import { tryConsumeRouteLoaderData } from '#client/loader-data-context.tsx'
@@ -15,6 +15,7 @@ import { type RouteLoaderResult } from '#client/route-loader.ts'
 import { reveal, revealPop } from '#client/reveal.ts'
 import { landingArtAttrs } from '#universal/landing-images.ts'
 import { landingWorldBrands } from '#universal/landing-world-brands.ts'
+import { renderIcon, type IconName } from '#universal/icon.tsx'
 import { homepageSignupPath } from '#universal/first-touch-attribution.ts'
 import { routes } from '#universal/routes.ts'
 import {
@@ -72,12 +73,14 @@ const factoryPathSteps = [
 
 const factoryBeats = [
 	{ trigger: 'Cron', title: 'Flake Hunter', icon: 'target' },
-	{ trigger: 'Webhook', title: 'Sentry Issues', icon: 'alert' },
-	{ trigger: 'Email', title: 'Agent inbox', icon: 'envelope' },
-	{ trigger: 'Event', title: 'Purchase thanks', icon: 'gift' },
-] as const
-
-type FactoryBeatIcon = (typeof factoryBeats)[number]['icon']
+	{ trigger: 'Webhook', title: 'Sentry Issues', icon: 'warning-triangle' },
+	{ trigger: 'Email', title: 'Agent inbox', icon: 'mail' },
+	{ trigger: 'Event', title: 'Purchase thanks', icon: 'heart' },
+] as const satisfies ReadonlyArray<{
+	trigger: string
+	title: string
+	icon: IconName
+}>
 
 const ecosystemPathSteps = [
 	{
@@ -251,7 +254,7 @@ export function HomeRoute(handle: Handle) {
 								>
 									<p class="landing-path-kicker">{beat.trigger}</p>
 									<p class="landing-path-fan-title">
-										{renderFactoryBeatIcon(beat.icon)}
+										{renderIcon(beat.icon, { size: '22' })}
 										{beat.title}
 									</p>
 								</li>
@@ -496,63 +499,4 @@ function renderGithubRepoLink(label: string) {
 			{label}
 		</a>
 	)
-}
-
-function factoryBeatIconSvg(paths: RemixNode) {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="22"
-			height="22"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="1.5"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			{paths}
-		</svg>
-	)
-}
-
-function renderFactoryBeatIcon(icon: FactoryBeatIcon) {
-	switch (icon) {
-		case 'target':
-			return factoryBeatIconSvg(
-				<>
-					<circle cx="12" cy="12" r="8" />
-					<circle cx="12" cy="12" r="3.25" />
-					<path d="M12 2.5v2.75M12 18.75V21.5M2.5 12h2.75M18.75 12H21.5" />
-				</>,
-			)
-		case 'alert':
-			return factoryBeatIconSvg(
-				<>
-					<path d="M12 4 21 19.5H3L12 4Z" />
-					<path d="M12 10v4.25" />
-					<circle cx="12" cy="16.75" r="0.75" fill="currentColor" />
-				</>,
-			)
-		case 'envelope':
-			return factoryBeatIconSvg(
-				<>
-					<rect x="3.5" y="6" width="17" height="12" rx="2" />
-					<path d="m4.2 7.6 7.8 5.2 7.8-5.2" />
-				</>,
-			)
-		case 'gift':
-			return factoryBeatIconSvg(
-				<>
-					<rect x="3.5" y="8" width="17" height="4" rx="1" />
-					<rect x="5" y="12" width="14" height="8.5" rx="1" />
-					<path d="M12 8v12.5" />
-					<path d="M12 8c-2.4-3.4-6-2.4-6 0 0 1.4 1.9 2.4 6 2.8 4.1-.4 6-1.4 6-2.8 0-2.4-3.6-3.4-6 0" />
-				</>,
-			)
-		default: {
-			const exhaustive: never = icon
-			return exhaustive
-		}
-	}
 }

--- a/packages/worker/client/routes/interactive-guide-walkthrough.tsx
+++ b/packages/worker/client/routes/interactive-guide-walkthrough.tsx
@@ -4,6 +4,7 @@ import {
 	type HighlightedCode,
 	highlightSnippetKey,
 } from '#universal/highlighted-code.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	walkthroughHostForAct,
 	walkthroughHostMarkUrl,
@@ -260,22 +261,7 @@ function isKodyToolName(name: string) {
 }
 
 function renderUserIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<circle cx="12" cy="8" r="3.5" />
-			<path d="M5 19.5c.7-3.2 3.4-5 7-5s6.3 1.8 7 5" />
-		</svg>
-	)
+	return renderIcon('user', { size: '1em' })
 }
 
 function renderAgentMark(host: WalkthroughHost) {
@@ -289,22 +275,7 @@ function renderAgentMark(host: WalkthroughHost) {
 }
 
 function renderEmailIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<rect x="3.5" y="6" width="17" height="12" rx="2" />
-			<path d="m4.2 7.6 7.8 5.2 7.8-5.2" />
-		</svg>
-	)
+	return renderIcon('mail', { size: '1em' })
 }
 
 function renderAgentIcon() {
@@ -339,23 +310,7 @@ function renderNotedText(note: string) {
 }
 
 function renderInfoIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<circle cx="12" cy="12" r="9" />
-			<path d="M12 11v5" />
-			<circle cx="12" cy="8" r="0.75" fill="currentColor" />
-		</svg>
-	)
+	return renderIcon('information', { size: '1em' })
 }
 
 function renderKodyMark() {

--- a/packages/worker/client/routes/landing-byok-demo.tsx
+++ b/packages/worker/client/routes/landing-byok-demo.tsx
@@ -1,5 +1,6 @@
 import { type Handle, ref } from 'remix/ui'
 import { passwordManagerIgnoreProps } from '#client/password-manager-ignore.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	listCodingWalkthroughHosts,
 	walkthroughHostMarkUrl,
@@ -346,20 +347,7 @@ export function LandingByokDemo(
 							{...passwordManagerIgnoreProps}
 						/>
 						<span class="landing-byok-eye">
-							<svg
-								viewBox="0 0 24 24"
-								width="22"
-								height="22"
-								aria-hidden="true"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="1.5"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<path d="M2.6 12s3.4-6.4 9.4-6.4S21.4 12 21.4 12s-3.4 6.4-9.4 6.4S2.6 12 2.6 12Z" />
-								<circle cx="12" cy="12" r="2.7" />
-							</svg>
+							{renderIcon('eye', { size: '22' })}
 						</span>
 					</div>
 					<span class="landing-byok-cursor">

--- a/packages/worker/client/routes/landing-loop-player.tsx
+++ b/packages/worker/client/routes/landing-loop-player.tsx
@@ -11,6 +11,7 @@ import {
 	type WalkthroughHostPick,
 } from '#universal/walkthrough-hosts.ts'
 import { type TranscriptLine } from './interactive-guide-transcript.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import { fetchLandingLoopHighlights } from './landing-loop-highlights.ts'
 import {
 	createLandingLoopPlayer,
@@ -532,47 +533,11 @@ function renderTeaser(hosts?: WalkthroughHostPick) {
 function renderLoopToggleIcon(label: LandingLoopToggleLabel) {
 	switch (label) {
 		case 'Pause':
-			return (
-				<svg
-					viewBox="0 0 24 24"
-					width="1em"
-					height="1em"
-					aria-hidden="true"
-					fill="currentColor"
-				>
-					<rect x="6" y="5" width="4.5" height="14" rx="1" />
-					<rect x="13.5" y="5" width="4.5" height="14" rx="1" />
-				</svg>
-			)
+			return renderIcon('pause', { size: '1em' })
 		case 'Play':
-			return (
-				<svg
-					viewBox="0 0 24 24"
-					width="1em"
-					height="1em"
-					aria-hidden="true"
-					fill="currentColor"
-				>
-					<path d="M8 5.5v13l11-6.5-11-6.5Z" />
-				</svg>
-			)
+			return renderIcon('play', { size: '1em' })
 		case 'Restart':
-			return (
-				<svg
-					viewBox="0 0 24 24"
-					width="1em"
-					height="1em"
-					aria-hidden="true"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				>
-					<path d="M9 14 4 9l5-5" />
-					<path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5 5.5 5.5 0 0 1-5.5 5.5H11" />
-				</svg>
-			)
+			return renderIcon('redo', { size: '1em' })
 		default: {
 			const exhaustive: never = label
 			return exhaustive
@@ -581,20 +546,5 @@ function renderLoopToggleIcon(label: LandingLoopToggleLabel) {
 }
 
 function renderLoopSkipIcon() {
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<path d="M12 5v14" />
-			<path d="m19 12-7 7-7-7" />
-		</svg>
-	)
+	return renderIcon('chevron-down', { size: '1em' })
 }

--- a/packages/worker/client/routes/landing-testimonials-carousel.tsx
+++ b/packages/worker/client/routes/landing-testimonials-carousel.tsx
@@ -8,6 +8,7 @@ import {
 	testimonialStoryHref,
 	type LandingTestimonial,
 } from '#universal/landing-testimonials.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	TESTIMONIALS_LAP_MS,
 	appendFlickSample,
@@ -566,22 +567,9 @@ function armTestimonialsMotion(scroller: HTMLElement, signal: AbortSignal) {
 }
 
 function renderChevron(direction: 'prev' | 'next') {
-	const path = direction === 'prev' ? 'M15 6 9 12l6 6' : 'M9 6l6 6-6 6'
-	return (
-		<svg
-			viewBox="0 0 24 24"
-			width="1em"
-			height="1em"
-			aria-hidden="true"
-			fill="none"
-			stroke="currentColor"
-			stroke-width="2.2"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<path d={path} />
-		</svg>
-	)
+	return renderIcon(direction === 'prev' ? 'chevron-left' : 'chevron-right', {
+		size: '1em',
+	})
 }
 
 function renderTestimonialIdentity(item: LandingTestimonial) {

--- a/packages/worker/client/routes/login-sections.tsx
+++ b/packages/worker/client/routes/login-sections.tsx
@@ -6,6 +6,7 @@ import {
 } from '#client/form-error-fields.ts'
 import { HeroStage } from '#client/hero-stage.tsx'
 import { renderHoneypot } from '#client/honeypot-field.tsx'
+import { renderIcon } from '#universal/icon.tsx'
 import { turnstileWidgetClassName } from '#client/public-form-protection.ts'
 import { colors, transitions, typography } from '#universal/styles/tokens.ts'
 import {
@@ -280,20 +281,7 @@ export function renderAuthForm(
 					disabled={props.isSubmitting}
 					mix={[css(ghostButtonCss), on('click', props.onPasskeySignIn)]}
 				>
-					<svg
-						viewBox="0 0 24 24"
-						width="17"
-						height="17"
-						aria-hidden="true"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="M2.586 17.414A2 2 0 0 0 2 18.828V21a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h.172a2 2 0 0 0 1.414-.586l.814-.814a6.5 6.5 0 1 0-4-4z" />
-						<circle cx="16.5" cy="7.5" r="0.5" fill="currentColor" />
-					</svg>
+					{renderIcon('key', { size: '17' })}
 					Sign in with a passkey
 				</button>
 			) : null}

--- a/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
+++ b/packages/worker/client/routes/onboarding-mcp-client-tabs.tsx
@@ -17,6 +17,7 @@ import {
 	openClawMcpLoginCommand,
 	openCodeMcpAuthCommand,
 } from '#client/routes/onboarding-mcp-clients.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	type OnboardingSecondAgentDisableReason,
 	onboardingSecondAgentDisableHint,
@@ -62,20 +63,9 @@ function AgentMarkIcon(
 	return () => {
 		const inline = handle.props.size === 'inline'
 		if (!handle.props.icon) {
-			return (
-				<svg
-					viewBox="0 0 24 24"
-					width={inline ? undefined : 22}
-					height={inline ? undefined : 22}
-					fill="currentColor"
-					aria-hidden="true"
-					mix={inline ? css(pickerIconImgInlineCss) : undefined}
-				>
-					<circle cx="6" cy="12" r="1.6" />
-					<circle cx="12" cy="12" r="1.6" />
-					<circle cx="18" cy="12" r="1.6" />
-				</svg>
-			)
+			return renderIcon('dots-horizontal', {
+				size: inline ? '1cap' : '22',
+			})
 		}
 		return (
 			<img

--- a/packages/worker/client/routes/onboarding-wizard-chrome.tsx
+++ b/packages/worker/client/routes/onboarding-wizard-chrome.tsx
@@ -6,6 +6,7 @@ import {
 	type OnboardingWizardStepNumber,
 } from '#universal/onboarding-process.ts'
 import { createOnboardingNextConfirmation } from '#client/routes/onboarding-next-confirmation.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import {
 	colors,
 	radius,
@@ -260,22 +261,7 @@ export function connectStatusContent(input: {
 }
 
 function connectedCheckIcon() {
-	return (
-		<svg
-			viewBox="0 0 16 16"
-			width="14"
-			height="14"
-			aria-hidden="true"
-			focusable={false}
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.8"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-		>
-			<path d="M3.4 8.2 6.5 11.2 12.6 4.8" />
-		</svg>
-	)
+	return renderIcon('check', { size: '14' })
 }
 
 /* Connection status pill: dashed while the product polls for the grant,

--- a/packages/worker/client/site-banner-editor.tsx
+++ b/packages/worker/client/site-banner-editor.tsx
@@ -2,6 +2,7 @@ import { type Handle, css } from 'remix/ui'
 import { on } from '#client/event-mixin.ts'
 import { accountInputCss } from '#client/routes/account-management-components.tsx'
 import { type BannerDraft } from '#client/routes/admin-banners-shared.ts'
+import { renderIcon } from '#universal/icon.tsx'
 import { resolveSiteBannerImageUrl } from '#universal/youtube-watch.ts'
 import {
 	fieldLabelCss,
@@ -24,7 +25,7 @@ import {
 	siteBannerBodyCss,
 	siteBannerCopyCss,
 	siteBannerDismissCss,
-	siteBannerIconGlyph,
+	siteBannerIconName,
 	siteBannerIconWellCss,
 	siteBannerImageCss,
 	siteBannerImagePixelSize,
@@ -165,7 +166,9 @@ export function SiteBannerEditor(
 								aria-hidden="true"
 								mix={css(siteBannerIconWellCss(look, tone))}
 							>
-								{siteBannerIconGlyph(draft.icon || defaultSiteBannerIcon(look))}
+								{renderIcon(
+									siteBannerIconName(draft.icon || defaultSiteBannerIcon(look)),
+								)}
 							</span>
 						)}
 						<div mix={css(siteBannerCopyCss(look))}>

--- a/packages/worker/client/site-banner-looks.ts
+++ b/packages/worker/client/site-banner-looks.ts
@@ -1,3 +1,4 @@
+import { type IconName } from '#universal/icon.tsx'
 import {
 	hoverMq,
 	layoutMaxWidths,
@@ -76,16 +77,16 @@ export function defaultSiteBannerIcon(look: SiteBannerLook): SiteBannerIcon {
 	}
 }
 
-export function siteBannerIconGlyph(icon: SiteBannerIcon) {
+export function siteBannerIconName(icon: SiteBannerIcon): IconName {
 	switch (icon) {
 		case 'play':
-			return '▶'
+			return 'play'
 		case 'megaphone':
-			return '📣'
+			return 'announcement'
 		case 'sparkle':
-			return '✦'
+			return 'star'
 		case 'info':
-			return 'ℹ'
+			return 'information'
 		default: {
 			const exhaustive: never = icon
 			return exhaustive

--- a/packages/worker/client/site-banner.tsx
+++ b/packages/worker/client/site-banner.tsx
@@ -4,6 +4,7 @@ import {
 	readRouterPathname,
 	readRouterSearch,
 } from '#client/router-location.tsx'
+import { renderIcon } from '#universal/icon.tsx'
 import { type SiteBannerLoaderData } from '#universal/loader-data.ts'
 import {
 	isSiteBannerId,
@@ -21,7 +22,7 @@ import {
 	siteBannerBodyCss,
 	siteBannerCopyCss,
 	siteBannerDismissCss,
-	siteBannerIconGlyph,
+	siteBannerIconName,
 	siteBannerIconWellCss,
 	siteBannerImageCss,
 	siteBannerImagePixelSize,
@@ -186,7 +187,9 @@ function renderMedia(
 	}
 	return (
 		<span aria-hidden="true" mix={css(siteBannerIconWellCss(look, tone))}>
-			{siteBannerIconGlyph(banner.icon ?? defaultSiteBannerIcon(look))}
+			{renderIcon(
+				siteBannerIconName(banner.icon ?? defaultSiteBannerIcon(look)),
+			)}
 		</span>
 	)
 }

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -432,7 +432,11 @@ test('SSR HTML routes render page content and embedded loader data', async () =>
 	// package list, so the nav links there rather than the `/account/packages`
 	// redirect).
 	expect(accountHtml).toContain('>Connections</a>')
-	expect(accountHtml).toMatch(/href="\/@account-user"[^>]*>Packages<\/a>/)
+	expect(accountHtml).toContain('data-icon="link"')
+	expect(accountHtml).toMatch(
+		/href="\/@account-user"[^>]*>[\s\S]*?Packages<\/a>/,
+	)
+	expect(accountHtml).toContain('data-icon="box"')
 	expect(accountProps.loaderData?.onboarding).toEqual({
 		ok: true,
 		loggedIn: true,

--- a/packages/worker/universal/icon-glyphs.tsx
+++ b/packages/worker/universal/icon-glyphs.tsx
@@ -1,0 +1,1152 @@
+/** @jsxImportSource remix/ui */
+/** @jsxRuntime automatic */
+import { type RemixNode } from 'remix/ui'
+
+/**
+ * Inner paths from Iconic (https://iconic.app) free SVG icons.
+ * 24×24 bounding box, 1.5px stroke. Cropping lives in `icon.tsx`.
+ */
+export const iconNames = [
+	'home',
+	'clock',
+	'link',
+	'box',
+	'share',
+	'wallet',
+	'chart',
+	'trending-up',
+	'briefcase',
+	'refresh',
+	'cloud',
+	'key',
+	'plug',
+	'server',
+	'book',
+	'mail',
+	'users',
+	'pie-chart',
+	'user-cross',
+	'flag',
+	'announcement',
+	'globe',
+	'photo',
+	'code',
+	'shield',
+	'warning-triangle',
+	'message',
+	'inbox',
+	'arrow-left',
+	'chevron-right',
+	'chevron-down',
+	'chevron-left',
+	'chevron-up',
+	'folder',
+	'file',
+	'search',
+	'edit',
+	'check',
+	'close',
+	'play',
+	'pause',
+	'information',
+	'user',
+	'lock',
+	'lock-unlocked',
+	'menu',
+	'copy',
+	'dots-horizontal',
+	'target',
+	'redo',
+	'star',
+	'heart',
+	'eye',
+] as const
+
+export type IconName = (typeof iconNames)[number]
+
+export const iconGlyphs = {
+	home: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M6.75024 19.2502H17.2502C18.3548 19.2502 19.2502 18.3548 19.2502 17.2502V9.75025L12.0002 4.75024L4.75024 9.75025V17.2502C4.75024 18.3548 5.64568 19.2502 6.75024 19.2502Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M9.74963 15.7493C9.74963 14.6447 10.6451 13.7493 11.7496 13.7493H12.2496C13.3542 13.7493 14.2496 14.6447 14.2496 15.7493V19.2493H9.74963V15.7493Z"
+			/>
+		</>
+	),
+	clock: () => (
+		<>
+			<circle
+				cx="12"
+				cy="12"
+				r="7.25"
+				stroke="currentColor"
+				stroke-width="1.5"
+			/>
+			<path stroke="currentColor" stroke-width="1.5" d="M12 8V12L14 14" />
+		</>
+	),
+	link: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M16.75 13.25L18 12C19.6569 10.3431 19.6569 7.65685 18 6V6C16.3431 4.34315 13.6569 4.34315 12 6L10.75 7.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M7.25 10.75L6 12C4.34315 13.6569 4.34315 16.3431 6 18V18C7.65685 19.6569 10.3431 19.6569 12 18L13.25 16.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M14.25 9.75L9.75 14.25"
+			/>
+		</>
+	),
+	box: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 8L12 4.75L19.25 8L12 11.25L4.75 8Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 16L12 19.25L19.25 16"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 8V16"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 8V16"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M12 11.5V19"
+			/>
+		</>
+	),
+	share: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M9.25 4.75H6.75C5.64543 4.75 4.75 5.64543 4.75 6.75V17.25C4.75 18.3546 5.64543 19.25 6.75 19.25H17.25C18.3546 19.25 19.25 18.3546 19.25 17.25V14.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 9.25V4.75H14.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19 5L11.75 12.25"
+			/>
+		</>
+	),
+	wallet: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 8.25V17.25C19.25 18.3546 18.3546 19.25 17.25 19.25H6.75C5.64543 19.25 4.75 18.3546 4.75 17.25V6.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="M16.5 13C16.5 13.2761 16.2761 13.5 16 13.5C15.7239 13.5 15.5 13.2761 15.5 13C15.5 12.7239 15.7239 12.5 16 12.5C16.2761 12.5 16.5 12.7239 16.5 13Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M17.25 8.25H6.5C5.5335 8.25 4.75 7.4665 4.75 6.5C4.75 5.5335 5.5335 4.75 6.5 4.75H15.25C16.3546 4.75 17.25 5.64543 17.25 6.75V8.25ZM17.25 8.25H19.25"
+			/>
+		</>
+	),
+	chart: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 6.75C4.75 5.64543 5.64543 4.75 6.75 4.75H17.25C18.3546 4.75 19.25 5.64543 19.25 6.75V17.25C19.25 18.3546 18.3546 19.25 17.25 19.25H6.75C5.64543 19.25 4.75 18.3546 4.75 17.25V6.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M8.75 15.25V9.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.25 15.25V9.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M12 15.25V12.75"
+			/>
+		</>
+	),
+	'trending-up': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 11.25L10.25 5.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5.75 19.2502H6.25C6.80229 19.2502 7.25 18.8025 7.25 18.2502V15.75C7.25 15.1977 6.80229 14.75 6.25 14.75H5.75C5.19772 14.75 4.75 15.1977 4.75 15.75V18.2502C4.75 18.8025 5.19772 19.2502 5.75 19.2502Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M11.75 19.2502H12.25C12.8023 19.2502 13.25 18.8025 13.25 18.2502V12.75C13.25 12.1977 12.8023 11.75 12.25 11.75H11.75C11.1977 11.75 10.75 12.1977 10.75 12.75V18.2502C10.75 18.8025 11.1977 19.2502 11.75 19.2502Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M17.75 19.2502H18.25C18.8023 19.2502 19.25 18.8025 19.25 18.2502V5.75C19.25 5.19772 18.8023 4.75 18.25 4.75H17.75C17.1977 4.75 16.75 5.19772 16.75 5.75V18.2502C16.75 18.8025 17.1977 19.2502 17.75 19.2502Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M11.25 8.25V4.75H7.75"
+			/>
+		</>
+	),
+	briefcase: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 9.75C4.75 8.64543 5.64543 7.75 6.75 7.75H17.25C18.3546 7.75 19.25 8.64543 19.25 9.75V17.25C19.25 18.3546 18.3546 19.25 17.25 19.25H6.75C5.64543 19.25 4.75 18.3546 4.75 17.25V9.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M8.75 7.5V6.75C8.75 5.64543 9.64543 4.75 10.75 4.75H13.25C14.3546 4.75 15.25 5.64543 15.25 6.75V7.5"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5 13.25H19"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M8.75 11.75V14.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.25 11.75V14.25"
+			/>
+		</>
+	),
+	refresh: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M11.25 4.75L8.75 7L11.25 9.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M12.75 19.25L15.25 17L12.75 14.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M9.75 7H13.25C16.5637 7 19.25 9.68629 19.25 13V13.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M14.25 17H10.75C7.43629 17 4.75 14.3137 4.75 11V10.75"
+			/>
+		</>
+	),
+	cloud: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 14C4.75 15.7949 6.20507 17.25 8 17.25H16C17.7949 17.25 19.25 15.7949 19.25 14C19.25 12.2869 17.9246 10.8834 16.2433 10.759C16.1183 8.5239 14.2663 6.75 12 6.75C9.73368 6.75 7.88168 8.5239 7.75672 10.759C6.07542 10.8834 4.75 12.2869 4.75 14Z"
+			/>
+		</>
+	),
+	key: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15 13.25C17.3472 13.25 19.25 11.3472 19.25 9C19.25 6.65279 17.3472 4.75 15 4.75C12.6528 4.75 10.75 6.65279 10.75 9C10.75 9.31012 10.7832 9.61248 10.8463 9.90372L4.75 16V19.25H8L8.75 18.5V16.75H10.5L11.75 15.5V13.75H13.5L14.0963 13.1537C14.3875 13.2168 14.6899 13.25 15 13.25Z"
+			/>
+			<path
+				stroke="currentColor"
+				d="M16.5 8C16.5 8.27614 16.2761 8.5 16 8.5C15.7239 8.5 15.5 8.27614 15.5 8C15.5 7.72386 15.7239 7.5 16 7.5C16.2761 7.5 16.5 7.72386 16.5 8Z"
+			/>
+		</>
+	),
+	plug: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M18.2813 12.0313L11.9687 5.7187C11.4896 5.23964 10.6829 5.36557 10.3726 5.96785L6.75 13L11 17.25L18.0321 13.6274C18.6344 13.3171 18.7604 12.5104 18.2813 12.0313Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 19.25L8.5 15.5"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M13.75 7.25L16.25 4.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M16.75 10.25L19.25 7.75"
+			/>
+		</>
+	),
+	server: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 5.75C4.75 5.19772 5.19772 4.75 5.75 4.75H18.25C18.8023 4.75 19.25 5.19772 19.25 5.75V9.25C19.25 9.80228 18.8023 10.25 18.25 10.25H5.75C5.19771 10.25 4.75 9.80228 4.75 9.25V5.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 14.75C4.75 14.1977 5.19772 13.75 5.75 13.75H18.25C18.8023 13.75 19.25 14.1977 19.25 14.75V18.25C19.25 18.8023 18.8023 19.25 18.25 19.25H5.75C5.19771 19.25 4.75 18.8023 4.75 18.25V14.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M16.25 5V10"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M16.25 14V19"
+			/>
+		</>
+	),
+	book: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 5.75C19.25 5.19772 18.8023 4.75 18.25 4.75H14C12.8954 4.75 12 5.64543 12 6.75V19.25L12.8284 18.4216C13.5786 17.6714 14.596 17.25 15.6569 17.25H18.25C18.8023 17.25 19.25 16.8023 19.25 16.25V5.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 5.75C4.75 5.19772 5.19772 4.75 5.75 4.75H10C11.1046 4.75 12 5.64543 12 6.75V19.25L11.1716 18.4216C10.4214 17.6714 9.40401 17.25 8.34315 17.25H5.75C5.19772 17.25 4.75 16.8023 4.75 16.25V5.75Z"
+			/>
+		</>
+	),
+	mail: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 7.75C4.75 6.64543 5.64543 5.75 6.75 5.75H17.25C18.3546 5.75 19.25 6.64543 19.25 7.75V16.25C19.25 17.3546 18.3546 18.25 17.25 18.25H6.75C5.64543 18.25 4.75 17.3546 4.75 16.25V7.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5.5 6.5L12 12.25L18.5 6.5"
+			/>
+		</>
+	),
+	users: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5.78168 19.25H13.2183C13.7828 19.25 14.227 18.7817 14.1145 18.2285C13.804 16.7012 12.7897 14 9.5 14C6.21031 14 5.19605 16.7012 4.88549 18.2285C4.773 18.7817 5.21718 19.25 5.78168 19.25Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.75 14C17.8288 14 18.6802 16.1479 19.0239 17.696C19.2095 18.532 18.5333 19.25 17.6769 19.25H16.75"
+			/>
+			<circle
+				cx="9.5"
+				cy="7.5"
+				r="2.75"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M14.75 10.25C16.2688 10.25 17.25 9.01878 17.25 7.5C17.25 5.98122 16.2688 4.75 14.75 4.75"
+			/>
+		</>
+	),
+	'pie-chart': () => (
+		<>
+			<circle
+				cx="12"
+				cy="12"
+				r="7.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M11.75 5V10.25C11.75 11.3546 12.6454 12.25 13.75 12.25H19"
+			/>
+		</>
+	),
+	'user-cross': () => (
+		<>
+			<circle
+				cx="12"
+				cy="8"
+				r="3.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M12.25 19.25H6.94953C5.77004 19.25 4.88989 18.2103 5.49085 17.1954C6.36247 15.7234 8.23935 14 12.25 14"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 19.25L15.75 15.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.75 19.25L19.25 15.75"
+			/>
+		</>
+	),
+	flag: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5.75 19.25L5.75 13.25M5.75 13.25L5.75 5.75C5.75 5.75 8.5 3.5 12 5.75C15.5 8 18.25 5.75 18.25 5.75L18.25 13.25C18.25 13.25 15.5 15.5 12 13.25C8.5 11 5.75 13.25 5.75 13.25Z"
+			/>
+		</>
+	),
+	announcement: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-width="1.5"
+				d="M19.25 10C19.25 12.7289 17.85 15.25 16.5 15.25C15.15 15.25 13.75 12.7289 13.75 10C13.75 7.27106 15.15 4.75 16.5 4.75C17.85 4.75 19.25 7.27106 19.25 10Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-width="1.5"
+				d="M16.5 15.25C16.5 15.25 8 13.5 7 13.25C6 13 4.75 11.6893 4.75 10C4.75 8.31066 6 7 7 6.75C8 6.5 16.5 4.75 16.5 4.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-width="1.5"
+				d="M6.75 13.5V17.25C6.75 18.3546 7.64543 19.25 8.75 19.25H9.25C10.3546 19.25 11.25 18.3546 11.25 17.25V14.5"
+			/>
+		</>
+	),
+	globe: () => (
+		<>
+			<circle
+				cx="12"
+				cy="12"
+				r="7.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.25 12C15.25 16.5 13.2426 19.25 12 19.25C10.7574 19.25 8.75 16.5 8.75 12C8.75 7.5 10.7574 4.75 12 4.75C13.2426 4.75 15.25 7.5 15.25 12Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5 12H12H19"
+			/>
+		</>
+	),
+	photo: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 16L7.49619 12.5067C8.2749 11.5161 9.76453 11.4837 10.5856 12.4395L13 15.25M10.915 12.823C11.9522 11.5037 13.3973 9.63455 13.4914 9.51294C13.4947 9.50859 13.4979 9.50448 13.5013 9.50017C14.2815 8.51598 15.7663 8.48581 16.5856 9.43947L19 12.25M6.75 19.25H17.25C18.3546 19.25 19.25 18.3546 19.25 17.25V6.75C19.25 5.64543 18.3546 4.75 17.25 4.75H6.75C5.64543 4.75 4.75 5.64543 4.75 6.75V17.25C4.75 18.3546 5.64543 19.25 6.75 19.25Z"
+			/>
+		</>
+	),
+	code: () => (
+		<>
+			<rect
+				width="14.5"
+				height="14.5"
+				x="4.75"
+				y="4.75"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				rx="2"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M8.75 10.75L11.25 13L8.75 15.25"
+			/>
+		</>
+	),
+	shield: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M12 4.75L4.75001 8C4.75001 8 4.00001 19.25 12 19.25C20 19.25 19.25 8 19.25 8L12 4.75Z"
+			/>
+		</>
+	),
+	'warning-triangle': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.9522 16.3536L10.2152 5.85658C10.9531 4.38481 13.0539 4.3852 13.7913 5.85723L19.0495 16.3543C19.7156 17.6841 18.7487 19.25 17.2613 19.25H6.74007C5.25234 19.25 4.2854 17.6835 4.9522 16.3536Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M12 10V12"
+			/>
+			<circle cx="12" cy="16" r="1" fill="currentColor" />
+		</>
+	),
+	message: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M12 18.25C15.5 18.25 19.25 16.5 19.25 12C19.25 7.5 15.5 5.75 12 5.75C8.5 5.75 4.75 7.5 4.75 12C4.75 13.0298 4.94639 13.9156 5.29123 14.6693C5.50618 15.1392 5.62675 15.6573 5.53154 16.1651L5.26934 17.5635C5.13974 18.2547 5.74527 18.8603 6.43651 18.7307L9.64388 18.1293C9.896 18.082 10.1545 18.0861 10.4078 18.1263C10.935 18.2099 11.4704 18.25 12 18.25Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="M9.5 12C9.5 12.2761 9.27614 12.5 9 12.5C8.72386 12.5 8.5 12.2761 8.5 12C8.5 11.7239 8.72386 11.5 9 11.5C9.27614 11.5 9.5 11.7239 9.5 12Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="M12.5 12C12.5 12.2761 12.2761 12.5 12 12.5C11.7239 12.5 11.5 12.2761 11.5 12C11.5 11.7239 11.7239 11.5 12 11.5C12.2761 11.5 12.5 11.7239 12.5 12Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="M15.5 12C15.5 12.2761 15.2761 12.5 15 12.5C14.7239 12.5 14.5 12.2761 14.5 12C14.5 11.7239 14.7239 11.5 15 11.5C15.2761 11.5 15.5 11.7239 15.5 12Z"
+			/>
+		</>
+	),
+	inbox: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 11.75L17.6644 6.20056C17.4191 5.34195 16.6344 4.75 15.7414 4.75H8.2586C7.36564 4.75 6.58087 5.34196 6.33555 6.20056L4.75 11.75"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M10.2142 12.3689C9.95611 12.0327 9.59467 11.75 9.17085 11.75H4.75V17.25C4.75 18.3546 5.64543 19.25 6.75 19.25H17.25C18.3546 19.25 19.25 18.3546 19.25 17.25V11.75H14.8291C14.4053 11.75 14.0439 12.0327 13.7858 12.3689C13.3745 12.9046 12.7276 13.25 12 13.25C11.2724 13.25 10.6255 12.9046 10.2142 12.3689Z"
+			/>
+		</>
+	),
+	'arrow-left': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M10.25 6.75L4.75 12L10.25 17.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 12H5"
+			/>
+		</>
+	),
+	'chevron-right': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M10.75 8.75L14.25 12L10.75 15.25"
+			/>
+		</>
+	),
+	'chevron-down': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.25 10.75L12 14.25L8.75 10.75"
+			/>
+		</>
+	),
+	'chevron-left': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M13.25 8.75L9.75 12L13.25 15.25"
+			/>
+		</>
+	),
+	'chevron-up': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.25 14.25L12 10.75L8.75 14.25"
+			/>
+		</>
+	),
+	folder: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 17.25V9.75C19.25 8.64543 18.3546 7.75 17.25 7.75H4.75V17.25C4.75 18.3546 5.64543 19.25 6.75 19.25H17.25C18.3546 19.25 19.25 18.3546 19.25 17.25Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M13.5 7.5L12.5685 5.7923C12.2181 5.14977 11.5446 4.75 10.8127 4.75H6.75C5.64543 4.75 4.75 5.64543 4.75 6.75V11"
+			/>
+		</>
+	),
+	file: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M7.75 19.25H16.25C17.3546 19.25 18.25 18.3546 18.25 17.25V9L14 4.75H7.75C6.64543 4.75 5.75 5.64543 5.75 6.75V17.25C5.75 18.3546 6.64543 19.25 7.75 19.25Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M18 9.25H13.75V5"
+			/>
+		</>
+	),
+	search: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 19.25L15.5 15.5M4.75 11C4.75 7.54822 7.54822 4.75 11 4.75C14.4518 4.75 17.25 7.54822 17.25 11C17.25 14.4518 14.4518 17.25 11 17.25C7.54822 17.25 4.75 14.4518 4.75 11Z"
+			/>
+		</>
+	),
+	edit: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 19.25L9 18.25L18.2929 8.95711C18.6834 8.56658 18.6834 7.93342 18.2929 7.54289L16.4571 5.70711C16.0666 5.31658 15.4334 5.31658 15.0429 5.70711L5.75 15L4.75 19.25Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 19.25H13.75"
+			/>
+		</>
+	),
+	check: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5.75 12.8665L8.33995 16.4138C9.15171 17.5256 10.8179 17.504 11.6006 16.3715L18.25 6.75"
+			/>
+		</>
+	),
+	close: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M17.25 6.75L6.75 17.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M6.75 6.75L17.25 17.25"
+			/>
+		</>
+	),
+	play: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M18.25 12L5.75 5.75V18.25L18.25 12Z"
+			/>
+		</>
+	),
+	pause: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M15.25 6.75V17.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M8.75 6.75V17.25"
+			/>
+		</>
+	),
+	information: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="2"
+				d="M12 13V15"
+			/>
+			<circle cx="12" cy="9" r="1" fill="currentColor" />
+			<circle
+				cx="12"
+				cy="12"
+				r="7.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+		</>
+	),
+	user: () => (
+		<>
+			<circle
+				cx="12"
+				cy="8"
+				r="3.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M6.8475 19.25H17.1525C18.2944 19.25 19.174 18.2681 18.6408 17.2584C17.8563 15.7731 16.068 14 12 14C7.93201 14 6.14367 15.7731 5.35924 17.2584C4.82597 18.2681 5.70558 19.25 6.8475 19.25Z"
+			/>
+		</>
+	),
+	lock: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5.75 11.75C5.75 11.1977 6.19772 10.75 6.75 10.75H17.25C17.8023 10.75 18.25 11.1977 18.25 11.75V17.25C18.25 18.3546 17.3546 19.25 16.25 19.25H7.75C6.64543 19.25 5.75 18.3546 5.75 17.25V11.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M7.75 10.5V10.3427C7.75 8.78147 7.65607 7.04125 8.74646 5.9239C9.36829 5.2867 10.3745 4.75 12 4.75C13.6255 4.75 14.6317 5.2867 15.2535 5.9239C16.3439 7.04125 16.25 8.78147 16.25 10.3427V10.5"
+			/>
+		</>
+	),
+	'lock-unlocked': () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M5.75 11.75C5.75 11.1977 6.19772 10.75 6.75 10.75H17.25C17.8023 10.75 18.25 11.1977 18.25 11.75V17.25C18.25 18.3546 17.3546 19.25 16.25 19.25H7.75C6.64543 19.25 5.75 18.3546 5.75 17.25V11.75Z"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M7.75 10.5V9.84343C7.75 8.61493 7.70093 7.29883 8.42416 6.30578C8.99862 5.51699 10.0568 4.75 12 4.75C14 4.75 15.25 6.25 15.25 6.25"
+			/>
+		</>
+	),
+	menu: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 5.75H19.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 18.25H19.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M4.75 12H19.25"
+			/>
+		</>
+	),
+	copy: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M6.5 15.25V15.25C5.5335 15.25 4.75 14.4665 4.75 13.5V6.75C4.75 5.64543 5.64543 4.75 6.75 4.75H13.5C14.4665 4.75 15.25 5.5335 15.25 6.5V6.5"
+			/>
+			<rect
+				width="10.5"
+				height="10.5"
+				x="8.75"
+				y="8.75"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				rx="2"
+			/>
+		</>
+	),
+	'dots-horizontal': () => (
+		<>
+			<path
+				fill="currentColor"
+				d="M13 12C13 12.5523 12.5523 13 12 13C11.4477 13 11 12.5523 11 12C11 11.4477 11.4477 11 12 11C12.5523 11 13 11.4477 13 12Z"
+			/>
+			<path
+				fill="currentColor"
+				d="M9 12C9 12.5523 8.55228 13 8 13C7.44772 13 7 12.5523 7 12C7 11.4477 7.44772 11 8 11C8.55228 11 9 11.4477 9 12Z"
+			/>
+			<path
+				fill="currentColor"
+				d="M17 12C17 12.5523 16.5523 13 16 13C15.4477 13 15 12.5523 15 12C15 11.4477 15.4477 11 16 11C16.5523 11 17 11.4477 17 12Z"
+			/>
+		</>
+	),
+	target: () => (
+		<>
+			<circle
+				cx="12"
+				cy="12"
+				r="7.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+			<circle
+				cx="12"
+				cy="12"
+				r="4.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+			<circle
+				cx="12"
+				cy="12"
+				r="1.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+		</>
+	),
+	redo: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M14.75 4.75L19.25 9L14.75 13.25"
+			/>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 9H8.75C6.54086 9 4.75 10.7909 4.75 13V19.25"
+			/>
+		</>
+	),
+	star: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M12 4.75L13.75 10.25H19.25L14.75 13.75L16.25 19.25L12 15.75L7.75 19.25L9.25 13.75L4.75 10.25H10.25L12 4.75Z"
+			/>
+		</>
+	),
+	heart: () => (
+		<>
+			<path
+				fill-rule="evenodd"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M11.995 7.23319C10.5455 5.60999 8.12832 5.17335 6.31215 6.65972C4.49599 8.14609 4.2403 10.6312 5.66654 12.3892L11.995 18.25L18.3235 12.3892C19.7498 10.6312 19.5253 8.13046 17.6779 6.65972C15.8305 5.18899 13.4446 5.60999 11.995 7.23319Z"
+				clip-rule="evenodd"
+			/>
+		</>
+	),
+	eye: () => (
+		<>
+			<path
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+				d="M19.25 12C19.25 13 17.5 18.25 12 18.25C6.5 18.25 4.75 13 4.75 12C4.75 11 6.5 5.75 12 5.75C17.5 5.75 19.25 11 19.25 12Z"
+			/>
+			<circle
+				cx="12"
+				cy="12"
+				r="2.25"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				stroke-width="1.5"
+			/>
+		</>
+	),
+} as const satisfies Record<IconName, () => RemixNode>

--- a/packages/worker/universal/icon.node.test.ts
+++ b/packages/worker/universal/icon.node.test.ts
@@ -1,0 +1,39 @@
+import { jsx } from 'remix/ui/jsx-runtime'
+import { renderToString } from 'remix/ui/server'
+import { expect, test } from 'vitest'
+import { Icon, iconicGlyphViewBox, renderIcon } from './icon.tsx'
+
+test('Iconic icons crop padded viewBoxes and stay decorative unless titled', async () => {
+	const decorative = await renderToString(
+		jsx(Icon, { name: 'home', size: '16' }),
+	)
+	expect(decorative).toContain(`viewBox="${iconicGlyphViewBox}"`)
+	expect(decorative).toContain('data-icon="home"')
+	expect(decorative).toContain('aria-hidden="true"')
+	expect(decorative).not.toContain('aria-label')
+	expect(decorative).toContain('stroke="currentColor"')
+	expect(decorative).toContain('width="16"')
+	expect(iconicGlyphViewBox).toBe('3.75 3.75 16.5 16.5')
+
+	const labelled = await renderToString(
+		jsx(Icon, { name: 'search', title: 'Search files' }),
+	)
+	expect(labelled).toContain('aria-label="Search files"')
+	expect(labelled).toContain('role="img"')
+	expect(labelled).not.toContain('aria-hidden')
+
+	const helper = await renderToString(renderIcon('mail'))
+	expect(helper).toContain('data-icon="mail"')
+	expect(helper).toContain('aria-hidden="true"')
+})
+
+test('every Iconic glyph name has a cropped currentColor stroke', async () => {
+	const { iconNames } = await import('./icon-glyphs.tsx')
+	for (const name of iconNames) {
+		const html = await renderToString(renderIcon(name))
+		expect(html).toContain(`data-icon="${name}"`)
+		expect(html).toContain(`viewBox="${iconicGlyphViewBox}"`)
+		expect(html).toContain('aria-hidden="true"')
+		expect(html).toContain('stroke="currentColor"')
+	}
+})

--- a/packages/worker/universal/icon.node.test.ts
+++ b/packages/worker/universal/icon.node.test.ts
@@ -12,6 +12,7 @@ test('Iconic icons crop padded viewBoxes and stay decorative unless titled', asy
 	expect(decorative).toContain('aria-hidden="true"')
 	expect(decorative).not.toContain('aria-label')
 	expect(decorative).toContain('stroke="currentColor"')
+	expect(decorative).not.toMatch(/<svg[^>]*\bstroke=/)
 	expect(decorative).toContain('width="16"')
 	expect(iconicGlyphViewBox).toBe('3.75 3.75 16.5 16.5')
 
@@ -25,6 +26,10 @@ test('Iconic icons crop padded viewBoxes and stay decorative unless titled', asy
 	const helper = await renderToString(renderIcon('mail'))
 	expect(helper).toContain('data-icon="mail"')
 	expect(helper).toContain('aria-hidden="true"')
+
+	const fillOnly = await renderToString(renderIcon('dots-horizontal'))
+	expect(fillOnly).toContain('fill="currentColor"')
+	expect(fillOnly).not.toMatch(/<svg[^>]*\bstroke=/)
 })
 
 test('every Iconic glyph name has a cropped currentColor stroke', async () => {
@@ -34,6 +39,10 @@ test('every Iconic glyph name has a cropped currentColor stroke', async () => {
 		expect(html).toContain(`data-icon="${name}"`)
 		expect(html).toContain(`viewBox="${iconicGlyphViewBox}"`)
 		expect(html).toContain('aria-hidden="true"')
-		expect(html).toContain('stroke="currentColor"')
+		expect(html).not.toMatch(/<svg[^>]*\bstroke=/)
+		expect(
+			html.includes('stroke="currentColor"') ||
+				html.includes('fill="currentColor"'),
+		).toBe(true)
 	}
 })

--- a/packages/worker/universal/icon.tsx
+++ b/packages/worker/universal/icon.tsx
@@ -8,7 +8,9 @@ export type { IconName } from './icon-glyphs.tsx'
 /**
  * Iconic draws in a 24×24 viewBox with ~4.75 units of padding so the 1.5px
  * stroke never clips. That reads small next to type. Crop to the glyph the
- * same way `provider-icons` crops padded brand marks.
+ * same way `provider-icons` crops padded brand marks. Glyphs carry their own
+ * stroke and fill — do not stamp stroke on the `<svg>` or fill-only marks
+ * inherit it and bloat.
  */
 export const iconicGlyphViewBox = '3.75 3.75 16.5 16.5'
 
@@ -36,10 +38,6 @@ export function renderIcon(
 			width={size}
 			height={size}
 			fill="none"
-			stroke="currentColor"
-			stroke-width="1.5"
-			stroke-linecap="round"
-			stroke-linejoin="round"
 			aria-hidden={labelled ? undefined : 'true'}
 			role={labelled ? 'img' : undefined}
 			aria-label={options.title}

--- a/packages/worker/universal/icon.tsx
+++ b/packages/worker/universal/icon.tsx
@@ -4,7 +4,6 @@ import { type Handle, type RemixNode } from 'remix/ui'
 import { iconGlyphs, type IconName } from './icon-glyphs.tsx'
 
 export type { IconName } from './icon-glyphs.tsx'
-export { iconNames } from './icon-glyphs.tsx'
 
 /**
  * Iconic draws in a 24×24 viewBox with ~4.75 units of padding so the 1.5px
@@ -13,7 +12,7 @@ export { iconNames } from './icon-glyphs.tsx'
  */
 export const iconicGlyphViewBox = '3.75 3.75 16.5 16.5'
 
-export const defaultIconSize = '1em'
+const defaultIconSize = '1em'
 
 export type IconProps = {
 	name: IconName

--- a/packages/worker/universal/icon.tsx
+++ b/packages/worker/universal/icon.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource remix/ui */
+/** @jsxRuntime automatic */
+import { type Handle, type RemixNode } from 'remix/ui'
+import { iconGlyphs, type IconName } from './icon-glyphs.tsx'
+
+export type { IconName } from './icon-glyphs.tsx'
+export { iconNames } from './icon-glyphs.tsx'
+
+/**
+ * Iconic draws in a 24×24 viewBox with ~4.75 units of padding so the 1.5px
+ * stroke never clips. That reads small next to type. Crop to the glyph the
+ * same way `provider-icons` crops padded brand marks.
+ */
+export const iconicGlyphViewBox = '3.75 3.75 16.5 16.5'
+
+export const defaultIconSize = '1em'
+
+export type IconProps = {
+	name: IconName
+	size?: string
+	/**
+	 * Accessible name. Omit for decorative icons (they are `aria-hidden`).
+	 */
+	title?: string
+}
+
+export function renderIcon(
+	name: IconName,
+	options: { size?: string; title?: string } = {},
+): RemixNode {
+	const size = options.size ?? defaultIconSize
+	const labelled = Boolean(options.title)
+	return (
+		<svg
+			data-icon={name}
+			viewBox={iconicGlyphViewBox}
+			width={size}
+			height={size}
+			fill="none"
+			stroke="currentColor"
+			stroke-width="1.5"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden={labelled ? undefined : 'true'}
+			role={labelled ? 'img' : undefined}
+			aria-label={options.title}
+			focusable={false}
+		>
+			{iconGlyphs[name]()}
+		</svg>
+	)
+}
+
+export function Icon(handle: Handle<IconProps>) {
+	return () => renderIcon(handle.props.name, handle.props)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give the account and admin left rails Iconic.app icons, and swap other in-page stroke icons onto the same Iconic glyphs so the site looks like one set.

## Why

The rails were label-only. Iconic is the licensed set (Pro on iconic.app; this PR vendors the official **free** SVGs — bulk Pro download is still paywalled). Do not invent a competing icon set.

## Summary

- Shared `Icon` / `renderIcon` crops Iconic's padded 24×24 viewBox to `3.75 3.75 16.5 16.5` (same idea as padded brand-mark crop). Glyphs carry their own stroke/fill so fill-only marks do not inherit a wrapper stroke.
- Account rail: home, clock, link, box, share, wallet, chart, trending-up, briefcase, refresh, cloud (Webhooks), key, plug, server, book, mail.
- Admin rail: users, pie-chart, user-cross, flag, announcement, globe, photo, code, shield, warning-triangle, message, inbox.
- Sweep: package explorer, heading permalinks, banners, combobox check, landing controls, login passkey, onboarding, docs mobile menu, BYOK eye, and similar ad-hoc SVGs.
- Left as-is: official brand marks, host logos, charts, site-header CSS burger, git-fork (no free Iconic fork), walkthrough agent-bot (no free robot).

## Testing

- Local `npm run validate` green after rebase onto `main` (includes `/account/webhooks`).
- `test:push` green after the fill-stroke inheritance fix.
- Browser: account + admin rails on desktop and mobile (~860px collapse), including Webhooks.
- Risk: **low** (`composes` app-ui). Preview-manual-test not required.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `e2a5e367` · **Head:** `800fb36b`

**Classification:** composes — no primitives added or changed; this PR wires Iconic glyphs into existing Remix rails and in-page UI.

### Primitives touched

| Primitive | Group    | Impact                                                                |
| --------- | -------- | --------------------------------------------------------------------- |
| `app-ui`  | surfaces | composes — shared `Icon` helper plus account/admin rail and UI swaps |

### Change flow

Signed-in account and admin shells render rail links through `AccountManagementLinkNav`, which now draws cropped Iconic SVGs.

```mermaid
sequenceDiagram
	actor user as Signed-in user
	participant appUi as app-ui
	user->>appUi: GET /account or /admin
	appUi->>appUi: pick Iconic name per rail item
	appUi->>appUi: crop padded 24x24 viewBox to 3.75 3.75 16.5 16.5
	appUi-->>user: decorative currentColor SVGs beside labels
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c2ea2b5-1ae7-5bd3-abae-6f5444bd8552?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c2ea2b5-1ae7-5bd3-abae-6f5444bd8552&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared icon library across account navigation, documentation menus, onboarding, authentication, package management, banners, and landing-page controls.
  - Account and admin navigation now displays relevant icons alongside labels.
  - Icons support flexible sizing, accessible labels, decorative behavior, and current-color styling.

- **Accessibility**
  - Improved icon semantics so decorative icons are hidden from assistive technology while titled icons provide accessible labels.

- **Style**
  - Replaced text-based menu symbols and locally rendered graphics with consistent icon appearances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->