### PR TITLE
Remove the admin platform feedback content warning banner

### DIFF
--- a/packages/worker/client/routes/admin-platform-feedback.tsx
+++ b/packages/worker/client/routes/admin-platform-feedback.tsx
@@ -236,291 +236,266 @@ export function AdminPlatformFeedbackRoute(handle: Handle) {
 				) : null}
 
 				{data ? (
-					<>
-						<section
-							aria-label="Content warning"
-							mix={css({
-								...cardCss,
-								borderColor: colors.danger,
-								backgroundColor:
-									'color-mix(in srgb, var(--color-danger) 8%, var(--color-surface))',
-							})}
-						>
-							<strong>Content warning: untrusted user-authored text</strong>
-							<p mix={css({ margin: 0 })}>{data.content_warning}</p>
-							{/* Lived on the queue sidebar until the table replaced it; it
-							    belongs with the other read-this-first framing anyway. */}
-							<p mix={css({ margin: 0 })}>
-								Table rows omit full details and account contact information.
-								Opening an entry is audit logged.
-							</p>
-						</section>
-
-						<RecordTable
-							mode="expand"
-							busy={pending}
-							ariaLabel="Platform feedback queue"
-							selectedId={selectedFeedbackId}
-							countLabel={`${data.total} submission${data.total === 1 ? '' : 's'}`}
-							emptyLabel="No platform feedback matches this view."
-							toolbar={
-								<>
-									<RecordTableSelect
-										label="Filter feedback by status"
-										value={filters.status}
-										onChange={(value) => {
-											replaceLocation(
-												buildHrefWithUpdatedFilters(currentHref, {
-													status: value,
-												}),
-											)
-										}}
+					<RecordTable
+						mode="expand"
+						busy={pending}
+						ariaLabel="Platform feedback queue"
+						selectedId={selectedFeedbackId}
+						countLabel={`${data.total} submission${data.total === 1 ? '' : 's'}`}
+						emptyLabel="No platform feedback matches this view."
+						toolbar={
+							<>
+								<RecordTableSelect
+									label="Filter feedback by status"
+									value={filters.status}
+									onChange={(value) => {
+										replaceLocation(
+											buildHrefWithUpdatedFilters(currentHref, {
+												status: value,
+											}),
+										)
+									}}
+								>
+									{statusOptions.map((option) => (
+										<option key={option.value} value={option.value}>
+											{option.label}
+										</option>
+									))}
+								</RecordTableSelect>
+								<RecordTableSelect
+									label="Filter feedback by category"
+									value={filters.category}
+									onChange={(value) => {
+										replaceLocation(
+											buildHrefWithUpdatedFilters(currentHref, {
+												category: value,
+											}),
+										)
+									}}
+								>
+									{categoryOptions.map((option) => (
+										<option key={option.value} value={option.value}>
+											{option.label}
+										</option>
+									))}
+								</RecordTableSelect>
+								{hasActiveFilters ? (
+									<button
+										type="button"
+										mix={[
+											on('click', () => {
+												replaceLocation(
+													buildHrefWithUpdatedFilters(currentHref, {
+														status: '',
+														category: '',
+													}),
+												)
+											}),
+											css(secondaryButtonCss),
+										]}
 									>
-										{statusOptions.map((option) => (
-											<option key={option.value} value={option.value}>
-												{option.label}
-											</option>
-										))}
-									</RecordTableSelect>
-									<RecordTableSelect
-										label="Filter feedback by category"
-										value={filters.category}
-										onChange={(value) => {
-											replaceLocation(
-												buildHrefWithUpdatedFilters(currentHref, {
-													category: value,
-												}),
-											)
-										}}
-									>
-										{categoryOptions.map((option) => (
-											<option key={option.value} value={option.value}>
-												{option.label}
-											</option>
-										))}
-									</RecordTableSelect>
-									{hasActiveFilters ? (
-										<button
-											type="button"
-											mix={[
-												on('click', () => {
-													replaceLocation(
-														buildHrefWithUpdatedFilters(currentHref, {
-															status: '',
-															category: '',
-														}),
-													)
-												}),
-												css(secondaryButtonCss),
-											]}
-										>
-											Clear filters
-										</button>
-									) : null}
-								</>
-							}
-							columns={[
-								{ key: 'category', label: 'Category', primary: true },
-								{ key: 'summary', label: 'Summary', drop: 1 },
-								{ key: 'status', label: 'Status' },
-								{ key: 'id', label: 'Feedback id', drop: 3 },
-								{ key: 'created', label: 'Created' },
-							]}
-							rows={data.feedback.map((feedback) => ({
-								id: feedback.id,
-								href: buildFeedbackHref(currentHref, feedback.id),
-								cells: {
-									category: feedback.category,
-									summary: feedback.summary_untrusted ? (
-										<span mix={summaryPreviewCss}>
-											{feedback.summary_untrusted}
-										</span>
-									) : null,
-									status: feedback.status,
-									id: (
-										<code
-											mix={css({
-												fontSize: '0.8rem',
-												color: colors.textMuted,
-												whiteSpace: 'nowrap',
-											})}
-										>
-											{feedback.id}
-										</code>
-									),
-									created: (
-										<span mix={css(recordStampCss)}>
-											{formatTimestamp(feedback.created_at)}
-										</span>
-									),
-								},
-							}))}
-							footer={
-								totalPages > 1 ? (
-									<nav
-										aria-label="Feedback pages"
+										Clear filters
+									</button>
+								) : null}
+							</>
+						}
+						columns={[
+							{ key: 'category', label: 'Category', primary: true },
+							{ key: 'summary', label: 'Summary', drop: 1 },
+							{ key: 'status', label: 'Status' },
+							{ key: 'id', label: 'Feedback id', drop: 3 },
+							{ key: 'created', label: 'Created' },
+						]}
+						rows={data.feedback.map((feedback) => ({
+							id: feedback.id,
+							href: buildFeedbackHref(currentHref, feedback.id),
+							cells: {
+								category: feedback.category,
+								summary: feedback.summary_untrusted ? (
+									<span mix={summaryPreviewCss}>
+										{feedback.summary_untrusted}
+									</span>
+								) : null,
+								status: feedback.status,
+								id: (
+									<code
 										mix={css({
-											display: 'flex',
-											alignItems: 'center',
-											justifyContent: 'center',
-											gap: spacing.sm,
-											flexWrap: 'wrap',
+											fontSize: '0.8rem',
+											color: colors.textMuted,
+											whiteSpace: 'nowrap',
 										})}
 									>
-										{data.page > 1 ? (
-											<a
-												href={buildPageHref(currentHref, data.page - 1)}
-												mix={css({
-													...secondaryButtonCss,
-													textDecoration: 'none',
-												})}
-											>
-												Previous
-											</a>
-										) : null}
-										<span
+										{feedback.id}
+									</code>
+								),
+								created: (
+									<span mix={css(recordStampCss)}>
+										{formatTimestamp(feedback.created_at)}
+									</span>
+								),
+							},
+						}))}
+						footer={
+							totalPages > 1 ? (
+								<nav
+									aria-label="Feedback pages"
+									mix={css({
+										display: 'flex',
+										alignItems: 'center',
+										justifyContent: 'center',
+										gap: spacing.sm,
+										flexWrap: 'wrap',
+									})}
+								>
+									{data.page > 1 ? (
+										<a
+											href={buildPageHref(currentHref, data.page - 1)}
 											mix={css({
-												color: colors.textMuted,
-												fontSize: typography.fontSize.xs,
+												...secondaryButtonCss,
+												textDecoration: 'none',
 											})}
 										>
-											Page {data.page} of {totalPages}
-										</span>
-										{data.page < totalPages ? (
-											<a
-												href={buildPageHref(currentHref, data.page + 1)}
-												mix={css({
-													...secondaryButtonCss,
-													textDecoration: 'none',
-												})}
-											>
-												Next
-											</a>
-										) : null}
-									</nav>
-								) : null
-							}
-							record={
-								selectedFeedback ? (
-									<div mix={css(recordBodyCss)}>
-										<div mix={css({ display: 'grid', gap: spacing.xs })}>
-											<h2
-												mix={css({
-													margin: 0,
-													fontSize: typography.fontSize.lg,
-													fontWeight: typography.fontWeight.semibold,
-													color: colors.text,
-												})}
-											>
-												{feedbackTitle(selectedFeedback)}
-											</h2>
-											<p mix={css({ margin: 0, color: colors.textMuted })}>
-												This detail read is audit logged.
-											</p>
-										</div>
-
-										<MetadataGrid
-											items={[
-												{
-													label: 'Submitter username',
-													value:
-														selectedFeedback.submitter?.username ??
-														'Account unavailable',
-												},
-												{
-													label: 'Submitter email',
-													value:
-														selectedFeedback.submitter?.email ??
-														'Account unavailable',
-												},
-												{
-													label: 'Stable user ID',
-													value: (
-														<IdValue
-															value={
-																selectedFeedback.submitter?.user_id ??
-																selectedFeedback.submitter_user_id
-															}
-															label="stable user ID"
-														/>
-													),
-												},
-												{
-													label: 'Category',
-													value: selectedFeedback.category,
-												},
-												{
-													label: 'Status',
-													value: selectedFeedback.status,
-												},
-												{
-													label: 'Created',
-													value: (
-														<TimestampValue
-															value={selectedFeedback.created_at}
-														/>
-													),
-												},
-												{
-													label: 'Updated',
-													value: (
-														<TimestampValue
-															value={selectedFeedback.updated_at}
-														/>
-													),
-												},
-												{
-													label: 'Reviewed',
-													value: (
-														<TimestampValue
-															value={selectedFeedback.reviewed_at}
-															fallback="Never"
-														/>
-													),
-												},
-												{
-													label: 'Reviewer ID',
-													value: selectedFeedback.reviewed_by_user_id ? (
-														<IdValue
-															value={selectedFeedback.reviewed_by_user_id}
-															label="reviewer ID"
-														/>
-													) : (
-														'None'
-													),
-												},
-											]}
-										/>
-
-										<section mix={css(cardCss)}>
-											<strong>Summary (untrusted)</strong>
-											<pre mix={untrustedTextCss}>
-												{selectedFeedback.summary_untrusted}
-											</pre>
-										</section>
-										<section mix={css(cardCss)}>
-											<strong>Details (untrusted)</strong>
-											<pre mix={untrustedTextCss}>
-												{selectedFeedback.details_untrusted}
-											</pre>
-										</section>
-										<section mix={css(cardCss)}>
-											<strong>Admin note</strong>
-											{selectedFeedback.admin_note ? (
-												<pre mix={untrustedTextCss}>
-													{selectedFeedback.admin_note}
-												</pre>
-											) : (
-												<p mix={css({ margin: 0, color: colors.textMuted })}>
-													No admin note.
-												</p>
-											)}
-										</section>
+											Previous
+										</a>
+									) : null}
+									<span
+										mix={css({
+											color: colors.textMuted,
+											fontSize: typography.fontSize.xs,
+										})}
+									>
+										Page {data.page} of {totalPages}
+									</span>
+									{data.page < totalPages ? (
+										<a
+											href={buildPageHref(currentHref, data.page + 1)}
+											mix={css({
+												...secondaryButtonCss,
+												textDecoration: 'none',
+											})}
+										>
+											Next
+										</a>
+									) : null}
+								</nav>
+							) : null
+						}
+						record={
+							selectedFeedback ? (
+								<div mix={css(recordBodyCss)}>
+									<div mix={css({ display: 'grid', gap: spacing.xs })}>
+										<h2
+											mix={css({
+												margin: 0,
+												fontSize: typography.fontSize.lg,
+												fontWeight: typography.fontWeight.semibold,
+												color: colors.text,
+											})}
+										>
+											{feedbackTitle(selectedFeedback)}
+										</h2>
+										<p mix={css({ margin: 0, color: colors.textMuted })}>
+											This detail read is audit logged.
+										</p>
 									</div>
-								) : null
-							}
-						/>
-					</>
+
+									<MetadataGrid
+										items={[
+											{
+												label: 'Submitter username',
+												value:
+													selectedFeedback.submitter?.username ??
+													'Account unavailable',
+											},
+											{
+												label: 'Submitter email',
+												value:
+													selectedFeedback.submitter?.email ??
+													'Account unavailable',
+											},
+											{
+												label: 'Stable user ID',
+												value: (
+													<IdValue
+														value={
+															selectedFeedback.submitter?.user_id ??
+															selectedFeedback.submitter_user_id
+														}
+														label="stable user ID"
+													/>
+												),
+											},
+											{
+												label: 'Category',
+												value: selectedFeedback.category,
+											},
+											{
+												label: 'Status',
+												value: selectedFeedback.status,
+											},
+											{
+												label: 'Created',
+												value: (
+													<TimestampValue value={selectedFeedback.created_at} />
+												),
+											},
+											{
+												label: 'Updated',
+												value: (
+													<TimestampValue value={selectedFeedback.updated_at} />
+												),
+											},
+											{
+												label: 'Reviewed',
+												value: (
+													<TimestampValue
+														value={selectedFeedback.reviewed_at}
+														fallback="Never"
+													/>
+												),
+											},
+											{
+												label: 'Reviewer ID',
+												value: selectedFeedback.reviewed_by_user_id ? (
+													<IdValue
+														value={selectedFeedback.reviewed_by_user_id}
+														label="reviewer ID"
+													/>
+												) : (
+													'None'
+												),
+											},
+										]}
+									/>
+
+									<section mix={css(cardCss)}>
+										<strong>Summary (untrusted)</strong>
+										<pre mix={untrustedTextCss}>
+											{selectedFeedback.summary_untrusted}
+										</pre>
+									</section>
+									<section mix={css(cardCss)}>
+										<strong>Details (untrusted)</strong>
+										<pre mix={untrustedTextCss}>
+											{selectedFeedback.details_untrusted}
+										</pre>
+									</section>
+									<section mix={css(cardCss)}>
+										<strong>Admin note</strong>
+										{selectedFeedback.admin_note ? (
+											<pre mix={untrustedTextCss}>
+												{selectedFeedback.admin_note}
+											</pre>
+										) : (
+											<p mix={css({ margin: 0, color: colors.textMuted })}>
+												No admin note.
+											</p>
+										)}
+									</section>
+								</div>
+							) : null
+						}
+					/>
 				) : null}
 			</AccountManagementShell>
 		)

