### PR TITLE
Cascade-delete community_forks when a saved package is deleted

### DIFF
--- a/docs/contributing/architecture/data-storage.md
+++ b/docs/contributing/architecture/data-storage.md
@@ -425,7 +425,12 @@ The schema is defined by migrations in `packages/worker/migrations/`:
   account UI
 - `community_listings`, `community_forks`, `community_ratings`,
   `community_reports`, `community_bans`: public package listings and moderation
-  (see [Public packages](../community-packages.md))
+  (see [Public packages](../community-packages.md)). `community_forks` rows for
+  a saved package are removed on package delete (`packageDelete` / account
+  package delete) and by D1 `AFTER DELETE` triggers on `saved_packages` and
+  `entity_sources` (`0061-community-forks-package-delete-cascade.sql`). Inert
+  forks keep an `entity_sources` row and no `saved_packages` row, so a foreign
+  key from `forked_package_id` cannot be declared.
 - `community_activity_events`: stored `listing_published` / `listing_updated`
   profile activity events (`actor_user_id` + `listing_id`); public forks are
   derived at read time from `community_forks`

--- a/docs/contributing/community-packages.md
+++ b/docs/contributing/community-packages.md
@@ -397,9 +397,15 @@ browse intentionally ranks only the newest 500 candidates. The reported
 production mismatch for `@kentcdodds/github` was therefore consistent with a
 data snapshot/cache artifact rather than a defect in the aggregate SQL; the
 worker integration test pins that a successful fork increments the surfaced
-count. Failed fork cleanup, `packageDelete` of the forked copy, and
-`adminCommunityOrphanForksCleanup` remove the matching `community_forks` row, so
-the live count drops without a separate recount.
+count. Failed fork cleanup and `packageDelete` of the forked copy remove the
+matching `community_forks` row (application delete plus D1 `AFTER DELETE`
+triggers on `saved_packages` and `entity_sources` in
+`0061-community-forks-package-delete-cascade.sql`), so the live count drops
+without a separate recount and the viewer overlay cannot keep showing **Fork
+outdated** for a package that is gone. Healthy inert forks keep their
+`entity_sources` row and are not dropped. `adminCommunityOrphanForksCleanup`
+remains a backstop for leftover rows whose source and saved package are both
+already gone.
 
 `computeCommunityBayesianScore` in `service.ts` implements the prior so a few
 5-star ratings do not beat many good ratings.

--- a/packages/worker/migrations/0061-community-forks-package-delete-cascade.sql
+++ b/packages/worker/migrations/0061-community-forks-package-delete-cascade.sql
@@ -1,0 +1,22 @@
+-- Cascade-delete community_forks when the forked saved package or its
+-- entity source is removed. Inert community forks keep an entity_sources
+-- row and no saved_packages row, so FOREIGN KEY ON DELETE CASCADE from
+-- forked_package_id to saved_packages.id cannot be declared.
+CREATE TRIGGER IF NOT EXISTS community_forks_delete_on_saved_package_delete
+AFTER DELETE ON saved_packages
+BEGIN
+	DELETE FROM community_forks
+	WHERE forker_user_id = OLD.user_id
+		AND (
+			forked_package_id = OLD.id
+			OR forked_source_id = OLD.source_id
+		);
+END;
+
+CREATE TRIGGER IF NOT EXISTS community_forks_delete_on_entity_source_delete
+AFTER DELETE ON entity_sources
+BEGIN
+	DELETE FROM community_forks
+	WHERE forked_source_id = OLD.id
+		AND forker_user_id = OLD.user_id;
+END;

--- a/packages/worker/src/community/community-flow-test-schema.ts
+++ b/packages/worker/src/community/community-flow-test-schema.ts
@@ -2,6 +2,7 @@ import { ensureUsersTestSchema } from '#worker/users-test-schema.ts'
 import { ensureUserStorageBucketsTestSchema } from '#worker/storage-buckets/test-schema.ts'
 import { ensurePackageInvocationTokensTestSchema } from '#worker/package-invocations/test-schema.ts'
 import { ensureSecretBucketsTestSchema } from '#worker/secrets-test-schema.ts'
