### PR TITLE
Batch entity_sources reads after listing saved packages (KODY-7H)

### DIFF
--- a/packages/worker/src/package-registry/source-row-batch.node.test.ts
+++ b/packages/worker/src/package-registry/source-row-batch.node.test.ts
@@ -1,0 +1,151 @@
+import { DatabaseSync } from 'node:sqlite'
+import { expect, test, vi } from 'vitest'
+import { createD1FromSqlite } from '#worker/test-support/create-d1-from-sqlite.ts'
+
+vi.mock('#worker/repo/published-source.ts', () => ({
+	loadPublishedEntitySource: vi.fn(),
+	loadPublishedEntityManifest: vi.fn(async (input: { sourceId: string }) => ({
+		content: JSON.stringify({
+			name: `@kentcdodds/${input.sourceId}`,
+			exports: { '.': './index.js' },
+			kody: {
+				id: input.sourceId,
+				description: 'Batched source fixture',
+			},
+		}),
+	})),
+}))
+
+const {
+	loadPackageManifestBySourceId,
+	loadPackageSourceRowForUser,
+	loadPackageSourceRowsForUser,
+} = await import('./source.ts')
+
+function createEntitySourcesTable(sqlite: DatabaseSync) {
+	sqlite.exec(`
+		CREATE TABLE entity_sources (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			entity_kind TEXT NOT NULL,
+			entity_id TEXT NOT NULL,
+			repo_id TEXT NOT NULL,
+			published_commit TEXT,
+			indexed_commit TEXT,
+			manifest_path TEXT NOT NULL,
+			source_root TEXT NOT NULL,
+			last_external_check_at TEXT,
+			external_check_until TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+	`)
+}
+
+function insertSource(
+	sqlite: DatabaseSync,
+	input: { id: string; userId: string },
+) {
+	sqlite
+		.prepare(
+			`INSERT INTO entity_sources VALUES
+				(?, ?, 'package', ?, ?, 'commit-1', NULL,
+				'package.json', '/', NULL, NULL,
+				'2026-09-10T00:00:00.000Z', '2026-09-10T00:00:00.000Z')`,
+		)
+		.run(input.id, input.userId, `package-${input.id}`, `repo-${input.id}`)
+}
+
+function createLoadEnv(db: D1Database) {
+	return {
+		env: {
+			APP_DB: db,
+			BUNDLE_ARTIFACTS_KV: {
+				get: vi.fn(async () => null),
+				put: vi.fn(async () => undefined),
+				delete: vi.fn(async () => undefined),
+			} as unknown as KVNamespace,
+		} as Env,
+		baseUrl: 'https://heykody.dev',
+	}
+}
+
+test('queue-style concurrent manifest loads issue one entity_sources IN query', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	createEntitySourcesTable(sqlite)
+	insertSource(sqlite, { id: 'source-a', userId: 'user-1' })
+	insertSource(sqlite, { id: 'source-b', userId: 'user-1' })
+	insertSource(sqlite, { id: 'source-c', userId: 'user-1' })
+	insertSource(sqlite, { id: 'source-other', userId: 'user-2' })
+
+	const queries: Array<string> = []
+	const db = createD1FromSqlite(sqlite, { queries })
+	const loadEnv = createLoadEnv(db)
+
+	const [first, second, third] = await Promise.all([
+		loadPackageManifestBySourceId({
+			...loadEnv,
+			userId: 'user-1',
+			sourceId: 'source-a',
+		}),
+		loadPackageManifestBySourceId({
+			...loadEnv,
+			userId: 'user-1',
+			sourceId: 'source-b',
+		}),
+		loadPackageManifestBySourceId({
+			...loadEnv,
+			userId: 'user-1',
+			sourceId: 'source-c',
+		}),
+	])
+
+	expect([first.source.id, second.source.id, third.source.id]).toEqual([
+		'source-a',
+		'source-b',
+		'source-c',
+	])
+	expect(first.manifest.kody.id).toBe('source-a')
+	const sourceQueries = queries.filter((query) =>
+		query.includes('FROM entity_sources'),
+	)
+	expect(sourceQueries).toEqual([
+		'SELECT * FROM entity_sources WHERE id IN (?, ?, ?)',
+	])
+
+	await expect(
+		loadPackageSourceRowForUser({
+			env: loadEnv.env,
+			userId: 'user-1',
+			sourceId: 'source-other',
+		}),
+	).rejects.toThrow('was not found')
+	await expect(
+		loadPackageSourceRowForUser({
+			env: loadEnv.env,
+			userId: 'user-1',
+			sourceId: 'source-missing',
+		}),
+	).rejects.toThrow('was not found')
+
+	const loneQueriesStart = queries.length
+	const lone = await loadPackageSourceRowForUser({
+		env: loadEnv.env,
+		userId: 'user-1',
+		sourceId: 'source-a',
+	})
+	expect(lone.id).toBe('source-a')
+	expect(queries.slice(loneQueriesStart)).toEqual([
+		'SELECT * FROM entity_sources WHERE id = ?',
+	])
+
+	const explicit = await loadPackageSourceRowsForUser({
+		env: loadEnv.env,
+		userId: 'user-1',
+		sourceIds: ['source-a', 'source-c', 'source-other', 'source-a', 'missing'],
+	})
+	expect([...explicit.keys()].sort()).toEqual(['source-a', 'source-c'])
+	expect(
+		queries.filter((query) => query.includes('WHERE id IN (')).at(-1),
+	).toBe('SELECT * FROM entity_sources WHERE id IN (?, ?, ?, ?)')
+})

