### PR TITLE
Keep previous webhook URL live briefly after rotate

### DIFF
--- a/.agents/skills/control-kody/references/features/webhooks.md
+++ b/.agents/skills/control-kody/references/features/webhooks.md
@@ -46,6 +46,9 @@ node tools/control-kody.ts request GET /account/webhooks.json
   hash deep links wait for it.
 - `mint` on an already-minted webhook is a 400 (“Rotate it”); the card only
   shows Mint for unminted rows. Rotate and Disable are double-check buttons.
+  Rotate keeps the previous URL active for 24 hours, or until a delivery arrives
+  on the new URL; the card shows “Previous URL active until …” during that
+  overlap.
 - `reveal` on a legacy mint without `url_secret_encrypted` is a 400; the card
   offers Rotate instead.
 - Every intent writes an `account` audit event (`webhook_url_reveal`, …).

--- a/.agents/skills/control-kody/references/features/webhooks.md
+++ b/.agents/skills/control-kody/references/features/webhooks.md
@@ -46,9 +46,9 @@ node tools/control-kody.ts request GET /account/webhooks.json
   hash deep links wait for it.
 - `mint` on an already-minted webhook is a 400 (“Rotate it”); the card only
   shows Mint for unminted rows. Rotate and Disable are double-check buttons.
-  Rotate keeps the previous URL active for 24 hours, or until a delivery arrives
-  on the new URL; the card shows “Previous URL active until …” during that
-  overlap.
+  Rotate keeps the previous URL active for 24 hours, or until the first accepted
+  delivery arrives on the new URL; the card shows “Previous URL active until …”
+  during that overlap. Only enabled cards show the overlap row.
 - `reveal` on a legacy mint without `url_secret_encrypted` is a 400; the card
   offers Rotate instead.
 - Every intent writes an `account` audit event (`webhook_url_reveal`, …).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ This file is intentionally brief. Detailed instructions live in focused docs:
   - [docs/contributing/architecture/index.md](./docs/contributing/architecture/index.md)
     (production worker fleet, request lifecycle, authentication, data storage,
     and the rest of the architecture leaves)
+  - Inbound webhooks (rotate keeps the previous URL live briefly):
+    [docs/use/webhooks.md](./docs/use/webhooks.md) and
+    [docs/contributing/architecture/webhooks.md](./docs/contributing/architecture/webhooks.md)
   - [docs/contributing/architecture/primitives.yaml](./docs/contributing/architecture/primitives.yaml)
     (stable taxonomy, not a feature changelog — see the architecture index for
     the classify/check workflow)

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -82,8 +82,10 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
    channels).
 4. Constant-time compare the URL secret against `url_secret_hash` (SHA-256) and,
    during rotate overlap, the previous hash. The previous URL stays active for
-   24 hours or until the first accepted POST on the new URL, whichever comes
-   first. An expired previous hash is treated as unknown.
+   24 hours or until the first POST on the new URL that is accepted for dispatch
+   (ack enqueue or sync invoke), whichever comes first. HMAC, rate limit,
+   payload, and declaration rejects do not retire the previous URL. An expired
+   previous hash is treated as unknown.
 5. After a matching URL secret, enforce per-webhook rate limit (declared
    `rateLimitPerMinute` when the name is still live, otherwise the default 60,
    max 600) → **429** (no delivery history on the limited path). Missing

--- a/docs/contributing/architecture/webhooks.md
+++ b/docs/contributing/architecture/webhooks.md
@@ -80,7 +80,10 @@ Route: `POST /@:username/webhooks/:packageKodyId/:webhookName/:urlSecret`
    URL-secret mismatch → **404** (indistinguishable). URL-secret mismatches do
    **not** record delivery history (avoids log-flush DoS and rate-limit side
    channels).
-4. Constant-time compare the URL secret against `url_secret_hash` (SHA-256).
+4. Constant-time compare the URL secret against `url_secret_hash` (SHA-256) and,
+   during rotate overlap, the previous hash. The previous URL stays active for
+   24 hours or until the first accepted POST on the new URL, whichever comes
+   first. An expired previous hash is treated as unknown.
 5. After a matching URL secret, enforce per-webhook rate limit (declared
    `rateLimitPerMinute` when the name is still live, otherwise the default 60,
    max 600) → **429** (no delivery history on the limited path). Missing
@@ -135,7 +138,8 @@ consumer's 15-minute wall-clock limit before later messages are acknowledged.
   immediately re-scopes by the owning user.
 - Account deletion/export include `webhook_endpoints` (minted URL state).
   Delivery history lives in run records and is covered with the rest of `RunLog`
-  export/deletion. Export redacts `url_secret_hash` and `url_secret_encrypted`.
+  export/deletion. Export redacts `url_secret_hash`, `url_secret_encrypted`, and
+  `previous_url_secret_hash`.
 - Plaintext URL secrets and verification secrets are never logged. URL secrets
   are hashed for ingress and stored encrypted for `webhookUrlApply` and the
   owner reveal in package settings. MCP mint, rotate, list, and apply never
@@ -151,15 +155,15 @@ Webhooks belong to the package that declares them, so the owner surface is the
 (`packages/worker/src/app/handlers/package-webhooks.ts`). The handler is
 owner-only: the signed-in user must be `:username` and own `:kodyId`, otherwise
 it answers 404 without naming the package or its webhooks. `GET` returns
-`listWebhooksForUser` filtered to the package and joined with `urlRecoverable`,
-never the URL. `POST { intent, webhookName }` intents `mint`, `rotate`, and
-`reveal` return the refreshed list plus a `revealed` entry built by
-`revealWebhookUrlForWebsite` (decrypt `url_secret_encrypted`, rebuild the
-ingress path from the request origin); `enable` / `disable` return the list
-only. Every intent writes an `account` audit event (`webhook_url_mint`,
-`webhook_url_rotate`, `webhook_url_reveal`, `webhook_enable`,
-`webhook_disable`). `mint` refuses an already-minted webhook so a stray click
-cannot rotate a provider's URL; `reveal` refuses mints without
+`listWebhooksForUser` filtered to the package and joined with `urlRecoverable`
+and `previousUrlActiveUntil`, never the URL. `POST { intent, webhookName }`
+intents `mint`, `rotate`, and `reveal` return the refreshed list plus a
+`revealed` entry built by `revealWebhookUrlForWebsite` (decrypt
+`url_secret_encrypted`, rebuild the ingress path from the request origin);
+`enable` / `disable` return the list only. Every intent writes an `account`
+audit event (`webhook_url_mint`, `webhook_url_rotate`, `webhook_url_reveal`,
+`webhook_enable`, `webhook_disable`). `mint` refuses an already-minted webhook
+so a stray click cannot rotate a provider's URL; `reveal` refuses mints without
 `url_secret_encrypted` and points at Rotate. The client keeps revealed URLs in
 memory only and drops them on Hide or when the settings page changes package.
 
@@ -176,12 +180,15 @@ binding, or apply result may return the credential URL.
 
 Minted endpoint state lives in the D1 `webhook_endpoints` table defined by
 `packages/worker/migrations/0001-squashed-init.sql`, with `url_secret_encrypted`
-added in `0057-webhook-url-secret-encrypted.sql`. `webhookUrlMint` /
-`webhookUrlRotate` return an opaque `handle` (`whh_<id>`) and `url_host`.
-`webhookUrlApply` resolves the handle inside Kody and registers the URL through
-a first-class destination adapter (GitHub repository hooks via the user GitHub
-integration or a host-approved GitHub token). The credential is injected into
-the provider API field; apply does not accept an arbitrary outbound URL.
-Delivery history is in the per-user `RunLog` Durable Object (`webhook` surface),
-not in D1. See [Data storage](./data-storage.md) and
-[Run records](./run-records.md).
+added in `0057-webhook-url-secret-encrypted.sql` and rotate-overlap columns in
+`0062-webhook-url-rotation-grace.sql`. Rotate copies the outgoing hash to
+`previous_url_secret_hash` with `previous_url_secret_expires_at` 24 hours out.
+The previous ciphertext is not stored: reveal and apply always rebuild the
+current URL. `webhookUrlMint` / `webhookUrlRotate` return an opaque `handle`
+(`whh_<id>`) and `url_host`. `webhookUrlApply` resolves the handle inside Kody
+and registers the URL through a first-class destination adapter (GitHub
+repository hooks via the user GitHub integration or a host-approved GitHub
+token). The credential is injected into the provider API field; apply does not
+accept an arbitrary outbound URL. Delivery history is in the per-user `RunLog`
+Durable Object (`webhook` surface), not in D1. See
+[Data storage](./data-storage.md) and [Run records](./run-records.md).