+import { communityForksDeleteCascadeStatements } from './community-forks-delete-cascade.ts'
 
 /**
  * Community flow workers-unit schema. Adds the community tables and the
@@ -143,6 +144,7 @@ export async function ensureCommunityFlowSchema(db: D1Database) {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_community_forks_forked_package_id
 			ON community_forks(forked_package_id)`,
+		...communityForksDeleteCascadeStatements,
 		`CREATE TABLE IF NOT EXISTS community_ratings (
 			id TEXT PRIMARY KEY NOT NULL,
 			listing_id TEXT NOT NULL,

--- a/packages/worker/src/community/community-forks-delete-cascade.ts
+++ b/packages/worker/src/community/community-forks-delete-cascade.ts
@@ -1,0 +1,33 @@
+/**
+ * D1 triggers that drop `community_forks` when the forked saved package or
+ * its entity source is deleted. Inert community forks keep an
+ * `entity_sources` row and no `saved_packages` row, so
+ * `FOREIGN KEY (forked_package_id) REFERENCES saved_packages(id) ON DELETE
+ * CASCADE` cannot be declared.
+ *
+ * Keep these statements identical to
+ * `packages/worker/migrations/0061-community-forks-package-delete-cascade.sql`.
+ */
+export const communityForksDeleteOnSavedPackageSql = `CREATE TRIGGER IF NOT EXISTS community_forks_delete_on_saved_package_delete
+AFTER DELETE ON saved_packages
+BEGIN
+	DELETE FROM community_forks
+	WHERE forker_user_id = OLD.user_id
+		AND (
+			forked_package_id = OLD.id
+			OR forked_source_id = OLD.source_id
+		);
+END`
+
+export const communityForksDeleteOnEntitySourceSql = `CREATE TRIGGER IF NOT EXISTS community_forks_delete_on_entity_source_delete
+AFTER DELETE ON entity_sources
+BEGIN
+	DELETE FROM community_forks
+	WHERE forked_source_id = OLD.id
+		AND forker_user_id = OLD.user_id;
+END`
+
+export const communityForksDeleteCascadeStatements = [
+	communityForksDeleteOnSavedPackageSql,
+	communityForksDeleteOnEntitySourceSql,
+] as const

