### PR TITLE
Fix OAuth consent clobbering query params before hydration

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -211,7 +211,13 @@ assistant features:
   (`403 email_verification_required`). The authorize HTML is server-rendered
   with client/scopes from `/oauth/authorize-info` and the signed-in app session
   from the SSR shell, so first paint already shows approve, inline login, or
-  verify-email instead of a client `/session` loading state. The authorize UI
+  verify-email instead of a client `/session` loading state. Approve stays
+  disabled until client hydration so a native GET cannot replace the OAuth query
+  with the honeypot field; the consent form POSTs to the current pathname+search
+  with a hidden `decision=approve` if it is submitted before handlers bind. A
+  `/oauth/authorize` request that has no `client_id` but includes `kody_hp` is
+  treated as that interrupted resubmit and returns a recoverable "start the
+  connection again" message instead of `client_id is required`. The authorize UI
   keeps inline verification/resend controls and the original OAuth query so
   verification in another tab can resume without restarting the host connection.
 - **MCP requests**: `handleMcpRequest` in `packages/worker/src/mcp-auth.ts` is
@@ -676,7 +682,8 @@ routed from `packages/worker/src/index.ts`.
   email link is opened elsewhere, so the original OAuth query remains resumable.
   Signed-in vs signed-out chrome on that page comes from the SSR-embedded app
   session; the route does not wait on a separate browser `/session` fetch before
-  rendering approve or login.
+  rendering approve or login. The approve control stays inert until hydration so
+  the visible button cannot submit a GET that drops `client_id`.
 - Approval is rejected before `completeAuthorization` when the account email is
   unverified, so no grant/token is created until verification succeeds.
 

--- a/docs/use/troubleshooting.md
+++ b/docs/use/troubleshooting.md
@@ -41,6 +41,14 @@ skipping refresh. Cursor and Claude Code stay logged in. Email
 [`support@kody.codes`](mailto:support@kody.codes) with your Codex version and
 how often it asks again if you want us to look.
 
+## Authorize says the request is missing its original connection details
+
+The authorize page needs the original OAuth query (`client_id`, `state`, PKCE).
+Clicking Approve before that page finishes loading can replace those parameters
+with an empty honeypot field, and the server then asks you to start over. Use
+the browser Back button when the previous history entry still has `client_id` in
+the URL, or start the connection again from your client.
+
 ## The host never opens the Kody authorize window
 
 Dynamic OAuth needs the host to open `/oauth/authorize`. If Admin add-connection

--- a/packages/worker/client/routes/oauth-authorize-form.node.test.ts
+++ b/packages/worker/client/routes/oauth-authorize-form.node.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'vitest'
+import {
+	oauthAuthorizeActionsDisabled,
+	oauthAuthorizeApproveAriaLabel,
+	oauthAuthorizeConsentFormAttrs,
+} from './oauth-authorize-form.ts'
+
+test('authorize consent form defaults preserve the OAuth query on native submit', () => {
+	const search =
+		'?response_type=code&client_id=demo&state=abc&code_challenge=xyz'
+	const href = `/oauth/authorize${search}`
+
+	expect(oauthAuthorizeConsentFormAttrs(href)).toEqual({
+		method: 'post',
+		action: href,
+	})
+	expect(oauthAuthorizeConsentFormAttrs(`https://kody.codes${href}`)).toEqual({
+		method: 'post',
+		action: href,
+	})
+
+	expect(
+		oauthAuthorizeActionsDisabled({
+			hydrated: false,
+			statusReady: true,
+			submitting: false,
+			sessionLoading: false,
+			needsEmailVerification: false,
+		}),
+	).toBe(true)
+	expect(
+		oauthAuthorizeActionsDisabled({
+			hydrated: true,
+			statusReady: true,
+			submitting: false,
+			sessionLoading: false,
+			needsEmailVerification: false,
+		}),
+	).toBe(false)
+	expect(
+		oauthAuthorizeActionsDisabled({
+			hydrated: true,
+			statusReady: false,
+			submitting: false,
+			sessionLoading: false,
+			needsEmailVerification: false,
+		}),
+	).toBe(true)
+
+	expect(
+		oauthAuthorizeApproveAriaLabel({
+			hydrated: false,
+			label: 'Approve connection',
+		}),
+	).toBe('Approve connection (available after the page finishes loading)')
+	expect(
+		oauthAuthorizeApproveAriaLabel({
+			hydrated: true,
+			label: 'Approve connection',
+		}),
+	).toBeUndefined()
+})