--- a/packages/worker/src/package-registry/source.ts
+++ b/packages/worker/src/package-registry/source.ts
@@ -1,5 +1,8 @@
 import { runD1WithRetry } from '#worker/d1-retry.ts'
-import { getEntitySourceById } from '#worker/repo/entity-sources.ts'
+import {
+	getEntitySourceById,
+	listEntitySourcesByIds,
+} from '#worker/repo/entity-sources.ts'
 import { type EntitySourceRow } from '#worker/repo/types.ts'
 import {
 	loadPublishedEntityManifest,
@@ -93,25 +96,126 @@ function canResolveRepoBackedPackageSource(env: Env) {
 	)
 }
 
+type PendingPackageSourceRowRequest = {
+	sourceId: string
+	userId: string
+	resolve: (source: EntitySourceRow) => void
+	reject: (error: unknown) => void
+}
+
+const pendingPackageSourceRowBatches = new WeakMap<
+	D1Database,
+	Array<PendingPackageSourceRowRequest>
+>()
+
+/**
+ * Fresh D1 read of the entity-source rows for `sourceIds`, omitting ids that
+ * are missing or owned by a different user. Used by queue subscription
+ * discovery after `listSavedPackagesByUserId` so one `IN (…)` replaces an
+ * N+1 of `SELECT * FROM entity_sources WHERE id = ?`.
+ */
+export async function loadPackageSourceRowsForUser(input: {
+	env: Pick<Env, 'APP_DB'>
+	userId: string
+	sourceIds: ReadonlyArray<string>
+}): Promise<Map<string, EntitySourceRow>> {
+	const uniqueIds = [...new Set(input.sourceIds)]
+	if (uniqueIds.length === 0) return new Map()
+	const [singleId] = uniqueIds
+	const rows = await runD1WithRetry(async () => {
+		if (uniqueIds.length === 1 && singleId) {
+			const row = await getEntitySourceById(input.env.APP_DB, singleId)
+			return row ? [row] : []
+		}
+		return await listEntitySourcesByIds(input.env.APP_DB, uniqueIds)
+	})
+	const byId = new Map<string, EntitySourceRow>()
+	for (const row of rows) {
+		if (row.user_id === input.userId) byId.set(row.id, row)
+	}
+	return byId
+}
+
 /**
  * Loads the entity-source row for a saved package, rejecting rows owned by a
  * different user. Always a fresh D1 read: publish and rebuild flows depend on
  * observing the current `published_commit`. Invocation hot paths that can
  * tolerate a bounded-staleness row wrap this in the invoke contract cache
  * instead (see `#worker/package-invocations/invoke-contract-cache.ts`).
+ *
+ * Concurrent calls against the same `APP_DB` in one isolate turn share one
+ * batched `IN (…)` read (KODY-7H). A lone lookup still uses
+ * {@link getEntitySourceById}.
  */
 export async function loadPackageSourceRowForUser(input: {
 	env: Env
 	userId: string
 	sourceId: string
 }) {
-	const source = await runD1WithRetry(() =>
-		getEntitySourceById(input.env.APP_DB, input.sourceId),
-	)
-	if (!source || source.user_id !== input.userId) {
-		throw new Error(`Saved package source "${input.sourceId}" was not found.`)
+	const db = input.env.APP_DB
+	return await new Promise<EntitySourceRow>((resolve, reject) => {
+		const pending = pendingPackageSourceRowBatches.get(db)
+		if (pending) {
+			pending.push({
+				sourceId: input.sourceId,
+				userId: input.userId,
+				resolve,
+				reject,
+			})
+			return
+		}
+		pendingPackageSourceRowBatches.set(db, [
+			{
+				sourceId: input.sourceId,
+				userId: input.userId,
+				resolve,
+				reject,
+			},
+		])
+		queueMicrotask(() => {
+			void flushPackageSourceRowBatch(db)
+		})
+	})
+}
+
+async function flushPackageSourceRowBatch(db: D1Database) {
+	const pending = pendingPackageSourceRowBatches.get(db)
+	pendingPackageSourceRowBatches.delete(db)
+	if (!pending || pending.length === 0) return
+
+	const uniqueIds = [...new Set(pending.map((request) => request.sourceId))]
+	const uniqueUserIds = [...new Set(pending.map((request) => request.userId))]
+	const [singleUserId] = uniqueUserIds
+	try {
+		const rowsById =
+			uniqueUserIds.length === 1 && singleUserId
+				? await loadPackageSourceRowsForUser({
+						env: { APP_DB: db },
+						userId: singleUserId,
+						sourceIds: uniqueIds,
+					})
+				: new Map(
+						(
+							await runD1WithRetry(() => listEntitySourcesByIds(db, uniqueIds))
+						).map((row) => [row.id, row]),
+					)
+		for (const request of pending) {
+			const source = rowsById.get(request.sourceId)
+			if (!source || source.user_id !== request.userId) {
+				request.reject(
+					new Error(
+						`Saved package source "${request.sourceId}" was not found.`,
+					),
+				)
+				continue
+			}
+			request.resolve(source)
+		}
+	} catch (error) {
+		for (const request of pending) {
+			request.reject(error)
+		}
 	}
-	return source
 }
 
 function createPackageSourceCacheKey(input: {

--- a/packages/worker/src/repo/entity-sources.node.test.ts
+++ b/packages/worker/src/repo/entity-sources.node.test.ts
@@ -6,6 +6,7 @@ import { type RepoSessionRow } from './types.ts'
 import {
 	deleteEntitySource,
 	externalReconcileGraceMs,
+	listEntitySourcesByIds,
 	listEntitySourcesForExternalReconcile,
 	markEntitySourcePendingExternalReconcile,
 } from './entity-sources.ts'
@@ -190,4 +191,61 @@ test('external reconcile selects token-pending packages and the daily backstop c
 		includeAll: true,
 	})
 	expect(dailyBackstop.map((row) => row.id)).toEqual(['dormant', 'pending'])
+})
+
+test('listEntitySourcesByIds batches ids into IN queries and skips missing rows', async () => {
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE entity_sources (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			entity_kind TEXT NOT NULL,
+			entity_id TEXT NOT NULL,
+			repo_id TEXT NOT NULL,
+			published_commit TEXT,
+			indexed_commit TEXT,
+			manifest_path TEXT NOT NULL,
+			source_root TEXT NOT NULL,
+			last_external_check_at TEXT,
+			external_check_until TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+	`)
+	for (const id of ['source-a', 'source-b', 'source-c']) {
+		sqlite
+			.prepare(
+				`INSERT INTO entity_sources VALUES
+					(?, 'user-1', 'package', ?, ?, 'commit-1', NULL,
+					'package.json', '/', NULL, NULL,
+					'2026-09-10T00:00:00.000Z', '2026-09-10T00:00:00.000Z')`,
+			)
+			.run(id, `package-${id}`, `repo-${id}`)
+	}
+
+	const queries: Array<string> = []
+	const db = createD1FromSqlite(sqlite, { queries, maxBindings: 100 })
+
+	expect(await listEntitySourcesByIds(db, [])).toEqual([])
+	expect(queries).toEqual([])
+
+	const loaded = await listEntitySourcesByIds(db, [
+		'source-b',
+		'source-missing',
+		'source-a',
+		'source-b',
+	])
+	expect(loaded.map((row) => row.id).sort()).toEqual(['source-a', 'source-b'])
+	expect(loaded.find((row) => row.id === 'source-a')?.entity_id).toBe(
+		'package-source-a',
+	)
+	expect(queries).toEqual([
+		'SELECT * FROM entity_sources WHERE id IN (?, ?, ?)',
+	])
+
+	const manyIds = Array.from({ length: 101 }, (_, index) => `missing-${index}`)
+	await listEntitySourcesByIds(db, manyIds)
+	expect(
+		queries.filter((query) => query.includes('WHERE id IN (')).length,
+	).toBe(3)
 })

--- a/packages/worker/src/repo/entity-sources.ts
+++ b/packages/worker/src/repo/entity-sources.ts
@@ -1,3 +1,7 @@
+import {
+	chunkArray,
+	maxD1BoundParameters,
+} from '@kody-internal/shared/chunk.ts'
 import { runD1WithRetry } from '#worker/d1-retry.ts'
 import {
 	repoSessionIndexNamespace,
@@ -75,6 +79,26 @@ export async function getEntitySourceById(
 		.bind(id)
 		.first<Record<string, unknown>>()
 	return result ? mapEntitySourceRow(result) : null
+}
+
+export async function listEntitySourcesByIds(
+	db: D1Database,
+	ids: ReadonlyArray<string>,
+): Promise<Array<EntitySourceRow>> {
+	if (ids.length === 0) return []
+	const uniqueIds = [...new Set(ids)]
+	const sources: Array<EntitySourceRow> = []
+	for (const idChunk of chunkArray(uniqueIds, maxD1BoundParameters)) {
+		const placeholders = idChunk.map(() => '?').join(', ')
+		const { results } = await db
+			.prepare(`SELECT * FROM entity_sources WHERE id IN (${placeholders})`)
+			.bind(...idChunk)
+			.all<Record<string, unknown>>()
+		for (const row of results ?? []) {
+			sources.push(mapEntitySourceRow(row))
+		}
+	}
+	return sources
 }
 
 export async function getEntitySourceByIdForUser(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop the KODY-7H N+1 on production queue consumers that list a user's `saved_packages` and then hydrate each row's `entity_sources`.

## Why

Sentry issue [KODY-7H](https://kent-c-dodds-tech-llc.sentry.io/issues/7723200596/) (`performance_n_plus_one_db_queries`, culprit `queue` / parent span `op=pubsub`) showed:

1. `SELECT … FROM saved_packages WHERE user_id = ? ORDER BY updated_at DESC`
2. Then ~15 repeats of `SELECT * FROM entity_sources WHERE id = ?`

That matches queue subscription discovery: `listSavedPackagesByUserId` then `Promise.all` of `loadPackageManifestBySourceId` → `loadPackageSourceRowForUser` → `getEntitySourceById`. Sibling KODY-7G was a different N+1 on `GET /community` and is not reused here.

## Summary

- Added `listEntitySourcesByIds` (`WHERE id IN (…)` with D1 binding-chunking).
- Added `loadPackageSourceRowsForUser` to load the listed `source_id`s in one (or few) reads and drop missing / other-user rows.
- Concurrent `loadPackageSourceRowForUser` calls against the same `APP_DB` in one isolate turn now flush through that batch helper. A lone lookup still uses `getEntitySourceById`.
- Ownership and "not found" errors are unchanged.

## Testing

- `source-row-batch.node.test.ts`: three concurrent `loadPackageManifestBySourceId` calls issue one `SELECT * FROM entity_sources WHERE id IN (?, ?, ?)`.
- `entity-sources.node.test.ts`: empty input, duplicates, missing ids, and 101-id chunking.
- Existing `source.node.test.ts` still covers single-id D1 retry.
- `npm run validate` passed locally (format, lint, typecheck, node-unit, workers-unit, e2e, mcp, builds, knip, and the rest of the gate).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1c2e9dd1` · **Head:** `63d173d2`

**Classification:** extends — `saved-packages` source-row hydration now batches `entity_sources` reads. No new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `saved-packages` | assistant | extends — concurrent source-row loads share one `IN (…)` |
| `repo-sessions` | runtime | extends — new `listEntitySourcesByIds` on `entity_sources` |
| `webhooks` | assistant | composes — still calls the shared source loader |

### Change flow

Queue subscription discovery still lists `saved_packages`, then hydrates manifests. This PR batches the `entity_sources` reads that used to run once per package.

```mermaid
sequenceDiagram
	actor Queue as queue pubsub
	participant savedPackages as saved-packages
	participant repoSessions as repo-sessions
	Queue->>savedPackages: listSavedPackagesByUserId
	Note over savedPackages: SELECT saved_packages WHERE user_id
	savedPackages->>savedPackages: Promise.all loadPackageManifestBySourceId
	savedPackages->>repoSessions: loadPackageSourceRowsForUser listed source_ids
	Note over repoSessions: one SELECT entity_sources WHERE id IN
	repoSessions-->>savedPackages: Map of owned source rows
```

### Before / after

```text
before: 1 saved_packages SELECT + N entity_sources WHERE id = ?
after:  1 saved_packages SELECT + 1 entity_sources WHERE id IN (…)
        (plus extra chunks only past the D1 binding cap)
```

### Invariants

Per-user isolation is unchanged: rows owned by another user still resolve as not found.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0395310d-fb64-41e1-bdd4-ff9936c60e58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0395310d-fb64-41e1-bdd4-ff9936c60e58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved package source loading by batching concurrent requests, reducing redundant database lookups.
  - Added efficient multi-source retrieval with duplicate ID handling and support for large source lists.

- **Reliability**
  - Added clearer handling for missing or unauthorized package sources.
  - Improved consistency when loading source information for individual and multiple requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->