--- a/packages/worker/src/community/orphan-forks.node.test.ts
+++ b/packages/worker/src/community/orphan-forks.node.test.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { communityForksDeleteCascadeStatements } from './community-forks-delete-cascade.ts'
 import {
 	countCommunityForksByListingIds,
 	deleteCommunityForksForPackage,
@@ -52,6 +53,7 @@ function createOrphanForkDb() {
 			actor TEXT,
 			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
 		);
+		${communityForksDeleteCascadeStatements.join(';\n')}
 	`)
 	return { sqlite, db: createD1FromSqlite(sqlite) }
 }

--- a/packages/worker/src/package-registry/delete-package-community-forks.node.test.ts
+++ b/packages/worker/src/package-registry/delete-package-community-forks.node.test.ts
@@ -1,0 +1,430 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { communityForksDeleteCascadeStatements } from '#worker/community/community-forks-delete-cascade.ts'
+import { insertCommunityFork } from '#worker/community/repo.ts'
+import { resolveViewerListingInstalls } from '#worker/community/viewer-install.ts'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+import { createInMemoryUserMeterEnv } from '#worker/test-support/user-meter.ts'
+
+const mockModule = vi.hoisted(() => ({
+	cleanupArtifactReposForPackage: vi.fn(),
+	deleteEntitySource: vi.fn(),
+	deleteJobRow: vi.fn(),
+	listJobRowsByUserId: vi.fn(),
+	syncJobManagerAlarm: vi.fn(),
+	deleteSavedPackageVector: vi.fn(),
+	removePackageRetrieverManifestCacheEntries: vi.fn(),
+	deleteAllAppScopedValues: vi.fn(),
+	deleteAllPackageScopedSecrets: vi.fn(),
+	removeAllSecretApprovalsForPackage: vi.fn(),
+	clearStorage: vi.fn(async () => ({ ok: true as const })),
+	storageRunnerRpc: vi.fn(),
+	unpublishCommunityListing: vi.fn(),
+}))
+
+vi.mock('#worker/storage-runner.ts', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>
+	return {
+		...actual,
+		storageRunnerRpc: (...args: Array<unknown>) => {
+			mockModule.storageRunnerRpc(...args)
+			return {
+				clearStorage: (...clearArgs: Array<unknown>) =>
+					mockModule.clearStorage(...clearArgs),
+			}
+		},
+	}
+})
+
+vi.mock('#worker/package-config-cleanup.ts', () => ({
+	deleteAllAppScopedValues: (...args: Array<unknown>) =>
+		mockModule.deleteAllAppScopedValues(...args),
+	deleteAllPackageScopedSecrets: (...args: Array<unknown>) =>
+		mockModule.deleteAllPackageScopedSecrets(...args),
+	removeAllSecretApprovalsForPackage: (...args: Array<unknown>) =>
+		mockModule.removeAllSecretApprovalsForPackage(...args),
+}))
+
+vi.mock('#worker/package-retrievers/manifest-cache.ts', () => ({
+	removePackageRetrieverManifestCacheEntries: (...args: Array<unknown>) =>
+		mockModule.removePackageRetrieverManifestCacheEntries(...args),
+	refreshPackageRetrieverManifestCache: vi.fn(),
+}))
+
+vi.mock('./vectorize.ts', () => ({
+	deleteSavedPackageVector: (...args: Array<unknown>) =>
+		mockModule.deleteSavedPackageVector(...args),
+	upsertSavedPackageVector: vi.fn(),
+}))
+
+vi.mock('#worker/jobs/jobs-data.ts', () => ({
+	jobsData: () => ({
+		deleteJob: (...args: Array<unknown>) => mockModule.deleteJobRow(...args),
+		listJobsForUser: (...args: Array<unknown>) =>
+			mockModule.listJobRowsByUserId(...args),
+	}),
+}))
+
+vi.mock('#worker/jobs/manager-client.ts', () => ({
+	syncJobManagerAlarm: (...args: Array<unknown>) =>
+		mockModule.syncJobManagerAlarm(...args),
+}))
+
+vi.mock('#worker/repo/artifact-repo-cleanup.ts', () => ({
+	cleanupArtifactReposForPackage: (...args: Array<unknown>) =>
+		mockModule.cleanupArtifactReposForPackage(...args),
+}))
+
+vi.mock('#worker/repo/entity-sources.ts', () => ({
+	deleteEntitySource: (...args: Array<unknown>) =>
+		mockModule.deleteEntitySource(...args),
+}))
+
+vi.mock('#worker/community/service.ts', () => ({
+	unpublishCommunityListing: (...args: Array<unknown>) =>
+		mockModule.unpublishCommunityListing(...args),
+}))
+
+vi.mock('#worker/community/repo.ts', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>
+	return {
+		...actual,
+		getCommunityListingByOwnerAndPackage: vi.fn(async () => null),
+	}
+})
+
+const { deleteSavedPackageProjection } = await import('./service.ts')
+
+const listingRef = {
+	id: 'listing-plaid',
+	kodyId: 'plaid',
+	pinnedCommit: 'commit-new',
+}
+
+function createDeleteForkDb() {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE users (
+			stable_user_id TEXT PRIMARY KEY NOT NULL,
+			deleting_at TEXT
+		);
+		CREATE TABLE saved_packages (
+			id TEXT PRIMARY KEY NOT NULL,
+			user_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			kody_id TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			tags_json TEXT NOT NULL DEFAULT '[]',
+			search_text TEXT,
+			source_id TEXT NOT NULL,
+			has_app INTEGER NOT NULL DEFAULT 0,
+			hidden INTEGER NOT NULL DEFAULT 0,
+			is_private INTEGER NOT NULL DEFAULT 1,
+			locked_at TEXT,
+			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+			updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+		);
+		CREATE TABLE entity_sources (
+			id TEXT PRIMARY KEY NOT NULL,
+			user_id TEXT NOT NULL,
+			entity_kind TEXT NOT NULL,
+			entity_id TEXT NOT NULL
+		);
+		CREATE TABLE community_forks (
+			id TEXT PRIMARY KEY NOT NULL,
+			listing_id TEXT NOT NULL,
+			forker_user_id TEXT NOT NULL,
+			origin_commit TEXT NOT NULL,
+			forked_package_id TEXT NOT NULL,
+			forked_source_id TEXT NOT NULL,
+			target_kody_id TEXT NOT NULL,
+			listing_name TEXT,
+			listing_kody_id TEXT,
+			adopted_at TEXT,
+			adoption_note TEXT,
+			actor TEXT,
+			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+		);
+		CREATE TABLE package_kody_id_redirects (
+			user_id TEXT NOT NULL,
+			old_kody_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+			PRIMARY KEY (user_id, old_kody_id)
+		);
+		CREATE TABLE package_invocation_tokens (
+			id TEXT PRIMARY KEY NOT NULL,
+			user_id TEXT NOT NULL,
+			package_id TEXT NOT NULL,
+			token_hash TEXT NOT NULL,
+			name TEXT NOT NULL,
+			export_names_json TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE user_storage_buckets (
+			user_id TEXT NOT NULL,
+			storage_id TEXT NOT NULL,
+			kind TEXT NOT NULL DEFAULT 'package'
+		);
+		${communityForksDeleteCascadeStatements.join(';\n')}
+	`)
+	return { sqlite, db: createD1FromSqlite(sqlite) }
+}
+
+test('package delete removes community_forks so Fork outdated does not linger', async () => {
+	const migrationPath = join(
+		dirname(fileURLToPath(import.meta.url)),
+		'../../migrations/0061-community-forks-package-delete-cascade.sql',
+	)
+	const migrationSql = readFileSync(migrationPath, 'utf8')
+	for (const statement of communityForksDeleteCascadeStatements) {
+		expect(migrationSql).toContain(statement)
+	}
+
+	const { db } = createDeleteForkDb()
+	const meter = createInMemoryUserMeterEnv()
+	const env = {
+		APP_DB: db,
+		USER_METER: meter.env.USER_METER,
+	} as Env
+	await db
+		.prepare(
+			`INSERT INTO users (stable_user_id, deleting_at) VALUES ('user-kent', NULL)`,
+		)
+		.run()
+	await db
+		.prepare(
+			`INSERT INTO entity_sources (id, user_id, entity_kind, entity_id)
+			VALUES ('source-live', 'user-kent', 'package', 'package-live'),
+				('source-inert', 'user-kent', 'package', 'package-inert'),
+				('source-other', 'user-other', 'package', 'package-other')`,
+		)
+		.run()
+	await db
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, source_id
+			) VALUES (
+				'package-live', 'user-kent', '@kentcdodds/plaid', 'plaid',
+				'Kent copy', 'source-live'
+			)`,
+		)
+		.run()
+	await insertCommunityFork(db, {
+		id: 'fork-live',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-kent',
+		origin_commit: 'commit-old',
+		forked_package_id: 'package-live',
+		forked_source_id: 'source-live',
+		target_kody_id: 'plaid',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+	await insertCommunityFork(db, {
+		id: 'fork-inert',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-kent',
+		origin_commit: 'commit-old',
+		forked_package_id: 'package-inert',
+		forked_source_id: 'source-inert',
+		target_kody_id: 'plaid-inert',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+	await insertCommunityFork(db, {
+		id: 'fork-other',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-other',
+		origin_commit: 'commit-old',
+		forked_package_id: 'package-other',
+		forked_source_id: 'source-other',
+		target_kody_id: 'plaid',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+
+	const beforeInstalls = resolveViewerListingInstalls({
+		listings: [listingRef],
+		packageScope: 'kentcdodds',
+		savedPackages: [
+			{
+				id: 'package-live',
+				kodyId: 'plaid',
+				name: '@kentcdodds/plaid',
+				sourceId: 'source-live',
+			},
+		],
+		forks: [
+			{
+				listingId: 'listing-plaid',
+				targetKodyId: 'plaid',
+				forkedPackageId: 'package-live',
+				forkedSourceId: 'source-live',
+				createdAt: '2026-08-13T00:00:00.000Z',
+				originCommit: 'commit-old',
+			},
+		],
+		listingPinIsAncestorByListingId: new Map([['listing-plaid', false]]),
+	})
+	expect(beforeInstalls.get('listing-plaid')).toMatchObject({
+		status: 'installed',
+		listingAhead: true,
+		packageId: 'package-live',
+	})
+
+	mockModule.cleanupArtifactReposForPackage.mockResolvedValue(0)
+	mockModule.deleteEntitySource.mockResolvedValue(true)
+	mockModule.listJobRowsByUserId.mockResolvedValue([])
+	mockModule.deleteSavedPackageVector.mockResolvedValue(undefined)
+	mockModule.removePackageRetrieverManifestCacheEntries.mockResolvedValue(
+		undefined,
+	)
+	mockModule.deleteAllAppScopedValues.mockResolvedValue(undefined)
+	mockModule.deleteAllPackageScopedSecrets.mockResolvedValue(undefined)
+	mockModule.removeAllSecretApprovalsForPackage.mockResolvedValue(undefined)
+
+	await deleteSavedPackageProjection({
+		env,
+		userId: 'user-kent',
+		packageId: 'package-live',
+	})
+
+	const remaining = await db
+		.prepare(
+			`SELECT id, forker_user_id, forked_package_id FROM community_forks
+			ORDER BY id`,
+		)
+		.all<{
+			id: string
+			forker_user_id: string
+			forked_package_id: string
+		}>()
+	expect(remaining.results).toEqual([
+		{
+			id: 'fork-inert',
+			forker_user_id: 'user-kent',
+			forked_package_id: 'package-inert',
+		},
+		{
+			id: 'fork-other',
+			forker_user_id: 'user-other',
+			forked_package_id: 'package-other',
+		},
+	])
+	expect(
+		await db
+			.prepare(`SELECT id FROM saved_packages WHERE id = 'package-live'`)
+			.first(),
+	).toBeNull()
+
+	const afterInstalls = resolveViewerListingInstalls({
+		listings: [listingRef],
+		packageScope: 'kentcdodds',
+		savedPackages: [],
+		forks: remaining.results
+			.filter((row) => row.forker_user_id === 'user-kent')
+			.map((row) => ({
+				listingId: 'listing-plaid',
+				targetKodyId: 'plaid-inert',
+				forkedPackageId: row.forked_package_id,
+				forkedSourceId: 'source-inert',
+				createdAt: '2026-08-13T00:00:00.000Z',
+				originCommit: 'commit-old',
+			})),
+		listingPinIsAncestorByListingId: new Map([['listing-plaid', false]]),
+	})
+	expect(afterInstalls.get('listing-plaid')).toMatchObject({
+		status: 'adaptation_required',
+		targetName: '@kentcdodds/plaid-inert',
+		packageId: null,
+	})
+	const kentDeletedCopyForks = await db
+		.prepare(
+			`SELECT id FROM community_forks
+			WHERE forker_user_id = 'user-kent'
+				AND listing_id = 'listing-plaid'
+				AND (forked_package_id = 'package-live' OR target_kody_id = 'plaid')`,
+		)
+		.all<{ id: string }>()
+	expect(kentDeletedCopyForks.results).toEqual([])
+	const afterDeletedCopyOnly = resolveViewerListingInstalls({
+		listings: [listingRef],
+		packageScope: 'kentcdodds',
+		savedPackages: [],
+		forks: kentDeletedCopyForks.results.map((row) => ({
+			listingId: 'listing-plaid',
+			targetKodyId: listingRef.kodyId,
+			forkedPackageId: row.id,
+			forkedSourceId: row.id,
+			createdAt: '2026-08-13T00:00:00.000Z',
+			originCommit: 'commit-old',
+		})),
+		listingPinIsAncestorByListingId: new Map([['listing-plaid', false]]),
+	})
+	expect(afterDeletedCopyOnly.has('listing-plaid')).toBe(false)
+
+	await db
+		.prepare(
+			`INSERT INTO saved_packages (
+				id, user_id, name, kody_id, description, source_id
+			) VALUES (
+				'package-trigger', 'user-kent', '@kentcdodds/plaid-trigger',
+				'plaid-trigger', 'Trigger copy', 'source-trigger'
+			)`,
+		)
+		.run()
+	await insertCommunityFork(db, {
+		id: 'fork-trigger-package',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-kent',
+		origin_commit: 'commit-old',
+		forked_package_id: 'package-trigger',
+		forked_source_id: 'source-trigger',
+		target_kody_id: 'plaid-trigger',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+	await db
+		.prepare(`DELETE FROM saved_packages WHERE id = 'package-trigger'`)
+		.run()
+	expect(
+		await db
+			.prepare(
+				`SELECT id FROM community_forks WHERE id = 'fork-trigger-package'`,
+			)
+			.first(),
+	).toBeNull()
+
+	await db
+		.prepare(
+			`INSERT INTO entity_sources (id, user_id, entity_kind, entity_id)
+			VALUES ('source-trigger-2', 'user-kent', 'package', 'package-gone')`,
+		)
+		.run()
+	await insertCommunityFork(db, {
+		id: 'fork-trigger-source',
+		listing_id: 'listing-plaid',
+		forker_user_id: 'user-kent',
+		origin_commit: 'commit-old',
+		forked_package_id: 'package-gone',
+		forked_source_id: 'source-trigger-2',
+		target_kody_id: 'plaid-source',
+		listing_name: '@kody/plaid',
+		listing_kody_id: 'plaid',
+	})
+	await db
+		.prepare(`DELETE FROM entity_sources WHERE id = 'source-trigger-2'`)
+		.run()
+	expect(
+		await db
+			.prepare(
+				`SELECT id FROM community_forks WHERE id = 'fork-trigger-source'`,
+			)
+			.first(),
+	).toBeNull()
+})

--- a/packages/worker/src/package-registry/service.ts
+++ b/packages/worker/src/package-registry/service.ts
@@ -516,6 +516,23 @@ export async function deleteSavedPackageProjection(input: {
 						listingId: listing.id,
 					})
 				}
+			}
+			// Drop fork metadata before later cleanup so a later failure cannot
+			// leave "Fork outdated" on community listings after the package is
+			// gone. D1 triggers on saved_packages / entity_sources are the
+			// cascade backstop if a future path skips this call.
+			const deletedForks = await deleteCommunityForksForPackage(
+				input.env.APP_DB,
+				{
+					userId: input.userId,
+					packageId: input.packageId,
+					sourceId: savedPackage?.sourceId,
+				},
+			)
+			if (deletedForks > 0) {
+				invalidateCommunityPublicCache()
+			}
+			if (savedPackage) {
 				await cleanupArtifactReposForPackage({
 					env: input.env,
 					userId: input.userId,
@@ -628,17 +645,6 @@ export async function deleteSavedPackageProjection(input: {
 				userId: input.userId,
 				packageId: input.packageId,
 			})
-			const deletedForks = await deleteCommunityForksForPackage(
-				input.env.APP_DB,
-				{
-					userId: input.userId,
-					packageId: input.packageId,
-					sourceId: savedPackage?.sourceId,
-				},
-			)
-			if (deletedForks > 0) {
-				invalidateCommunityPublicCache()
-			}
 			try {
 				await removePackageRetrieverManifestCacheEntries({
 					env: input.env,

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -243,6 +243,10 @@
 		{
 			"filename": "0060-package-share-grants.sql",
 			"sha256": "4a58a86dc879782b745bf58cb6ad4d812f5b54507e042c24c6e258d3bfd03c0f"
+		},
+		{
+			"filename": "0061-community-forks-package-delete-cascade.sql",
+			"sha256": "d3701812617f097a85c49f45899b1290c0d5bdc697d6db66408333981ff321ae"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Deleting a saved package must also remove that user’s `community_forks` rows so community listings cannot keep showing **Fork outdated** after the copy is gone.

## Why

Kent’s copies of `@kody/local-conditions`, `personal-capture`, and `hn-pulse` were deleted, but leftover `community_forks` rows still overlay those listings. `#2231` already called `deleteCommunityForksForPackage` from `packageDelete`, but that cleanup ran late and there was no schema-level cascade. Inert forks cannot use `FOREIGN KEY … ON DELETE CASCADE` because they have an `entity_sources` row and no `saved_packages` row.

## Summary

- Move `deleteCommunityForksForPackage` earlier in `deleteSavedPackageProjection` so a later cleanup failure cannot leave fork metadata
- Add D1 `AFTER DELETE` triggers on `saved_packages` and `entity_sources` (`0061-community-forks-package-delete-cascade.sql`) as the durable cascade
- Keep `adminCommunityOrphanForksCleanup` as a backstop only
- Add a real-D1 test: package delete drops the live fork, healthy inert / other-user forks remain, and the deleted copy no longer resolves a viewer overlay (`listingAhead` / Fork outdated)

## Testing

- `packages/worker/src/package-registry/delete-package-community-forks.node.test.ts` (real sqlite D1 + `deleteSavedPackageProjection`)
- `packages/worker/src/community/orphan-forks.node.test.ts`
- `packages/worker/src/package-registry/service.node.test.ts`
- Pre-push: `test:node` 3115 passed, `test:workers` 345 passed
- `npm run migrations:check` (ledger 0061)

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `ad53c104` · **Head:** `94373775`

**Classification:** extends — package delete now cascades `community_forks` in the application path and at the D1 trigger layer.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — delete projection removes fork rows before later cleanup |
| `community-listings` | assistant | extends — leftover forks can no longer keep Fork outdated after package delete |
| `d1-app-db` | storage | extends — `0061` AFTER DELETE triggers on `saved_packages` and `entity_sources` |

`webhooks` matched the `package-registry/` root but this diff does not change webhook behavior.

### Change flow

Package delete drops matching `community_forks` before the rest of cleanup, and D1 triggers do the same if a row is deleted directly.

```mermaid
sequenceDiagram
	actor Owner
	participant savedPackages as saved-packages
	participant d1AppDb as d1-app-db
	participant communityListings as community-listings
	Owner->>savedPackages: packageDelete or Delete package
	savedPackages->>d1AppDb: deleteCommunityForksForPackage
	Note over d1AppDb: AFTER DELETE triggers also drop matching community_forks
	savedPackages->>d1AppDb: DELETE saved_packages and entity_sources
	communityListings->>d1AppDb: viewer overlay finds no leftover fork for that copy
```

### Before / after

**Before:** `community_forks` had no FK/trigger cascade. Delete cleaned forks late, so a later failure or a raw `saved_packages` delete left orphan rows and **Fork outdated**.

**After:** explicit delete runs first, and `0061` triggers remove rows matching `forked_package_id` / `forked_source_id` for that user. Healthy inert forks keep their `entity_sources` row.

### Invariants

Per-user isolation: triggers and the application delete both require `forker_user_id` to match the package/source owner. Other users’ forks of the same listing stay.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-936b111d-a3d2-4019-8885-aaf996abfa4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-936b111d-a3d2-4019-8885-aaf996abfa4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting a package now also removes its associated community fork records.
  - Community fork counts update automatically after package deletion.
  - Removed packages no longer leave stale “Fork outdated” indicators in viewer overlays.
  - Inert forks that still have valid source information are preserved.

- **Documentation**
  - Clarified package deletion, fork cleanup, and fork-count behavior in contributor documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->