--- a/docs/guides/triggers.md
+++ b/docs/guides/triggers.md
@@ -110,9 +110,9 @@ request to the package export that owns it.
    copies the URL from the package's settings page
    (`/@<username>/<packageKodyId>/settings`, Webhooks section), where they can
    also reveal, rotate, disable, or enable it. Rotate keeps the previous URL
-   live for 24 hours, or until a delivery arrives on the new URL.
-   `/account/webhooks` lists every webhook across packages and links to those
-   sections.
+   live for 24 hours, or until the first accepted delivery arrives on the new
+   URL. `/account/webhooks` lists every webhook across packages and links to
+   those sections.
 
 Declaring a webhook does not open ingress; minting does. Deliveries are
 rate-limited per webhook (default 60 per minute, at most 600), and body-only

--- a/docs/guides/triggers.md
+++ b/docs/guides/triggers.md
@@ -109,8 +109,10 @@ request to the package export that owns it.
    output never includes it. For a provider apply does not cover, the owner
    copies the URL from the package's settings page
    (`/@<username>/<packageKodyId>/settings`, Webhooks section), where they can
-   also reveal, rotate, disable, or enable it. `/account/webhooks` lists every
-   webhook across packages and links to those sections.
+   also reveal, rotate, disable, or enable it. Rotate keeps the previous URL
+   live for 24 hours, or until a delivery arrives on the new URL.
+   `/account/webhooks` lists every webhook across packages and links to those
+   sections.
 
 Declaring a webhook does not open ingress; minting does. Deliveries are
 rate-limited per webhook (default 60 per minute, at most 600), and body-only

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -111,9 +111,10 @@ package declares, joined with its minted state, one card per webhook:
   URL once so you can paste it into the provider.
 - **Reveal URL** shows a minted URL again, with a copy button. Each reveal is
   written to the account audit log.
-- **Rotate URL** replaces the secret. The previous URL stops working
-  immediately; rerun `webhookUrlApply` (same handle) or paste the new URL into
-  the provider.
+- **Rotate URL** replaces the secret. The previous URL stays active for **24
+  hours**, or until a delivery arrives on the new URL. Rerun `webhookUrlApply`
+  (same handle) or paste the new URL into the provider. The card shows “Previous
+  URL active until …” during that overlap.
 - **Disable** / **Enable** toggle ingress without deleting the mint. Disabled
   webhooks answer 404.
 
@@ -334,8 +335,9 @@ ingress (unknown name → 404). Disable with `webhookDisable` without deleting t
 mint; re-enable with `webhookEnable`. Rotate the URL secret with
 `webhookUrlRotate` when a credential may have leaked, then call
 `webhookUrlApply` again with the same handle so providers get the new URL. The
-same disable, enable, and rotate actions are in the package's settings Webhooks
-section.
+previous URL stays active for 24 hours, or until a delivery arrives on the new
+URL. The same disable, enable, and rotate actions are in the package's settings
+Webhooks section.
 
 ## Related
 

--- a/docs/use/webhooks.md
+++ b/docs/use/webhooks.md
@@ -112,9 +112,9 @@ package declares, joined with its minted state, one card per webhook:
 - **Reveal URL** shows a minted URL again, with a copy button. Each reveal is
   written to the account audit log.
 - **Rotate URL** replaces the secret. The previous URL stays active for **24
-  hours**, or until a delivery arrives on the new URL. Rerun `webhookUrlApply`
-  (same handle) or paste the new URL into the provider. The card shows “Previous
-  URL active until …” during that overlap.
+  hours**, or until the first accepted delivery arrives on the new URL. Rerun
+  `webhookUrlApply` (same handle) or paste the new URL into the provider. The
+  card shows “Previous URL active until …” during that overlap.
 - **Disable** / **Enable** toggle ingress without deleting the mint. Disabled
   webhooks answer 404.
 
@@ -335,9 +335,9 @@ ingress (unknown name → 404). Disable with `webhookDisable` without deleting t
 mint; re-enable with `webhookEnable`. Rotate the URL secret with
 `webhookUrlRotate` when a credential may have leaked, then call
 `webhookUrlApply` again with the same handle so providers get the new URL. The
-previous URL stays active for 24 hours, or until a delivery arrives on the new
-URL. The same disable, enable, and rotate actions are in the package's settings
-Webhooks section.
+previous URL stays active for 24 hours, or until the first accepted delivery
+arrives on the new URL. The same disable, enable, and rotate actions are in the
+package's settings Webhooks section.
 
 ## Related
 