--- a/packages/worker/client/routes/oauth-authorize-form.node.test.ts
+++ b/packages/worker/client/routes/oauth-authorize-form.node.test.ts
@@ -3,6 +3,7 @@ import {
 	oauthAuthorizeActionsDisabled,
 	oauthAuthorizeApproveAriaLabel,
 	oauthAuthorizeConsentFormAttrs,
+	oauthAuthorizeEmailVerificationDenyDisabled,
 } from './oauth-authorize-form.ts'
 
 test('authorize consent form defaults preserve the OAuth query on native submit', () => {
@@ -59,4 +60,26 @@ test('authorize consent form defaults preserve the OAuth query on native submit'
 			label: 'Approve connection',
 		}),
 	).toBeUndefined()
+
+	expect(
+		oauthAuthorizeEmailVerificationDenyDisabled({
+			hydrated: false,
+			submitting: false,
+			sessionLoading: false,
+		}),
+	).toBe(true)
+	expect(
+		oauthAuthorizeEmailVerificationDenyDisabled({
+			hydrated: true,
+			submitting: false,
+			sessionLoading: false,
+		}),
+	).toBe(false)
+	expect(
+		oauthAuthorizeEmailVerificationDenyDisabled({
+			hydrated: true,
+			submitting: true,
+			sessionLoading: false,
+		}),
+	).toBe(true)
 })

--- a/packages/worker/client/routes/oauth-authorize-form.ts
+++ b/packages/worker/client/routes/oauth-authorize-form.ts
@@ -16,6 +16,7 @@ export function oauthAuthorizeConsentFormAttrs(href: string) {
 	}
 }
 