--- a/packages/worker/src/app/admin-platform-feedback-data.node.test.ts
+++ b/packages/worker/src/app/admin-platform-feedback-data.node.test.ts
@@ -1,6 +1,5 @@
 import { DatabaseSync } from 'node:sqlite'
 import { expect, test } from 'vitest'
-import { platformFeedbackContentWarning } from '#worker/platform-feedback/content-warning.ts'
 import { platformFeedbackTestSchemaSql } from '#worker/platform-feedback/test-schema.ts'
 import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
 import { loadAdminPlatformFeedbackData } from './admin-platform-feedback-data.ts'
@@ -103,7 +102,6 @@ test('admin platform feedback data lists safely and uses stored submitter snapsh
 		total: 1,
 		page: 1,
 		pageSize: 20,
-		content_warning: platformFeedbackContentWarning,
 		statusFilter: 'open',
 		categoryFilter: 'suggestion',
 		selectedFeedback: null,

--- a/packages/worker/src/app/admin-platform-feedback-data.ts
+++ b/packages/worker/src/app/admin-platform-feedback-data.ts
@@ -4,7 +4,6 @@ import {
 	type AdminPlatformFeedbackListItem,
 	type AdminPlatformFeedbackLoaderData,
 } from '#universal/loader-data.ts'
-import { platformFeedbackContentWarning } from '#worker/platform-feedback/content-warning.ts'
 import {
 	getPlatformFeedbackForAdmin,
 	listPlatformFeedbackForAdmin,
@@ -123,7 +122,6 @@ export async function loadAdminPlatformFeedbackData(
 		ok: true,
 		feedback: list.items.map(formatListItem),
 		selectedFeedback: selectedRecord ? formatDetail(selectedRecord) : null,
-		content_warning: platformFeedbackContentWarning,
 		page: list.page,
 		pageSize: list.pageSize,
 		total: list.total,

--- a/packages/worker/src/app/handlers/admin-platform-feedback.node.test.ts
+++ b/packages/worker/src/app/handlers/admin-platform-feedback.node.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, vi } from 'vitest'
 import { logAuditEventSpy } from '#worker/test-support/audit-log-spy.ts'
-import { platformFeedbackContentWarning } from '#worker/platform-feedback/content-warning.ts'
 import { type AdminPlatformFeedbackLoaderData } from '#universal/loader-data.ts'
 import type * as AdminPlatformFeedbackData from '#app/admin-platform-feedback-data.ts'
 import type * as AuditLog from '#worker/audit-log.ts'
@@ -38,7 +37,6 @@ const listPayload = {
 	ok: true,
 	feedback: [],
 	selectedFeedback: null,
-	content_warning: platformFeedbackContentWarning,
 	page: 1,
 	pageSize: 20,
 	total: 0,

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1021,7 +1021,6 @@ export type AdminPlatformFeedbackLoaderData = {
 	ok: true
 	feedback: Array<AdminPlatformFeedbackListItem>
 	selectedFeedback: AdminPlatformFeedbackDetail | null
-	content_warning: string
 	page: number
 	pageSize: number
 	total: number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Remove the content-warning banner from the admin Platform feedback page.

## Why

Kent does not want this notice. Platform feedback is already labeled `_untrusted` in the fields themselves, and the red banner is extra chrome.

## Summary

- Delete the “Content warning: untrusted user-authored text” banner on `/admin/platform-feedback` (no replacement notice)
- Drop `content_warning` from the admin page JSON loader — that field only existed to feed the banner
- Leave MCP and package-subscription `content_warning` fields in place (those are for agents and notification handlers, not this page)

## Testing

- `npm run validate` green (format, lint, typecheck, node/workers/e2e/mcp, builds, knip, mermaid, etc.)
- Admin JSON `/admin/platform-feedback.json` no longer includes `content_warning`
- Browser as `kody@example.com`: `/admin/platform-feedback` shows the heading, description, and empty queue with **no** red content-warning banner

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>composes existing primitives</b> (low risk)</summary>

**Mode:** recap · **Base:** `main` @ `66700d0a` · **Head:** `b24a8ee0`

**Classification:** composes — no primitives added or changed. This PR removes a composed admin-page banner and the loader field that only existed to feed it.

### Primitives touched

| Primitive | Group | Impact |
| --------- | ----- | ------ |
| `app-ui` | surfaces | composes — delete the Platform feedback content-warning banner and drop `content_warning` from the admin page JSON |
| `rbac` | auth | composes — admin handler test fixture only, no authorization change |

### Change flow

An admin opening Platform feedback still loads the attributed queue. The page no longer renders the untrusted-content banner, and the JSON payload no longer carries `content_warning`. MCP and package-subscription warnings are unchanged.

```mermaid
sequenceDiagram
	actor Admin
	participant appUi as app-ui
	Admin->>appUi: GET /admin/platform-feedback
	appUi->>appUi: render queue without content warning banner
	Note over appUi: JSON loader omits content_warning
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae9e5cf4-c701-5c88-8595-d8ac93569fc0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae9e5cf4-c701-5c88-8595-d8ac93569fc0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the content-warning banner and related audit-log detail notice from the admin platform feedback queue.
  - Admin feedback data no longer includes a content-warning field.
  - Updated feedback-related validation and test coverage to reflect the streamlined data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->