--- a/packages/worker/client/routes/account-webhooks.node.test.ts
+++ b/packages/worker/client/routes/account-webhooks.node.test.ts
@@ -48,6 +48,7 @@ const unminted: PackageWebhookListItem = {
 	urlRecoverable: false,
 	createdAt: null,
 	rotatedAt: null,
+	previousUrlActiveUntil: null,
 }
 
 const minted: PackageWebhookListItem = {
@@ -70,6 +71,7 @@ const minted: PackageWebhookListItem = {
 	urlRecoverable: true,
 	createdAt: '2026-09-01T10:00:00.000Z',
 	rotatedAt: '2026-09-05T10:00:00.000Z',
+	previousUrlActiveUntil: null,
 }
 
 function renderWebhooksPage(

--- a/packages/worker/client/routes/package-webhook-card.tsx
+++ b/packages/worker/client/routes/package-webhook-card.tsx
@@ -180,7 +180,7 @@ export function renderPackageWebhookCard(input: {
 						label: 'Rotated',
 						value: <TimestampValue value={webhook.rotatedAt} />,
 					},
-					...(webhook.previousUrlActiveUntil
+					...(webhook.enabled && webhook.previousUrlActiveUntil
 						? [
 								{
 									label: 'Previous URL',

--- a/packages/worker/client/routes/package-webhook-card.tsx
+++ b/packages/worker/client/routes/package-webhook-card.tsx
@@ -180,6 +180,19 @@ export function renderPackageWebhookCard(input: {
 						label: 'Rotated',
 						value: <TimestampValue value={webhook.rotatedAt} />,
 					},
+					...(webhook.previousUrlActiveUntil
+						? [
+								{
+									label: 'Previous URL',
+									value: (
+										<span>
+											active until{' '}
+											<TimestampValue value={webhook.previousUrlActiveUntil} />
+										</span>
+									),
+								},
+							]
+						: []),
 				]}
 			/>
 
@@ -259,8 +272,8 @@ export function renderPackageWebhookCard(input: {
 
 			{rotateCheck.doubleCheck ? (
 				<AccountManagementMessage tone="info">
-					Rotating replaces the secret immediately. The current URL stops
-					working and every provider that posts to it needs the new one.
+					Rotating mints a new URL. The previous URL stays active for 24 hours,
+					or until a delivery arrives on the new one.
 				</AccountManagementMessage>
 			) : null}
 

--- a/packages/worker/client/routes/package-webhook-settings.node.test.ts
+++ b/packages/worker/client/routes/package-webhook-settings.node.test.ts
@@ -343,4 +343,22 @@ test('a webhook card shows previous URL overlap until the grace timestamp', asyn
 	expect(html).toContain('Previous URL')
 	expect(html).toContain('active until')
 	expect(html).toContain(new Date(until).toLocaleString())
+
+	const disabledOverlap: PackageWebhookListItem = {
+		...overlapping,
+		enabled: false,
+	}
+	const disabledHtml = await renderToString(
+		renderPackageWebhookCard({
+			webhook: disabledOverlap,
+			revealedUrl: null,
+			isMutating: false,
+			rotateCheck: createDoubleCheck(handle),
+			disableCheck: createDoubleCheck(handle),
+			onIntent: () => {},
+			onHideUrl: () => {},
+		}),
+	)
+	expect(disabledHtml).not.toContain('Previous URL')
+	expect(disabledHtml).toContain('>Disabled<')
 })

--- a/packages/worker/client/routes/package-webhook-settings.node.test.ts
+++ b/packages/worker/client/routes/package-webhook-settings.node.test.ts
@@ -33,6 +33,7 @@ const listCommands: PackageWebhookListItem = {
 	urlRecoverable: false,
 	createdAt: null,
 	rotatedAt: null,
+	previousUrlActiveUntil: null,
 }
 
 const run: PackageWebhookListItem = {
@@ -55,6 +56,7 @@ const run: PackageWebhookListItem = {
 	urlRecoverable: true,
 	createdAt: '2026-09-01T10:00:00.000Z',
 	rotatedAt: '2026-09-05T10:00:00.000Z',
+	previousUrlActiveUntil: null,
 }
 
 const secretUrl =
@@ -148,6 +150,7 @@ test('the settings section loads one package’s webhooks, then mints, reveals, 
 				urlHost: 'kody.example',
 				createdAt: '2026-09-11T10:00:00.000Z',
 				rotatedAt: '2026-09-11T10:00:00.000Z',
+				previousUrlActiveUntil: null,
 			}
 			const payload: PackageWebhooksActionPayload = {
 				...listPayload([listCommandsState, run]),
@@ -317,4 +320,27 @@ test('a webhook card points legacy mints at Rotate instead of Reveal and offers 
 	expect(html).toContain('600 / min')
 	expect(html).toContain('delivery id X-Delivery-Id')
 	expect(html).toContain('surface=webhook')
+})
+
+test('a webhook card shows previous URL overlap until the grace timestamp', async () => {
+	const { handle } = createStubHandle()
+	const until = '2026-09-13T15:04:05.000Z'
+	const overlapping: PackageWebhookListItem = {
+		...run,
+		previousUrlActiveUntil: until,
+	}
+	const html = await renderToString(
+		renderPackageWebhookCard({
+			webhook: overlapping,
+			revealedUrl: null,
+			isMutating: false,
+			rotateCheck: createDoubleCheck(handle),
+			disableCheck: createDoubleCheck(handle),
+			onIntent: () => {},
+			onHideUrl: () => {},
+		}),
+	)
+	expect(html).toContain('Previous URL')
+	expect(html).toContain('active until')
+	expect(html).toContain(new Date(until).toLocaleString())
 })

--- a/packages/worker/client/routes/package-webhook-settings.tsx
+++ b/packages/worker/client/routes/package-webhook-settings.tsx
@@ -189,8 +189,9 @@ export function createPackageWebhooksController(handle: Handle) {
 					Inbound webhook URLs this package declares in{' '}
 					<code>package.json#kody.webhooks</code>. Mint a URL here, copy it into
 					the provider that will POST to it, and rotate or disable it when it
-					leaks or goes unused. Agents connected over MCP can mint and apply
-					handles but never see these URLs.
+					leaks or goes unused. Rotate keeps the previous URL live for a short
+					overlap so providers can finish switching. Agents connected over MCP
+					can mint and apply handles but never see these URLs.
 				</p>
 
 				{showLoading ? (

--- a/packages/worker/client/routes/webhooks-shared.ts
+++ b/packages/worker/client/routes/webhooks-shared.ts
@@ -87,7 +87,7 @@ export function webhookSuccessMessage(intent: WebhookIntent) {
 		case 'mint':
 			return 'Webhook URL minted. Copy it now and paste it into the provider.'
 		case 'rotate':
-			return 'Webhook URL rotated. The previous URL no longer works.'
+			return 'Webhook URL rotated. The previous URL stays active until the new one receives a delivery, or for 24 hours.'
 		case 'reveal':
 			return null
 		case 'enable':

--- a/packages/worker/migrations/0062-webhook-url-rotation-grace.sql
+++ b/packages/worker/migrations/0062-webhook-url-rotation-grace.sql
@@ -1,0 +1,6 @@
+-- Rotate keeps one previous URL secret hash live for a short overlap so
+-- providers can finish switching. Ingress accepts the previous hash until
+-- a delivery arrives on the new URL, or until previous_url_secret_expires_at.
+-- The previous ciphertext is not stored: reveal / apply always use the current URL.
+ALTER TABLE webhook_endpoints ADD COLUMN previous_url_secret_hash TEXT;
+ALTER TABLE webhook_endpoints ADD COLUMN previous_url_secret_expires_at TEXT;

--- a/packages/worker/src/account/data-targets.node.test.ts
+++ b/packages/worker/src/account/data-targets.node.test.ts
@@ -194,7 +194,11 @@ test('every accountUserDataTargets kind has a shared match builder and export gu
 		expect.arrayContaining(['client_secret_encrypted']),
 	)
 	expect(accountExportRedactedColumnsByTable.webhook_endpoints).toEqual(
-		expect.arrayContaining(['url_secret_hash', 'url_secret_encrypted']),
+		expect.arrayContaining([
+			'url_secret_hash',
+			'url_secret_encrypted',
+			'previous_url_secret_hash',
+		]),
 	)
 	expect(
 		accountExportForeignUserIdColumnsByTable.community_activity_events,

--- a/packages/worker/src/account/data-targets.ts
+++ b/packages/worker/src/account/data-targets.ts
@@ -779,7 +779,11 @@ export const accountExportRedactedColumnsByTable: Readonly<
 	user_oauth_apps: ['client_secret_encrypted'],
 	users: ['password_hash'],
 	verifications: ['secret'],
-	webhook_endpoints: ['url_secret_hash', 'url_secret_encrypted'],
+	webhook_endpoints: [
+		'url_secret_hash',
+		'url_secret_encrypted',
+		'previous_url_secret_hash',
+	],
 }
 
 // Cross-user export rows can include another user's stable id. Keep the

--- a/packages/worker/src/app/handlers/account-webhooks.node.test.ts
+++ b/packages/worker/src/app/handlers/account-webhooks.node.test.ts
@@ -115,6 +115,8 @@ function createEnv() {
 			webhook_name TEXT NOT NULL,
 			url_secret_hash TEXT NOT NULL,
 			url_secret_encrypted TEXT,
+			previous_url_secret_hash TEXT,
+			previous_url_secret_expires_at TEXT,
 			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
 			created_at TEXT NOT NULL,
 			rotated_at TEXT NOT NULL

--- a/packages/worker/src/app/handlers/package-webhooks.node.test.ts
+++ b/packages/worker/src/app/handlers/package-webhooks.node.test.ts
@@ -94,6 +94,8 @@ function createEnv() {
 			webhook_name TEXT NOT NULL,
 			url_secret_hash TEXT NOT NULL,
 			url_secret_encrypted TEXT,
+			previous_url_secret_hash TEXT,
+			previous_url_secret_expires_at TEXT,
 			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
 			created_at TEXT NOT NULL,
 			rotated_at TEXT NOT NULL
@@ -282,6 +284,11 @@ test('package webhooks API mints, reveals, rotates, and toggles a declared webho
 	)!
 	// Rotate keeps the disabled state; only Enable flips it back.
 	expect(rotatedLauncher.enabled).toBe(false)
+	expect(rotatedLauncher.previousUrlActiveUntil).toEqual(expect.any(String))
+	const overlapUntil = Date.parse(rotatedLauncher.previousUrlActiveUntil!)
+	const overlapExpected = Date.now() + 24 * 60 * 60 * 1000
+	expect(overlapUntil).toBeGreaterThan(overlapExpected - 10_000)
+	expect(overlapUntil).toBeLessThan(overlapExpected + 10_000)
 
 	const enabled = await runHandler(
 		handler,

--- a/packages/worker/src/app/package-webhooks-data.ts
+++ b/packages/worker/src/app/package-webhooks-data.ts
@@ -43,6 +43,7 @@ function toPackageWebhookListItem(
 		urlRecoverable: webhook.urlRecoverable,
 		createdAt: webhook.createdAt,
 		rotatedAt: webhook.rotatedAt,
+		previousUrlActiveUntil: webhook.previousUrlActiveUntil,
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/webhooks/domain.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/domain.ts
@@ -11,7 +11,7 @@ import { webhookUrlRotateCapability } from './webhook-url-rotate.ts'
 export const webhooksDomain = defineDomain({
 	name: capabilityDomainNames.webhooks,
 	description:
-		'Package-declared inbound webhooks with minted handles. Register first-class destinations with webhookUrlApply — credential URLs never appear in tool output.',
+		'Package-declared inbound webhooks with minted handles. Rotate keeps the previous URL live briefly. Register first-class destinations with webhookUrlApply — credential URLs never appear in tool output.',
 	keywords: [
 		'webhook',
 		'inbound',
@@ -23,6 +23,7 @@ export const webhooksDomain = defineDomain({
 		'signature',
 		'hmac',
 		'mint',
+		'rotate',
 		'apply',
 	],
 	capabilities: [

--- a/packages/worker/src/mcp/capabilities/webhooks/shared.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/shared.ts
@@ -62,6 +62,12 @@ export const listedWebhookSchema = z.object({
 		.describe('Null when not minted; otherwise the mint enabled flag.'),
 	created_at: z.string().nullable(),
 	rotated_at: z.string().nullable(),
+	previous_url_active_until: z
+		.string()
+		.nullable()
+		.describe(
+			'ISO timestamp while the previous URL still accepts deliveries after rotate. Null when there is no live overlap.',
+		),
 })
 
 export const mintedWebhookHandleSchema = z.object({
@@ -79,6 +85,12 @@ export const mintedWebhookHandleSchema = z.object({
 	enabled: z.boolean(),
 	created_at: z.string(),
 	rotated_at: z.string(),
+	previous_url_active_until: z
+		.string()
+		.nullable()
+		.describe(
+			'ISO timestamp while the previous URL still accepts deliveries after rotate. Null on first mint.',
+		),
 })
 
 export const webhookUrlApplyResultSchema = z.object({
@@ -127,6 +139,7 @@ export function toListedWebhookCapability(webhook: {
 	enabled: boolean | null
 	createdAt: string | null
 	rotatedAt: string | null
+	previousUrlActiveUntil: string | null
 }) {
 	return {
 		package_id: webhook.packageId,
@@ -146,6 +159,7 @@ export function toListedWebhookCapability(webhook: {
 		enabled: webhook.enabled,
 		created_at: webhook.createdAt,
 		rotated_at: webhook.rotatedAt,
+		previous_url_active_until: webhook.previousUrlActiveUntil,
 	}
 }
 
@@ -158,6 +172,7 @@ export function toMintedWebhookCapability(minted: {
 	enabled: boolean
 	createdAt: string
 	rotatedAt: string
+	previousUrlActiveUntil: string | null
 }) {
 	return {
 		package_id: minted.packageId,
@@ -168,6 +183,7 @@ export function toMintedWebhookCapability(minted: {
 		enabled: minted.enabled,
 		created_at: minted.createdAt,
 		rotated_at: minted.rotatedAt,
+		previous_url_active_until: minted.previousUrlActiveUntil,
 	}
 }
 

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-capabilities.node.test.ts
@@ -89,6 +89,7 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 			enabled: true,
 			createdAt: '2026-07-24T00:00:00.000Z',
 			rotatedAt: '2026-07-24T00:00:00.000Z',
+			previousUrlActiveUntil: null,
 		},
 	])
 	mockModule.mintWebhookUrlForUser.mockResolvedValue({
@@ -100,6 +101,7 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 		enabled: true,
 		createdAt: '2026-07-24T00:00:00.000Z',
 		rotatedAt: '2026-07-24T00:00:00.000Z',
+		previousUrlActiveUntil: null,
 	})
 	mockModule.rotateWebhookUrlForUser.mockResolvedValue({
 		packageId: 'pkg-1',
@@ -110,6 +112,7 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 		enabled: true,
 		createdAt: '2026-07-24T00:00:00.000Z',
 		rotatedAt: '2026-07-24T01:00:00.000Z',
+		previousUrlActiveUntil: '2026-07-25T01:00:00.000Z',
 	})
 	mockModule.setWebhookEnabledForUser.mockImplementation(
 		async (input: { enabled: boolean }) => ({
@@ -178,6 +181,7 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 	const listed = await webhookListCapability.handler({}, ctx)
 	expect(listed.webhooks[0]?.minted).toBe(true)
 	expect(listed.webhooks[0]?.handle).toBe('whh_ep-1')
+	expect(listed.webhooks[0]?.previous_url_active_until).toBeNull()
 	expect(JSON.stringify(listed)).not.toContain('secret-once')
 
 	const minted = await webhookUrlMintCapability.handler(
@@ -194,6 +198,9 @@ test('webhook capabilities expose mint once and never leak secrets on list', asy
 		ctx,
 	)
 	expect(rotated.webhook.handle).toBe('whh_ep-1')
+	expect(rotated.webhook.previous_url_active_until).toBe(
+		'2026-07-25T01:00:00.000Z',
+	)
 	expect(rotated.webhook).not.toHaveProperty('url_secret')
 
 	mockModule.applyWebhookUrlForUser.mockResolvedValue({

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-url-rotate.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-url-rotate.ts
@@ -15,7 +15,7 @@ export const webhookUrlRotateCapability = defineDomainCapability(
 	{
 		name: 'webhookUrlRotate',
 		description:
-			'Rotate the URL secret for a minted package webhook and return a new opaque handle. The previous URL stays active for 24 hours, or until a delivery arrives on the new URL. Register the new URL with webhookUrlApply — the credential is never returned.',
+			'Rotate the URL secret for a minted package webhook and return a new opaque handle. The previous URL stays active for 24 hours, or until the first accepted delivery arrives on the new URL. Register the new URL with webhookUrlApply — the credential is never returned.',
 		keywords: ['webhook', 'rotate', 'secret', 'handle', 'url'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/mcp/capabilities/webhooks/webhook-url-rotate.ts
+++ b/packages/worker/src/mcp/capabilities/webhooks/webhook-url-rotate.ts
@@ -15,7 +15,7 @@ export const webhookUrlRotateCapability = defineDomainCapability(
 	{
 		name: 'webhookUrlRotate',
 		description:
-			'Rotate the URL secret for a minted package webhook and return a new opaque handle. The replaced URL stops working immediately. Register the new URL with webhookUrlApply — the credential is never returned.',
+			'Rotate the URL secret for a minted package webhook and return a new opaque handle. The previous URL stays active for 24 hours, or until a delivery arrives on the new URL. Register the new URL with webhookUrlApply — the credential is never returned.',
 		keywords: ['webhook', 'rotate', 'secret', 'handle', 'url'],
 		readOnly: false,
 		idempotent: false,

--- a/packages/worker/src/webhooks/apply.node.test.ts
+++ b/packages/worker/src/webhooks/apply.node.test.ts
@@ -138,6 +138,8 @@ function createEnv(userId: string) {
 			webhook_name TEXT NOT NULL,
 			url_secret_hash TEXT NOT NULL,
 			url_secret_encrypted TEXT,
+			previous_url_secret_hash TEXT,
+			previous_url_secret_expires_at TEXT,
 			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
 			created_at TEXT NOT NULL,
 			rotated_at TEXT NOT NULL

--- a/packages/worker/src/webhooks/crypto.node.test.ts
+++ b/packages/worker/src/webhooks/crypto.node.test.ts
@@ -6,6 +6,7 @@ import {
 	generateWebhookUrlSecret,
 	hashWebhookUrlSecret,
 	isWebhookTimestampWithinTolerance,
+	matchWebhookIngressUrlSecret,
 	parseWebhookReplayTimestamp,
 	providedWebhookHmacValues,
 	verifyWebhookHmacSignature,
@@ -25,6 +26,30 @@ test('webhook URL secrets hash for storage and compare in constant time', async 
 			storedHash: hash,
 		}),
 	).toBe(false)
+
+	const previous = await generateWebhookUrlSecret()
+	const previousHash = await hashWebhookUrlSecret(previous)
+	expect(
+		await matchWebhookIngressUrlSecret({
+			candidate: secret,
+			currentHash: hash,
+			previousHash,
+		}),
+	).toBe('current')
+	expect(
+		await matchWebhookIngressUrlSecret({
+			candidate: previous,
+			currentHash: hash,
+			previousHash,
+		}),
+	).toBe('previous')
+	expect(
+		await matchWebhookIngressUrlSecret({
+			candidate: `${secret}x`,
+			currentHash: hash,
+			previousHash,
+		}),
+	).toBeNull()
 })
 
 test('HMAC signatures cover GitHub-style prefixed hex and raw hex', async () => {

--- a/packages/worker/src/webhooks/crypto.ts
+++ b/packages/worker/src/webhooks/crypto.ts
@@ -31,6 +31,31 @@ export async function webhookUrlSecretMatches(input: {
 	return timingSafeEqualString(candidateHash, input.storedHash)
 }
 
+/**
+ * Compare the path secret against current and previous hashes. Both hashes
+ * are compared when a previous hash is present so timing does not reveal
+ * which generation matched.
+ */
+export async function matchWebhookIngressUrlSecret(input: {
+	candidate: string
+	currentHash: string
+	previousHash: string | null
+}): Promise<'current' | 'previous' | null> {
+	const currentMatches = await webhookUrlSecretMatches({
+		candidate: input.candidate,
+		storedHash: input.currentHash,
+	})
+	const previousMatches = input.previousHash
+		? await webhookUrlSecretMatches({
+				candidate: input.candidate,
+				storedHash: input.previousHash,
+			})
+		: false
+	if (currentMatches) return 'current'
+	if (previousMatches) return 'previous'
+	return null
+}
+
 function hmacHashName(algorithm: WebhookHmacAlgorithm) {
 	switch (algorithm) {
 		case 'hmac-sha256':

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -91,6 +91,7 @@ async function retirePreviousWebhookUrlIfConfirmed(input: {
 	endpoint: {
 		id: string
 		userId: string
+		urlSecretHash: string
 		previousUrlSecretHash: string | null
 	}
 	secretMatch: 'current' | 'previous'
@@ -105,6 +106,7 @@ async function retirePreviousWebhookUrlIfConfirmed(input: {
 		db: input.env.APP_DB,
 		userId: input.endpoint.userId,
 		endpointId: input.endpoint.id,
+		urlSecretHash: input.endpoint.urlSecretHash,
 	})
 }
 

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -15,9 +15,9 @@ import {
 	buildWebhookTimestampBodyPayload,
 	isWebhookTimestampWithinTolerance,
 	parseWebhookReplayTimestamp,
+	matchWebhookIngressUrlSecret,
 	providedWebhookHmacValues,
 	verifyWebhookHmacSignature,
-	webhookUrlSecretMatches,
 } from './crypto.ts'
 import {
 	dispatchWebhookInvocation,
@@ -42,8 +42,12 @@ import {
 	readWebhookCallerIdempotencyKey,
 	resolveWebhookParamsModeFirstArg,
 } from './params.ts'
-import { getWebhookEndpointByKey } from './repo.ts'
 import {
+	clearWebhookEndpointPreviousUrlSecret,
+	getWebhookEndpointByKey,
+} from './repo.ts'
+import {
+	isWebhookPreviousUrlLive,
 	webhookDefaultReplayToleranceSeconds,
 	webhookIdempotencyKeyHeader,
 	webhookMaxPayloadBytes,
@@ -306,14 +310,25 @@ export async function handleWebhookIngressRequest(
 		return notFoundResponse()
 	}
 
-	const secretMatches = await webhookUrlSecretMatches({
+	const secretMatch = await matchWebhookIngressUrlSecret({
 		candidate: route.urlSecret,
-		storedHash: endpoint.urlSecretHash,
+		currentHash: endpoint.urlSecretHash,
+		previousHash: endpoint.previousUrlSecretHash,
 	})
+	const previousLive = isWebhookPreviousUrlLive(endpoint, receivedAt)
 	// Wrong secret: no delivery row (avoids log-flush DoS) and no rate-limit
 	// side channel that would distinguish minted names from unknown ones.
-	if (!secretMatches) {
+	// An expired previous hash is treated as unknown.
+	if (secretMatch === null || (secretMatch === 'previous' && !previousLive)) {
 		return notFoundResponse()
+	}
+	// First accepted POST on the new URL retires the previous secret early.
+	if (secretMatch === 'current' && endpoint.previousUrlSecretHash) {
+		await clearWebhookEndpointPreviousUrlSecret({
+			db: env.APP_DB,
+			userId: endpoint.userId,
+			endpointId: endpoint.id,
+		})
 	}
 
 	const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })

--- a/packages/worker/src/webhooks/http.ts
+++ b/packages/worker/src/webhooks/http.ts
@@ -85,6 +85,29 @@ export function isWebhookIngressRequest(pathname: string) {
 	return parseWebhookIngressPath(pathname) !== null
 }
 
+/** Retire rotate-overlap only after the new URL is accepted for dispatch. */
+async function retirePreviousWebhookUrlIfConfirmed(input: {
+	env: Env
+	endpoint: {
+		id: string
+		userId: string
+		previousUrlSecretHash: string | null
+	}
+	secretMatch: 'current' | 'previous'
+}) {
+	if (
+		input.secretMatch !== 'current' ||
+		!input.endpoint.previousUrlSecretHash
+	) {
+		return
+	}
+	await clearWebhookEndpointPreviousUrlSecret({
+		db: input.env.APP_DB,
+		userId: input.endpoint.userId,
+		endpointId: input.endpoint.id,
+	})
+}
+
 function notFoundResponse() {
 	return jsonResponse(
 		{
@@ -321,14 +344,6 @@ export async function handleWebhookIngressRequest(
 	// An expired previous hash is treated as unknown.
 	if (secretMatch === null || (secretMatch === 'previous' && !previousLive)) {
 		return notFoundResponse()
-	}
-	// First accepted POST on the new URL retires the previous secret early.
-	if (secretMatch === 'current' && endpoint.previousUrlSecretHash) {
-		await clearWebhookEndpointPreviousUrlSecret({
-			db: env.APP_DB,
-			userId: endpoint.userId,
-			endpointId: endpoint.id,
-		})
 	}
 
 	const baseUrl = getAppBaseUrl({ env, requestUrl: request.url })
@@ -707,10 +722,20 @@ export async function handleWebhookIngressRequest(
 			})
 			return dispatchUnavailableResponse()
 		}
+		await retirePreviousWebhookUrlIfConfirmed({
+			env,
+			endpoint,
+			secretMatch,
+		})
 		return jsonResponse({ ok: true }, { status: 202 })
 	}
 
 	try {
+		await retirePreviousWebhookUrlIfConfirmed({
+			env,
+			endpoint,
+			secretMatch,
+		})
 		const response = await runWithTimeout(
 			dispatchWebhookInvocation({
 				env,

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -159,6 +159,8 @@ async function ensureSchema(db: D1Database) {
 				webhook_name TEXT NOT NULL,
 				url_secret_hash TEXT NOT NULL,
 				url_secret_encrypted TEXT,
+				previous_url_secret_hash TEXT,
+				previous_url_secret_expires_at TEXT,
 				enabled INTEGER NOT NULL DEFAULT 1,
 				created_at TEXT NOT NULL,
 				rotated_at TEXT NOT NULL
@@ -173,6 +175,18 @@ async function ensureSchema(db: D1Database) {
 			.run()
 	} catch {
 		// Column already present on newer schemas.
+	}
+	for (const column of [
+		'previous_url_secret_hash',
+		'previous_url_secret_expires_at',
+	]) {
+		try {
+			await db
+				.prepare(`ALTER TABLE webhook_endpoints ADD COLUMN ${column} TEXT`)
+				.run()
+		} catch {
+			// Column already present on newer schemas.
+		}
 	}
 }
 
@@ -204,19 +218,26 @@ async function mintWebhook(input: {
 	urlSecret: string
 	enabled?: boolean
 	id?: string
+	previousUrlSecret?: string
+	previousExpiresAt?: string
 }) {
 	const now = '2026-07-24T00:00:00.000Z'
 	await env.APP_DB.prepare(
 		`INSERT INTO webhook_endpoints (
 			id, user_id, package_id, webhook_name, url_secret_hash,
+			previous_url_secret_hash, previous_url_secret_expires_at,
 			enabled, created_at, rotated_at
-		) VALUES (?, ?, 'pkg-1', ?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, 'pkg-1', ?, ?, ?, ?, ?, ?, ?)`,
 	)
 		.bind(
 			input.id ?? crypto.randomUUID(),
 			input.userId,
 			input.webhookName,
 			await hashWebhookUrlSecret(input.urlSecret),
+			input.previousUrlSecret
+				? await hashWebhookUrlSecret(input.previousUrlSecret)
+				: null,
+			input.previousExpiresAt ?? null,
 			input.enabled === false ? 0 : 1,
 			now,
 			now,
@@ -1262,4 +1283,85 @@ test('first-party trusted webhooks accept Idempotency-Key, params mode, and a hi
 	expect(vendorCall.request.params.request.json).toEqual({
 		ref: 'refs/heads/main',
 	})
+})
+
+test('rotate overlap accepts the previous URL until the new URL is used or the grace expires', async () => {
+	silenceExpectedConsoleWarns(['activation-run-record-failed'])
+	await ensureSchema(env.APP_DB)
+	await env.APP_DB.prepare(`DELETE FROM webhook_endpoints`).run()
+	await env.APP_DB.prepare(`DELETE FROM saved_packages`).run()
+	await env.APP_DB.prepare(`DELETE FROM users`).run()
+
+	const userId = await seedOwner()
+	await clearRunRecords({ env, userId })
+	const previousSecret = 'previous-url-secret'
+	const currentSecret = 'current-url-secret'
+	await mintWebhook({
+		userId,
+		webhookName: 'overlap',
+		urlSecret: currentSecret,
+		previousUrlSecret: previousSecret,
+		previousExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+		id: 'mint-overlap',
+	})
+	declareWebhook({ name: 'overlap' })
+	mocks.enqueueWebhookDispatch.mockReset()
+	mocks.enqueueWebhookDispatch.mockResolvedValue(undefined)
+
+	const previousDuringGrace = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'overlap',
+		urlSecret: previousSecret,
+	})
+	expect(previousDuringGrace.status).toBe(202)
+	const stillOverlapping = await env.APP_DB.prepare(
+		`SELECT previous_url_secret_hash FROM webhook_endpoints WHERE id = 'mint-overlap'`,
+	).first<{ previous_url_secret_hash: string | null }>()
+	expect(stillOverlapping?.previous_url_secret_hash).toBeTruthy()
+
+	const confirmedOnNew = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'overlap',
+		urlSecret: currentSecret,
+	})
+	expect(confirmedOnNew.status).toBe(202)
+	const retired = await env.APP_DB.prepare(
+		`SELECT previous_url_secret_hash, previous_url_secret_expires_at
+		FROM webhook_endpoints WHERE id = 'mint-overlap'`,
+	).first<{
+		previous_url_secret_hash: string | null
+		previous_url_secret_expires_at: string | null
+	}>()
+	expect(retired?.previous_url_secret_hash).toBeNull()
+	expect(retired?.previous_url_secret_expires_at).toBeNull()
+
+	const previousAfterConfirm = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'overlap',
+		urlSecret: previousSecret,
+	})
+	expect(previousAfterConfirm.status).toBe(404)
+
+	await env.APP_DB.prepare(`DELETE FROM webhook_endpoints`).run()
+	await mintWebhook({
+		userId,
+		webhookName: 'expired',
+		urlSecret: currentSecret,
+		previousUrlSecret: previousSecret,
+		previousExpiresAt: '2026-07-23T00:00:00.000Z',
+		id: 'mint-expired',
+	})
+	declareWebhook({ name: 'expired' })
+	const previousAfterExpiry = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'expired',
+		urlSecret: previousSecret,
+	})
+	expect(previousAfterExpiry.status).toBe(404)
+	const currentAfterExpiry = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'expired',
+		urlSecret: currentSecret,
+	})
+	expect(currentAfterExpiry.status).toBe(202)
 })

--- a/packages/worker/src/webhooks/http.workers.test.ts
+++ b/packages/worker/src/webhooks/http.workers.test.ts
@@ -1319,10 +1319,48 @@ test('rotate overlap accepts the previous URL until the new URL is used or the g
 	).first<{ previous_url_secret_hash: string | null }>()
 	expect(stillOverlapping?.previous_url_secret_hash).toBeTruthy()
 
+	declareWebhook({
+		name: 'overlap',
+		verification: {
+			type: 'hmac-sha256',
+			header: 'x-hub-signature-256',
+			secretName: 'githubWebhookSecret',
+			encoding: 'hex',
+			prefix: 'sha256=',
+		},
+	})
+	mocks.resolveSecret.mockResolvedValue({
+		found: true,
+		value: 'hmac-shared-secret',
+		scope: 'user',
+		allowedHosts: [],
+		allowedPackages: [],
+	})
+	const rejectedOnNew = await postWebhook({
+		packageKodyId: 'sentry-bridge',
+		webhookName: 'overlap',
+		urlSecret: currentSecret,
+	})
+	expect(rejectedOnNew.status).toBe(401)
+	const stillOverlappingAfterReject = await env.APP_DB.prepare(
+		`SELECT previous_url_secret_hash FROM webhook_endpoints WHERE id = 'mint-overlap'`,
+	).first<{ previous_url_secret_hash: string | null }>()
+	expect(stillOverlappingAfterReject?.previous_url_secret_hash).toBeTruthy()
+
+	const confirmBody = JSON.stringify({ event: 'push' })
+	const confirmSignature = await computeWebhookHmacSignature({
+		algorithm: 'hmac-sha256',
+		secret: 'hmac-shared-secret',
+		body: encodeBody(confirmBody),
+		encoding: 'hex',
+		prefix: 'sha256=',
+	})
 	const confirmedOnNew = await postWebhook({
 		packageKodyId: 'sentry-bridge',
 		webhookName: 'overlap',
 		urlSecret: currentSecret,
+		body: confirmBody,
+		headers: { 'x-hub-signature-256': confirmSignature },
 	})
 	expect(confirmedOnNew.status).toBe(202)
 	const retired = await env.APP_DB.prepare(

--- a/packages/worker/src/webhooks/repo.ts
+++ b/packages/worker/src/webhooks/repo.ts
@@ -1,5 +1,8 @@
 import { WebhookEndpointIdRaceError } from './errors.ts'
-import { type WebhookEndpointRecord } from './types.ts'
+import {
+	type WebhookEndpointRecord,
+	webhookUrlRotationGraceExpiresAt,
+} from './types.ts'
 
 type WebhookEndpointRow = {
 	id: string
@@ -8,6 +11,8 @@ type WebhookEndpointRow = {
 	webhook_name: string
 	url_secret_hash: string
 	url_secret_encrypted?: string | null
+	previous_url_secret_hash?: string | null
+	previous_url_secret_expires_at?: string | null
 	enabled: number
 	created_at: string
 	rotated_at: string
@@ -21,6 +26,8 @@ function mapEndpointRow(row: WebhookEndpointRow): WebhookEndpointRecord {
 		webhookName: row.webhook_name,
 		urlSecretHash: row.url_secret_hash,
 		urlSecretEncrypted: row.url_secret_encrypted ?? null,
+		previousUrlSecretHash: row.previous_url_secret_hash ?? null,
+		previousUrlSecretExpiresAt: row.previous_url_secret_expires_at ?? null,
 		enabled: row.enabled === 1,
 		createdAt: row.created_at,
 		rotatedAt: row.rotated_at,
@@ -34,6 +41,9 @@ function mapEndpointRow(row: WebhookEndpointRow): WebhookEndpointRecord {
  *
  * When `updateEnabledOnConflict` is true (mint/activate), updates also set
  * `enabled`. Rotate passes false so disable state sticks.
+ *
+ * On update, the outgoing hash becomes the previous secret for the rotate
+ * overlap window (`previousExpiresAt`, default 24h from `now`).
  */
 export async function upsertWebhookEndpointSecret(input: {
 	db: D1Database
@@ -46,6 +56,7 @@ export async function upsertWebhookEndpointSecret(input: {
 	enabled?: boolean
 	updateEnabledOnConflict?: boolean
 	now?: string
+	previousExpiresAt?: string
 }): Promise<WebhookEndpointRecord> {
 	const now = input.now ?? new Date().toISOString()
 	const enabled = input.enabled === false ? 0 : 1
@@ -59,14 +70,22 @@ export async function upsertWebhookEndpointSecret(input: {
 		if (existing.id !== input.id) {
 			throw new WebhookEndpointIdRaceError(existing.id)
 		}
+		const previousExpiresAt =
+			input.previousExpiresAt ?? webhookUrlRotationGraceExpiresAt(now)
 		const result = input.updateEnabledOnConflict
 			? await input.db
 					.prepare(
 						`UPDATE webhook_endpoints
-						SET url_secret_hash = ?, url_secret_encrypted = ?, rotated_at = ?, enabled = ?
+						SET previous_url_secret_hash = url_secret_hash,
+							previous_url_secret_expires_at = ?,
+							url_secret_hash = ?,
+							url_secret_encrypted = ?,
+							rotated_at = ?,
+							enabled = ?
 						WHERE user_id = ? AND id = ?`,
 					)
 					.bind(
+						previousExpiresAt,
 						input.urlSecretHash,
 						input.urlSecretEncrypted,
 						now,
@@ -78,10 +97,15 @@ export async function upsertWebhookEndpointSecret(input: {
 			: await input.db
 					.prepare(
 						`UPDATE webhook_endpoints
-						SET url_secret_hash = ?, url_secret_encrypted = ?, rotated_at = ?
+						SET previous_url_secret_hash = url_secret_hash,
+							previous_url_secret_expires_at = ?,
+							url_secret_hash = ?,
+							url_secret_encrypted = ?,
+							rotated_at = ?
 						WHERE user_id = ? AND id = ?`,
 					)
 					.bind(
+						previousExpiresAt,
 						input.urlSecretHash,
 						input.urlSecretEncrypted,
 						now,
@@ -203,4 +227,21 @@ export async function setWebhookEndpointEnabled(input: {
 		packageId: input.packageId,
 		webhookName: input.webhookName,
 	})
+}
+
+/** Drop the rotate-overlap previous secret (confirmed on the new URL, or expired). */
+export async function clearWebhookEndpointPreviousUrlSecret(input: {
+	db: D1Database
+	userId: string
+	endpointId: string
+}) {
+	await input.db
+		.prepare(
+			`UPDATE webhook_endpoints
+			SET previous_url_secret_hash = NULL,
+				previous_url_secret_expires_at = NULL
+			WHERE user_id = ? AND id = ?`,
+		)
+		.bind(input.userId, input.endpointId)
+		.run()
 }

--- a/packages/worker/src/webhooks/repo.ts
+++ b/packages/worker/src/webhooks/repo.ts
@@ -234,14 +234,15 @@ export async function clearWebhookEndpointPreviousUrlSecret(input: {
 	db: D1Database
 	userId: string
 	endpointId: string
+	urlSecretHash: string
 }) {
 	await input.db
 		.prepare(
 			`UPDATE webhook_endpoints
 			SET previous_url_secret_hash = NULL,
 				previous_url_secret_expires_at = NULL
-			WHERE user_id = ? AND id = ?`,
+			WHERE user_id = ? AND id = ? AND url_secret_hash = ?`,
 		)
-		.bind(input.userId, input.endpointId)
+		.bind(input.userId, input.endpointId, input.urlSecretHash)
 		.run()
 }

--- a/packages/worker/src/webhooks/service.node.test.ts
+++ b/packages/worker/src/webhooks/service.node.test.ts
@@ -295,6 +295,105 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	expect(reminted).not.toHaveProperty('urlSecret')
 })
 
+test('clearing rotate overlap ignores a stale current-hash snapshot', async () => {
+	const userId = await createStableUserIdFromEmail('overlap-race@example.com')
+	const { env, db } = createEnv(userId)
+	await db
+		.prepare(
+			`INSERT INTO users (username, email, password_hash, stable_user_id)
+			VALUES ('racer', 'overlap-race@example.com', 'hash', ?)`,
+		)
+		.bind(userId)
+		.run()
+
+	await mintWebhookUrlForUser({
+		env,
+		userId,
+		username: 'racer',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+	await rotateWebhookUrlForUser({
+		env,
+		userId,
+		username: 'racer',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+	const afterFirstRotate = await db
+		.prepare(
+			`SELECT id, url_secret_hash, previous_url_secret_hash
+			FROM webhook_endpoints
+			WHERE user_id = ? AND webhook_name = 'sentry'`,
+		)
+		.bind(userId)
+		.first<{
+			id: string
+			url_secret_hash: string
+			previous_url_secret_hash: string
+		}>()
+	expect(afterFirstRotate?.previous_url_secret_hash).toBeTruthy()
+
+	await rotateWebhookUrlForUser({
+		env,
+		userId,
+		username: 'racer',
+		kodyId: 'sentry-bridge',
+		webhookName: 'sentry',
+	})
+	const afterSecondRotate = await db
+		.prepare(
+			`SELECT url_secret_hash, previous_url_secret_hash
+			FROM webhook_endpoints WHERE id = ?`,
+		)
+		.bind(afterFirstRotate!.id)
+		.first<{
+			url_secret_hash: string
+			previous_url_secret_hash: string
+		}>()
+	expect(afterSecondRotate?.url_secret_hash).not.toBe(
+		afterFirstRotate?.url_secret_hash,
+	)
+	expect(afterSecondRotate?.previous_url_secret_hash).toBe(
+		afterFirstRotate?.url_secret_hash,
+	)
+
+	await webhookRepo.clearWebhookEndpointPreviousUrlSecret({
+		db,
+		userId,
+		endpointId: afterFirstRotate!.id,
+		urlSecretHash: afterFirstRotate!.url_secret_hash,
+	})
+	const ignoredStaleClear = await db
+		.prepare(
+			`SELECT previous_url_secret_hash FROM webhook_endpoints WHERE id = ?`,
+		)
+		.bind(afterFirstRotate!.id)
+		.first<{ previous_url_secret_hash: string | null }>()
+	expect(ignoredStaleClear?.previous_url_secret_hash).toBe(
+		afterSecondRotate?.previous_url_secret_hash,
+	)
+
+	await webhookRepo.clearWebhookEndpointPreviousUrlSecret({
+		db,
+		userId,
+		endpointId: afterFirstRotate!.id,
+		urlSecretHash: afterSecondRotate!.url_secret_hash,
+	})
+	const retired = await db
+		.prepare(
+			`SELECT previous_url_secret_hash, previous_url_secret_expires_at
+			FROM webhook_endpoints WHERE id = ?`,
+		)
+		.bind(afterFirstRotate!.id)
+		.first<{
+			previous_url_secret_hash: string | null
+			previous_url_secret_expires_at: string | null
+		}>()
+	expect(retired?.previous_url_secret_hash).toBeNull()
+	expect(retired?.previous_url_secret_expires_at).toBeNull()
+})
+
 test('first mint that loses the id race retries with the persisted endpoint id', async () => {
 	const userId = await createStableUserIdFromEmail('race@example.com')
 	const { env, db } = createEnv(userId)

--- a/packages/worker/src/webhooks/service.node.test.ts
+++ b/packages/worker/src/webhooks/service.node.test.ts
@@ -97,6 +97,8 @@ function createEnv(userId: string) {
 			webhook_name TEXT NOT NULL,
 			url_secret_hash TEXT NOT NULL,
 			url_secret_encrypted TEXT,
+			previous_url_secret_hash TEXT,
+			previous_url_secret_expires_at TEXT,
 			enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
 			created_at TEXT NOT NULL,
 			rotated_at TEXT NOT NULL
@@ -219,7 +221,9 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	expect(rotated).not.toHaveProperty('url')
 	const stored = await db
 		.prepare(
-			`SELECT id, url_secret_hash, url_secret_encrypted FROM webhook_endpoints
+			`SELECT id, url_secret_hash, url_secret_encrypted,
+				previous_url_secret_hash, previous_url_secret_expires_at
+			FROM webhook_endpoints
 			WHERE user_id = ? AND package_id = 'pkg-1' AND webhook_name = 'sentry'`,
 		)
 		.bind(userId)
@@ -227,6 +231,8 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 			id: string
 			url_secret_hash: string
 			url_secret_encrypted: string
+			previous_url_secret_hash: string
+			previous_url_secret_expires_at: string
 		}>()
 	expect(stored?.id).toBe(parseWebhookUrlHandle(rotated.handle))
 	expect(stored?.url_secret_encrypted).toBeTruthy()
@@ -241,6 +247,23 @@ test('mint/list/rotate/enable/disable webhooks are package-centered and user-sco
 	expect(rotatedSecret).not.toBe(
 		revealed.url.slice(revealed.url.lastIndexOf('/') + 1),
 	)
+	const previousSecret = revealed.url.slice(revealed.url.lastIndexOf('/') + 1)
+	expect(stored?.previous_url_secret_hash).toBe(
+		await hashWebhookUrlSecret(previousSecret),
+	)
+	expect(stored?.previous_url_secret_expires_at).toEqual(expect.any(String))
+	const listedAfterRotate = await listWebhooksForUser({
+		env,
+		baseUrl: 'https://heykody.dev',
+		userId,
+	})
+	expect(listedAfterRotate[0]?.previousUrlActiveUntil).toBe(
+		stored?.previous_url_secret_expires_at,
+	)
+	const overlapUntil = Date.parse(stored!.previous_url_secret_expires_at)
+	const overlapExpected = Date.now() + 24 * 60 * 60 * 1000
+	expect(overlapUntil).toBeGreaterThan(overlapExpected - 10_000)
+	expect(overlapUntil).toBeLessThan(overlapExpected + 10_000)
 
 	const disabled = await setWebhookEnabledForUser({
 		env,

--- a/packages/worker/src/webhooks/service.ts
+++ b/packages/worker/src/webhooks/service.ts
@@ -39,7 +39,10 @@ import {
 	setWebhookEndpointEnabled,
 	upsertWebhookEndpointSecret,
 } from './repo.ts'
-import { type WebhookEndpointRecord } from './types.ts'
+import {
+	isWebhookPreviousUrlLive,
+	type WebhookEndpointRecord,
+} from './types.ts'
 
 export type ListedWebhook = {
 	packageId: string
@@ -64,6 +67,8 @@ export type ListedWebhook = {
 	urlRecoverable: boolean
 	createdAt: string | null
 	rotatedAt: string | null
+	/** ISO timestamp while the previous URL still accepts deliveries. */
+	previousUrlActiveUntil: string | null
 }
 
 export type MintedWebhookHandle = {
@@ -75,6 +80,7 @@ export type MintedWebhookHandle = {
 	enabled: boolean
 	createdAt: string
 	rotatedAt: string
+	previousUrlActiveUntil: string | null
 }
 
 export type {
@@ -211,6 +217,10 @@ export async function listWebhooksForUser(input: {
 				urlRecoverable: mint?.urlSecretEncrypted != null,
 				createdAt: mint?.createdAt ?? null,
 				rotatedAt: mint?.rotatedAt ?? null,
+				previousUrlActiveUntil:
+					mint && isWebhookPreviousUrlLive(mint)
+						? mint.previousUrlSecretExpiresAt
+						: null,
 			})
 		}
 	}
@@ -314,6 +324,9 @@ export async function mintWebhookUrlForUser(input: {
 		enabled: stored.enabled,
 		createdAt: stored.createdAt,
 		rotatedAt: stored.rotatedAt,
+		previousUrlActiveUntil: isWebhookPreviousUrlLive(stored)
+			? stored.previousUrlSecretExpiresAt
+			: null,
 	}
 }
 

--- a/packages/worker/src/webhooks/types.ts
+++ b/packages/worker/src/webhooks/types.ts
@@ -45,9 +45,38 @@ export type WebhookEndpointRecord = {
 	webhookName: string
 	urlSecretHash: string
 	urlSecretEncrypted: string | null
+	previousUrlSecretHash: string | null
+	previousUrlSecretExpiresAt: string | null
 	enabled: boolean
 	createdAt: string
 	rotatedAt: string
+}
+
+/**
+ * Rotate overlap fallback. Ack-queue spilled payloads already live for 24h
+ * (`webhookDispatchPayloadTtlSeconds`); GitHub-style provider retries cover
+ * about the same window. The first accepted POST on the new URL retires the
+ * previous secret earlier.
+ */
+export const webhookUrlRotationGraceMs = 24 * 60 * 60 * 1000
+
+export function webhookUrlRotationGraceExpiresAt(now: Date | string) {
+	const nowMs = typeof now === 'string' ? Date.parse(now) : now.getTime()
+	return new Date(nowMs + webhookUrlRotationGraceMs).toISOString()
+}
+
+export function isWebhookPreviousUrlLive(
+	endpoint: {
+		previousUrlSecretHash: string | null
+		previousUrlSecretExpiresAt: string | null
+	},
+	now: Date | string = new Date(),
+) {
+	if (!endpoint.previousUrlSecretHash || !endpoint.previousUrlSecretExpiresAt) {
+		return false
+	}
+	const nowMs = typeof now === 'string' ? Date.parse(now) : now.getTime()
+	return Date.parse(endpoint.previousUrlSecretExpiresAt) > nowMs
 }
 
 export type WebhookDeliveryOutcome = 'delivered' | 'rejected' | 'failed'

--- a/packages/worker/src/webhooks/types.ts
+++ b/packages/worker/src/webhooks/types.ts
@@ -55,8 +55,8 @@ export type WebhookEndpointRecord = {
 /**
  * Rotate overlap fallback. Ack-queue spilled payloads already live for 24h
  * (`webhookDispatchPayloadTtlSeconds`); GitHub-style provider retries cover
- * about the same window. The first accepted POST on the new URL retires the
- * previous secret earlier.
+ * about the same window. The first POST on the new URL that is accepted for
+ * dispatch retires the previous secret earlier.
  */
 export const webhookUrlRotationGraceMs = 24 * 60 * 60 * 1000
 

--- a/packages/worker/universal/loader-data.ts
+++ b/packages/worker/universal/loader-data.ts
@@ -1228,6 +1228,8 @@ export type PackageWebhookListItem = {
 	urlRecoverable: boolean
 	createdAt: string | null
 	rotatedAt: string | null
+	/** ISO timestamp while the previous URL still accepts deliveries after rotate. */
+	previousUrlActiveUntil: string | null
 }
 
 /** `/account/webhooks.json`: every declared webhook across the owner's packages. */

--- a/tools/migration-ledger.json
+++ b/tools/migration-ledger.json
@@ -247,6 +247,10 @@
 		{
 			"filename": "0061-community-forks-package-delete-cascade.sql",
 			"sha256": "d3701812617f097a85c49f45899b1290c0d5bdc697d6db66408333981ff321ae"
+		},
+		{
+			"filename": "0062-webhook-url-rotation-grace.sql",
+			"sha256": "7b399500a63898a5af7985b1131e6a8e760af77d5f7abdc709ded16402bacbf0"
 		}
 	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Give webhook URL rotation a short dual-live overlap so providers can finish switching without dropping in-flight deliveries.

## Why

@ThorCommerce’s product feedback: rotation needs a brief window where the old and new endpoints both work, then cut the old one off once deliveries on the new URL are confirmed. Rotate previously overwrote `url_secret_hash` immediately, so the old URL 404’d before the provider could be updated.

## Summary

- Rotate copies the outgoing secret hash to `previous_url_secret_hash` with a 24h `previous_url_secret_expires_at`.
- Ingress accepts **current or unexpired previous** URL secrets. The first accepted POST on the **new** URL retires the previous secret immediately.
- If the new URL never receives a delivery, the previous secret expires after 24 hours.
- Package settings shows a quiet “Previous URL active until …” row during overlap (enabled cards only).
- MCP `webhookUrlRotate` / `webhookList` expose `previous_url_active_until`. Agents and docs describe the overlap (not immediate cutover).
- Account export redacts `previous_url_secret_hash`. The previous ciphertext is never stored; reveal/apply always return the current URL.
- Overlap clear requires the authenticated current `url_secret_hash`, so a concurrent rotate cannot drop the newer previous secret.

## Grace default (for Pam)

**24 hours**, with early retirement on the first accepted POST to the new URL.

**Why 24h, not 1h:** inbound webhook ack-queue spilled payloads already live for 24h (`webhookDispatchPayloadTtlSeconds`), and GitHub-style provider retries cover about the same window. Confirmation on the new URL makes the typical overlap much shorter than the fallback.

## Exact UX copy (for Pam)

**Settings intro (added sentence):**
> Rotate keeps the previous URL live for a short overlap so providers can finish switching.

**Rotate confirm (double-check):**
> Rotating mints a new URL. The previous URL stays active for 24 hours, or until a delivery arrives on the new one.

**Rotate success toast:**
> Webhook URL rotated. The previous URL stays active until the new one receives a delivery, or for 24 hours.

**Overlap status (metadata row, only while live and enabled):**
> Previous URL — active until {formatted timestamp}

## Testing

- `vitest` node-unit: webhook service, crypto match helper, package/account webhook handlers, settings card overlap (hidden when disabled), stale-hash overlap clear, MCP rotate/list field, export redaction.
- `vitest` workers-unit: ingress dual-accept during grace, HMAC reject does not retire, retire after new-URL delivery, 404 after expiry.
- Pre-push hook: full `test:node` (3151) + `test:workers` (347) passed.
- Typecheck + `migrations:check` passed on commit.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `06665e70` · **Head:** `1214645f`

**Classification:** extends — rotate overlap changes inbound webhook URL acceptance and D1 mint state. No new primitive.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `webhooks` | assistant | extends — dual-accept previous URL during rotate overlap, retire only after accepted dispatch on the new URL |
| `d1-app-db` | storage | extends — `previous_url_secret_hash` and `previous_url_secret_expires_at` |
| `app-ui` | surfaces | composes — settings card overlap row (enabled only) and `previousUrlActiveUntil` |
| `account-export` | assistant | extends — redact `previous_url_secret_hash` (via `data-targets.ts`) |

### Change flow

Rotate keeps the previous URL secret hash live on the same endpoint row. Ingress accepts it until the new URL is accepted for dispatch or the 24h grace ends. A concurrent rotate cannot drop the newer previous secret.

```mermaid
sequenceDiagram
	actor Owner
	actor Provider
	participant appUi as app-ui
	participant webhooks as webhooks
	participant d1AppDb as d1-app-db
	Owner->>appUi: Rotate URL
	appUi->>webhooks: POST rotate intent
	webhooks->>d1AppDb: copy current hash to previous_url_secret_hash and set 24h expires_at
	appUi-->>Owner: Previous URL active until timestamp
	Provider->>webhooks: POST previous URL
	webhooks->>d1AppDb: match previous hash while live
	webhooks-->>Provider: accept delivery
	Provider->>webhooks: POST new URL
	webhooks->>d1AppDb: match current hash
	Note over webhooks: HMAC, rate-limit, payload, and enqueue rejects keep previous live
	webhooks->>d1AppDb: clear previous only when current hash still matches
	webhooks-->>Provider: accept delivery
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Rotate | Overwrites `url_secret_hash` | Current hash becomes previous, new hash is current |
| Old URL | Immediate 404 | Accepted until new-URL dispatch is accepted or 24h |
| Settings | “stops working immediately” | “Previous URL active until …” on enabled cards |
| Export | Redacts current hash/ciphertext | Also redacts `previous_url_secret_hash` |

### Invariants

Per-user isolation is unchanged: previous hashes live on the same `webhook_endpoints` row and are still scoped by `user_id`. Wrong secrets still 404 with no delivery row.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2028ac22-9fc9-453e-bb33-4c5d61cde197?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2028ac22-9fc9-453e-bb33-4c5d61cde197&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rotating a webhook URL keeps the previous URL active for up to 24 hours, or until the new URL receives an accepted delivery.
  - Webhook settings show when the previous URL will stop working; this information is hidden for disabled webhooks.
  - Webhook listings and integrations expose the previous URL’s active-until time.

- **Documentation**
  - Updated webhook guides and architecture documentation to explain the rotation grace period and management workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->