+/** `hydrated` is post-hydrate interactivity, not `typeof document`. */
 export function oauthAuthorizeActionsDisabled(input: {
 	hydrated: boolean
 	statusReady: boolean

--- a/packages/worker/client/routes/oauth-authorize-form.ts
+++ b/packages/worker/client/routes/oauth-authorize-form.ts
@@ -1,0 +1,41 @@
+/**
+ * Native consent-form defaults for `/oauth/authorize`.
+ *
+ * A method-less form GETs the pathname with field names only, which replaces
+ * the OAuth query string with `kody_hp=` and surfaces a misleading
+ * `client_id is required`. POST to pathname+search keeps those params, and the
+ * hidden approve decision matches the submit button.
+ */
+export const oauthAuthorizeConsentDecision = 'approve' as const
+
+export function oauthAuthorizeConsentFormAttrs(href: string) {
+	const url = new URL(href, 'http://localhost')
+	return {
+		method: 'post' as const,
+		action: `${url.pathname}${url.search}`,
+	}
+}
+
+export function oauthAuthorizeActionsDisabled(input: {
+	hydrated: boolean
+	statusReady: boolean
+	submitting: boolean
+	sessionLoading: boolean
+	needsEmailVerification: boolean
+}) {
+	return (
+		!input.hydrated ||
+		!input.statusReady ||
+		input.submitting ||
+		input.sessionLoading ||
+		input.needsEmailVerification
+	)
+}
+
+export function oauthAuthorizeApproveAriaLabel(input: {
+	hydrated: boolean
+	label: string
+}) {
+	if (input.hydrated) return undefined
+	return `${input.label} (available after the page finishes loading)`
+}

--- a/packages/worker/client/routes/oauth-authorize-form.ts
+++ b/packages/worker/client/routes/oauth-authorize-form.ts
@@ -40,3 +40,12 @@ export function oauthAuthorizeApproveAriaLabel(input: {
 	if (input.hydrated) return undefined
 	return `${input.label} (available after the page finishes loading)`
 }
+
+/** Standalone verify-email Deny is outside the consent form, so it cannot use `actionsDisabled`. */
+export function oauthAuthorizeEmailVerificationDenyDisabled(input: {
+	hydrated: boolean
+	submitting: boolean
+	sessionLoading: boolean
+}) {
+	return !input.hydrated || input.submitting || input.sessionLoading
+}

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -26,6 +26,7 @@ import {
 	oauthAuthorizeApproveAriaLabel,
 	oauthAuthorizeConsentDecision,
 	oauthAuthorizeConsentFormAttrs,
+	oauthAuthorizeEmailVerificationDenyDisabled,
 } from '#client/routes/oauth-authorize-form.ts'
 import { resolveAuthorizeSession } from '#client/routes/oauth-authorize-session.ts'
 import {
@@ -603,7 +604,16 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 					<div mix={css({ marginBottom: spacing.md })}>
 						<button
 							type="button"
-							disabled={Boolean(submittingDecision) || isSessionLoading}
+							data-testid="oauth-authorize-email-verify-deny"
+							disabled={oauthAuthorizeEmailVerificationDenyDisabled({
+								hydrated,
+								submitting: Boolean(submittingDecision),
+								sessionLoading: isSessionLoading,
+							})}
+							aria-label={oauthAuthorizeApproveAriaLabel({
+								hydrated,
+								label: 'Deny',
+							})}
 							mix={[
 								on('click', () => submitDecision('deny')),
 								css(secondaryButtonCss),

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -21,6 +21,12 @@ import {
 	requestResendVerification,
 } from '#client/routes/email-verification-prompt.tsx'
 import { resolveAuthorizeEmailVerified } from '#client/routes/oauth-authorize-email-verified.ts'
+import {
+	oauthAuthorizeActionsDisabled,
+	oauthAuthorizeApproveAriaLabel,
+	oauthAuthorizeConsentDecision,
+	oauthAuthorizeConsentFormAttrs,
+} from '#client/routes/oauth-authorize-form.ts'
 import { resolveAuthorizeSession } from '#client/routes/oauth-authorize-session.ts'
 import {
 	fetchSessionInfo,
@@ -48,6 +54,7 @@ import {
 	pageTitleCss,
 	sectionTitleCss,
 	stackedPageCss,
+	visuallyHiddenCss,
 } from '#universal/styles/style-primitives.ts'
 
 type OAuthAuthorizeInfo = {
@@ -504,20 +511,28 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const needsEmailVerification = isLoggedIn && !emailVerified
 		const showResetClientCard = allowClientReset && !resetCompleted
 		const showAuthorizeForm = !resetCompleted && !needsEmailVerification
-		const actionsDisabled =
-			status !== 'ready' ||
-			Boolean(submittingDecision) ||
-			isSessionLoading ||
-			needsEmailVerification
+		const hydrated = typeof document !== 'undefined'
+		const consentForm = oauthAuthorizeConsentFormAttrs(currentHref)
+		const actionsDisabled = oauthAuthorizeActionsDisabled({
+			hydrated,
+			statusReady: status === 'ready',
+			submitting: Boolean(submittingDecision),
+			sessionLoading: isSessionLoading,
+			needsEmailVerification,
+		})
 		const resetClientDisabled =
 			Boolean(submittingDecision) || isSessionLoading || !isLoggedIn
-		const formReady = status === 'ready' && !isSessionLoading
+		const formReady = hydrated && status === 'ready' && !isSessionLoading
 		const accessLead = oauthAuthorizeAccessLead(status, clientLabel)
 		const authorizeLabel = submittingDecision
 			? 'Submitting...'
 			: isLoggedIn
 				? 'Approve connection'
 				: 'Authorize'
+		const approveAriaLabel = oauthAuthorizeApproveAriaLabel({
+			hydrated,
+			label: authorizeLabel,
+		})
 		const resetClientLabel =
 			submittingDecision === 'reset-client'
 				? 'Resetting this connection...'
@@ -623,6 +638,10 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				) : null}
 				{showAuthorizeForm ? (
 					<form
+						method={consentForm.method}
+						action={consentForm.action}
+						data-testid="oauth-authorize-form"
+						aria-busy={hydrated ? undefined : 'true'}
 						mix={[
 							css({
 								...cardCss,
@@ -631,6 +650,17 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 							on('submit', handleSubmit),
 						]}
 					>
+						{hydrated ? null : (
+							<p role="status" mix={css(visuallyHiddenCss)}>
+								Connection approval is available after the page finishes
+								loading.
+							</p>
+						)}
+						<input
+							type="hidden"
+							name="decision"
+							value={oauthAuthorizeConsentDecision}
+						/>
 						{renderHoneypot()}
 						{!isLoggedIn && isSessionReady ? (
 							<>
@@ -668,7 +698,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						>
 							<button
 								type="submit"
+								data-testid="oauth-authorize-approve"
 								disabled={actionsDisabled}
+								aria-label={approveAriaLabel}
 								mix={css(primaryButtonCss)}
 							>
 								{authorizeLabel}
@@ -676,6 +708,10 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 							<button
 								type="button"
 								disabled={actionsDisabled}
+								aria-label={oauthAuthorizeApproveAriaLabel({
+									hydrated,
+									label: 'Deny',
+								})}
 								mix={[
 									on('click', () => submitDecision('deny')),
 									css(secondaryButtonCss),

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -510,7 +510,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		})
 		const needsEmailVerification = isLoggedIn && !emailVerified
 		const showResetClientCard = allowClientReset && !resetCompleted
-		const showAuthorizeForm = !resetCompleted && !needsEmailVerification
+		const showAuthorizeForm =
+			!resetCompleted && !needsEmailVerification && status !== 'error'
 		const hydrated = typeof document !== 'undefined'
 		const consentForm = oauthAuthorizeConsentFormAttrs(currentHref)
 		const actionsDisabled = oauthAuthorizeActionsDisabled({

--- a/packages/worker/client/routes/oauth-authorize.tsx
+++ b/packages/worker/client/routes/oauth-authorize.tsx
@@ -193,6 +193,9 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	let resendStatus: 'idle' | 'sending' = 'idle'
 	let resendMessage: string | null = null
 	let resendTone: 'error' | 'info' = 'info'
+	// Stay false through SSR and the first client render so hydrate matches
+	// the disabled form. Flip after queueTask, once submit handlers are bound.
+	let consentInteractive = false
 
 	function setMessage(next: OAuthAuthorizeMessage | null) {
 		message = next
@@ -512,7 +515,14 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const showResetClientCard = allowClientReset && !resetCompleted
 		const showAuthorizeForm =
 			!resetCompleted && !needsEmailVerification && status !== 'error'
-		const hydrated = typeof document !== 'undefined'
+		if (typeof document !== 'undefined' && !consentInteractive) {
+			handle.queueTask(() => {
+				if (consentInteractive) return
+				consentInteractive = true
+				handle.update()
+			})
+		}
+		const hydrated = consentInteractive
 		const consentForm = oauthAuthorizeConsentFormAttrs(currentHref)
 		const actionsDisabled = oauthAuthorizeActionsDisabled({
 			hydrated,

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -1036,6 +1036,9 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 	const signedInHtml = await readResponseText(signedInResponse)
 	expect(signedInHtml).toContain('aria-label="Email verification status"')
 	expect(signedInHtml).not.toContain('Approve connection')
+	expect(signedInHtml).toMatch(
+		/data-testid="oauth-authorize-email-verify-deny"[^>]*disabled/,
+	)
 })
 
 test('renderAppPage server-renders connect-oauth provider visits without a loading flash', async () => {

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -967,8 +967,10 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 		]),
 	)
 
+	const anonymousAuthorizeUrl =
+		'https://example.com/oauth/authorize?response_type=code&client_id=client-1&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&scope=profile'
 	const anonymousResponse = await renderAppPage({
-		request: new Request('https://example.com/oauth/authorize', {
+		request: new Request(anonymousAuthorizeUrl, {
 			headers: { Cookie: 'kody_session=stale-or-unsigned; other=1' },
 		}),
 		env,
@@ -992,6 +994,21 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 	expect(anonymousHtml).toContain('<code>email</code>')
 	expect(anonymousHtml).not.toContain('Unknown client')
 	expect(anonymousHtml).not.toContain('Loading authorization details')
+	expect(anonymousHtml).toContain('data-testid="oauth-authorize-form"')
+	expect(anonymousHtml).toMatch(
+		/data-testid="oauth-authorize-form"[^>]*method="post"/,
+	)
+	expect(anonymousHtml).toContain(
+		'action="/oauth/authorize?response_type=code&amp;client_id=client-1',
+	)
+	expect(anonymousHtml).toMatch(
+		/name="decision"[^>]*value="approve"|value="approve"[^>]*name="decision"/,
+	)
+	expect(anonymousHtml).toMatch(
+		/data-testid="oauth-authorize-approve"[^>]*disabled/,
+	)
+	expect(anonymousHtml).toContain('aria-busy="true"')
+	expect(anonymousHtml).toContain('available after the page finishes loading')
 
 	setAuthSessionSecret(testCookieSecret)
 	const cookie = await createAuthCookie(

--- a/packages/worker/src/app/ssr-render.node.test.ts
+++ b/packages/worker/src/app/ssr-render.node.test.ts
@@ -995,15 +995,12 @@ test('renderAppPage configures session secret and server-renders oauth authorize
 	expect(anonymousHtml).not.toContain('Unknown client')
 	expect(anonymousHtml).not.toContain('Loading authorization details')
 	expect(anonymousHtml).toContain('data-testid="oauth-authorize-form"')
-	expect(anonymousHtml).toMatch(
-		/data-testid="oauth-authorize-form"[^>]*method="post"/,
-	)
+	expect(anonymousHtml).toContain('method="post"')
 	expect(anonymousHtml).toContain(
 		'action="/oauth/authorize?response_type=code&amp;client_id=client-1',
 	)
-	expect(anonymousHtml).toMatch(
-		/name="decision"[^>]*value="approve"|value="approve"[^>]*name="decision"/,
-	)
+	expect(anonymousHtml).toContain('name="decision"')
+	expect(anonymousHtml).toContain('value="approve"')
 	expect(anonymousHtml).toMatch(
 		/data-testid="oauth-authorize-approve"[^>]*disabled/,
 	)

--- a/packages/worker/src/oauth-authorize-clobber.node.test.ts
+++ b/packages/worker/src/oauth-authorize-clobber.node.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest'
+import { honeypotFieldName } from '#universal/public-form-protection.ts'
+import { isOAuthAuthorizeClobberedResubmit } from './oauth-authorize-clobber.ts'
+
+test('authorize clobber detection is the honeypot-only missing-client_id case', () => {
+	expect(
+		isOAuthAuthorizeClobberedResubmit({
+			searchParams: new URLSearchParams(`${honeypotFieldName}=`),
+		}),
+	).toBe(true)
+	expect(
+		isOAuthAuthorizeClobberedResubmit({
+			searchParams: new URLSearchParams(),
+			formData: new FormData(),
+		}),
+	).toBe(false)
+
+	const formData = new FormData()
+	formData.set(honeypotFieldName, '')
+	expect(
+		isOAuthAuthorizeClobberedResubmit({
+			searchParams: new URLSearchParams(),
+			formData,
+		}),
+	).toBe(true)
+	expect(
+		isOAuthAuthorizeClobberedResubmit({
+			searchParams: new URLSearchParams(`client_id=demo&${honeypotFieldName}=`),
+			formData,
+		}),
+	).toBe(false)
+})

--- a/packages/worker/src/oauth-authorize-clobber.ts
+++ b/packages/worker/src/oauth-authorize-clobber.ts
@@ -1,0 +1,18 @@
+import { honeypotFieldName } from '#universal/public-form-protection.ts'
+
+export const oauthAuthorizeClobberedResubmitMessage =
+	'This authorization request is missing its original connection details. Use your browser Back button or start the connection again from your client.'
+
+/**
+ * Native GET submit of the consent form (no method/action) replaces the OAuth
+ * query with only the honeypot field (`kody_hp=`). Missing `client_id` plus
+ * that field is that interrupted resubmit, not a well-formed authorize call.
+ */
+export function isOAuthAuthorizeClobberedResubmit(input: {
+	searchParams: URLSearchParams
+	formData?: FormData | null
+}) {
+	if (input.searchParams.get('client_id')?.trim()) return false
+	if (input.searchParams.has(honeypotFieldName)) return true
+	return input.formData?.has(honeypotFieldName) === true
+}

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -47,6 +47,10 @@ import {
 } from '#app/account-mcp-oauth-clients.ts'
 import { mcpOauthScopes } from '#worker/mcp-oauth-scopes.ts'
 import {
+	isOAuthAuthorizeClobberedResubmit,
+	oauthAuthorizeClobberedResubmitMessage,
+} from '#worker/oauth-authorize-clobber.ts'
+import {
 	evaluateOidcAuthorizeGate,
 	isOidcAuthorizeParamsParseError,
 	parseOidcAuthorizeParams,
@@ -734,6 +738,20 @@ export async function loadOAuthAuthorizeData(
 	request: Request,
 	env: Env,
 ): Promise<OAuthAuthorizeDataResult> {
+	if (
+		isOAuthAuthorizeClobberedResubmit({
+			searchParams: new URL(request.url).searchParams,
+		})
+	) {
+		return {
+			data: {
+				ok: false,
+				error: oauthAuthorizeClobberedResubmitMessage,
+				allowClientReset: false,
+			},
+			setCookie: null,
+		}
+	}
 	const oidcParamsOrError = parseOidcAuthorizeParams(request)
 	if (isOidcAuthorizeParamsParseError(oidcParamsOrError)) {
 		return {
@@ -1155,6 +1173,17 @@ export async function handleAuthorizeRequest(
 	const formData = await request.formData().catch(() => null)
 	if (!formData) {
 		return respondAuthorizeError(request, 'Invalid form data')
+	}
+	if (
+		isOAuthAuthorizeClobberedResubmit({
+			searchParams: new URL(request.url).searchParams,
+			formData,
+		})
+	) {
+		return respondAuthorizeError(
+			request,
+			oauthAuthorizeClobberedResubmitMessage,
+		)
 	}
 	const decision = String(formData.get('decision') ?? 'approve')
 	if (decision === 'reset-client') {

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -16,6 +16,8 @@ import {
 } from '#app/auth-session.ts'
 import { createPasswordHash } from '@kody-internal/shared/password-hash.ts'
 import { invalidClientIdMismatchMessage } from '@kody-internal/shared/oauth-messages.ts'
+import { honeypotFieldName } from '#universal/public-form-protection.ts'
+import { oauthAuthorizeClobberedResubmitMessage } from './oauth-authorize-clobber.ts'
 import {
 	handleAuthorizeInfo,
 	handleAuthorizeRequest,
@@ -1662,4 +1664,56 @@ test('malformed max_age does not redirect authorize GET to itself', async () => 
 		/max_age must be a non-negative integer/i,
 	)
 	expect(silentRedirect.searchParams.get('state')).toBe('demo')
+})
+
+test('authorize recovers when a pre-hydration submit clobbers the OAuth query', async () => {
+	const helpers = createHelpers({
+		parseAuthRequest: async () => {
+			throw new Error('client_id is required')
+		},
+	})
+	const envWithHelpers = createEnv(helpers)
+	const clobberedUrl = `https://example.com/oauth/authorize?${honeypotFieldName}=`
+
+	const htmlResponse = await handleAuthorizeRequest(
+		new Request(clobberedUrl),
+		envWithHelpers,
+	)
+	expect(htmlResponse.status).toBe(200)
+	const html = await htmlResponse.text()
+	expect(html).toContain(oauthAuthorizeClobberedResubmitMessage)
+	expect(html).not.toContain('client_id is required')
+
+	const infoResponse = await handleAuthorizeInfo(
+		new Request(
+			`https://example.com/oauth/authorize-info?${honeypotFieldName}=`,
+		),
+		envWithHelpers,
+	)
+	expect(infoResponse.status).toBe(400)
+	await expect(infoResponse.json()).resolves.toEqual({
+		ok: false,
+		error: oauthAuthorizeClobberedResubmitMessage,
+		allowClientReset: false,
+	})
+
+	const postResponse = await handleAuthorizeRequest(
+		new Request('https://example.com/oauth/authorize', {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				decision: 'approve',
+				[honeypotFieldName]: '',
+			}),
+		}),
+		envWithHelpers,
+	)
+	expect(postResponse.status).toBe(400)
+	await expect(postResponse.json()).resolves.toMatchObject({
+		ok: false,
+		error: oauthAuthorizeClobberedResubmitMessage,
+	})
 })

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -1683,6 +1683,7 @@ test('authorize recovers when a pre-hydration submit clobbers the OAuth query', 
 	const html = await htmlResponse.text()
 	expect(html).toContain(oauthAuthorizeClobberedResubmitMessage)
 	expect(html).not.toContain('client_id is required')
+	expect(html).not.toContain('data-testid="oauth-authorize-approve"')
 
 	const infoResponse = await handleAuthorizeInfo(
 		new Request(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop `/oauth/authorize` from destroying the OAuth query when Approve is clicked before the consent page hydrates, and recover already-clobbered requests instead of a dead-end `client_id is required`.

## Why

Platform feedback `c34f5b54-af45-4bf6-9654-941c25d40376` (Noah / @noah): browser history ~3s apart showed the full authorize URL, then `/oauth/authorize?kody_hp=`. The consent form had no `method`/`action`, so a native GET submitted only the honeypot field and wiped `client_id`. Separate from the MCP OAuth refresh-race (#2233). Eng fix + PR only; do not resolve the feedback item.

## Summary

- Consent form POSTs to pathname+search with a hidden `decision=approve`, so a native submit cannot replace the OAuth query.
- Approve/Deny stay disabled through SSR and the first client render, then become interactive after `queueTask` so hydrate matches the disabled form and submit handlers are bound first.
- The standalone email-verification Deny control is also disabled until after hydrate (it sits outside the consent form, so it cannot reuse `actionsDisabled`).
- The consent form is hidden when authorize details fail to load, so a `kody_hp`-only recovery page does not offer another Approve.
- GET/POST `/oauth/authorize` (and authorize-info) treat missing `client_id` plus `kody_hp` as that interrupted resubmit and return a recoverable "start the connection again" message.
- Docs: contributing authentication notes and usage troubleshooting.

## Testing

- `npm run validate` passed on the first revision (format, lint, typecheck, node 3125, workers 346, e2e 17, mcp 5, builds, docs, knip). GitHub CI was green on `e1d8bc99` (20 checks).
- Pre-push on `f1387172`: `CI=1 npm run test:node` (3125) and `CI=1 npm run test:workers` (346).
- Focused: form-default unit test (including verify-email Deny disabled before hydrate), clobber-detection unit test, SSR authorize HTML (`method="post"`, action keeps `client_id`, Approve disabled, unverified-session Deny disabled), workers authorize recovery workflow.
- Preview `https://kody-pr-2267.kody-a99.workers.dev` (merge of `7699429a`): `GET /oauth/authorize?kody_hp=` is 200; `GET /oauth/authorize-info?kody_hp=` is 400 with the recoverable missing-details JSON (`allowClientReset: false`).
- Addressed Bugbot: do not use `typeof document !== 'undefined'` as the interactivity gate (that mismatched SSR on first client paint).
- Addressed CodeRabbit: disable the standalone verify-email Deny before hydrate.

### How to verify

1. Open `/oauth/authorize?response_type=code&client_id=…&state=…` (full OAuth params).
2. Before hydration: Approve is disabled, form is `method="post"` with `action` still containing `client_id`.
3. Visit `/oauth/authorize?kody_hp=`: recoverable missing-details message, no Approve button, not `client_id is required`.
4. After hydration, logged-in approve/deny, credentials, and email-verification paths still work.
5. Unverified signed-in path: standalone Deny is disabled until after hydrate.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `e2a5e367` · **Head:** `f1387172`

**Classification:** extends — consent-form progressive enhancement and a new recoverable authorize error for the honeypot-only clobber case.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — authorize form POSTs to pathname and search, Approve and verify-email Deny stay disabled until after hydrate |
| `mcp-oauth` | auth | extends — missing `client_id` plus `kody_hp` returns a recoverable resubmit message |
| `app-sessions` | auth | composes — shared `oauth-handlers.ts` ownership, session contract unchanged |

### Change flow

A pre-hydration Approve click can no longer GET-submit the honeypot over the OAuth query. Already-clobbered URLs get an actionable error instead of `client_id is required`.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpOauth as mcp-oauth
	User->>appUi: open /oauth/authorize with OAuth query
	appUi->>User: SSR POST form to pathname and search, Approve and verify-email Deny disabled
	alt already on kody_hp-only URL
		User->>mcpOauth: GET /oauth/authorize?kody_hp=
		mcpOauth->>User: recoverable missing-details message
	else Approve after hydrate queueTask
		User->>appUi: click Approve
		appUi->>mcpOauth: POST current authorize URL with decision=approve
		mcpOauth->>User: redirect to the client
	end
```

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Consent `<form>` | no method/action, Approve enabled on SSR | `method="post"` `action=pathname+search`, hidden `decision=approve`, disabled until after hydrate |
| Verify-email Deny | enabled in SSR before click handler binds | disabled until after hydrate `queueTask` |
| `GET /oauth/authorize?kody_hp=` | `client_id is required` | recoverable start-again message, no Approve control |

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6852b216-c068-44e0-a143-b80bb5b84c85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6852b216-c068-44e0-a143-b80bb5b84c85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved OAuth connection details during authorization form submissions.
  - Prevented approval and denial actions until the page is ready.
  - Disabled email-verification denial while required session information is loading or submitting.
  - Replaced confusing missing-connection errors with actionable recovery messages.
  - Prevented incomplete authorization requests from displaying an approval option.

- **Documentation**
  - Expanded authentication architecture guidance for authorization page behavior.
  - Added troubleshooting steps for missing OAuth connection details, including using Back or restarting the connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->