### PR TITLE
Waiting: discrete first-use cards and Join Discord

### DIFF
--- a/.agents/skills/control-kody/references/features/waiting.md
+++ b/.agents/skills/control-kody/references/features/waiting.md
@@ -22,7 +22,10 @@ node tools/control-kody.ts preview -- \
 
 ## Gotchas
 
-- Empty is the common seed state. Create the pending grant or locked package
-  through the same JSON APIs the UI uses before asserting copy.
+- Seed accounts usually still show first-use setup cards (search, memory,
+  execute, package, job, integration, secret, Discord) until those gates clear.
+  Empty is only after those plus reconnects and locks are gone. Create the
+  pending grant or locked package through the same JSON APIs the UI uses before
+  asserting copy.
 - The error-rate card counts **open** Activity errors in the last 7 days.
   Ignored and resolved runs do not keep it on Waiting.

--- a/docs/contributing/architecture/index.md
+++ b/docs/contributing/architecture/index.md
@@ -60,7 +60,9 @@ wrote during that fetch) so the next cron can skip the synthetic.
   cache for anonymous marketing HTML.
 - [Onboarding process](./onboarding.md): wizard steps, derived checklist, and
   the optional first-win guide (aligned by
-  `packages/worker/universal/onboarding-process.ts`).
+  `packages/worker/universal/onboarding-process.ts`). Waiting first-use cards
+  (search, memory, execute, package, job, integration, secret, Discord) are not
+  wizard steps; see [Waiting](../../use/waiting.md).
 - [Authentication](./authentication.md): app session auth and OAuth-protected
   MCP auth.
 - [Platform accounts](./platform-accounts.md): operator-provisioned platform

--- a/docs/contributing/architecture/onboarding.md
+++ b/docs/contributing/architecture/onboarding.md
@@ -48,6 +48,15 @@ not `users.mcp_client_name` (first-touch) and not `/account/mcp-oauth-clients`
 `onboarding_first_win` and `search({ entity: "first_win:guide" })` serves the
 guide.
 
+Waiting (`/account/waiting` and `waitingSummary`) does not mirror the coarse
+checklist. It keeps wizard-resume cards for `connect-agent` and
+`connect-second-agent` unless the checklist is dismissed or complete, and it
+shows discrete first-use cards for search, memory, execute, package, job,
+integration, secret, and official Discord membership. Those first-use items are
+not wizard steps and are not checklist ids. Coarse `give-access` /
+`install-starter` checklist ids do not emit Waiting cards because they duplicate
+the broken-out first-use items. See [Waiting](../../use/waiting.md).
+
 ## Alignment check
 
 `packages/worker/universal/onboarding-process.node.test.ts` (part of

--- a/docs/contributing/architecture/primitives.yaml
+++ b/docs/contributing/architecture/primitives.yaml
@@ -145,6 +145,7 @@ primitives:
       - packages/worker/src/app/kit-subscriber-sync.ts
       - packages/worker/src/app/handlers/account-connections.ts
       - packages/worker/src/discord/guild-role.ts
+      - packages/worker/src/discord/guild-membership.ts
       - packages/worker/src/app/oauth-
       - packages/worker/src/app/handlers/verify
       - packages/worker/src/app/handlers/pending-verification.ts

--- a/docs/use/waiting.md
+++ b/docs/use/waiting.md
@@ -25,7 +25,26 @@ Typical items:
 - a plan resource at its cap
 - an elevated **open** error rate (one card that points at Activity; ignored and
   resolved runs do not keep it around)
-- unfinished onboarding steps, unless you dismissed the checklist
+- unfinished wizard resume cards (`connect-agent`, `connect-second-agent`)
+  unless you dismissed the checklist on Get started
+- discrete first-use setup cards until each gate clears: first search, first
+  memory, first execute, first saved package, first job, first connected
+  integration grant, first user-scope secret, and official Kody Discord
+  membership (Connect Discord on `/discord`)
+
+The `/onboarding` wizard stays Steps 1–3 plus the derived checklist
+(`verify-email`, `connect-agent`, `give-access`, `connect-second-agent`,
+`install-starter`). Waiting does **not** add Discord or the broken-out first-use
+list as wizard steps. Coarse checklist cards for `give-access` and
+`install-starter` do not appear here — they would duplicate first search /
+memory / execute / package.
+
+First-use cards are independent of checklist dismiss. A probe that errors is
+treated as unknown: Waiting neither invents that card nor claims the gate
+cleared. Discord membership is official-guild membership as Kody can see it
+(Discord social login plus a live member read). No Discord connection shows the
+card. A linked account whose membership cannot be checked (bot unset, API blip)
+fails open and hides the card, because login already attempted `guilds.join`.
 
 Vendor outages, operator work, and other people's queues do not appear here.
 Session-scoped secret approvals stay on the session that requested them. Missing

--- a/packages/worker/client/routes/account-waiting.tsx
+++ b/packages/worker/client/routes/account-waiting.tsx
@@ -101,7 +101,7 @@ function renderWaitingBody(items: Array<WaitingItem>) {
 		return (
 			<AccountManagementPanel
 				title="Nothing is waiting on you"
-				description="Onboarding is done, connections are healthy, and no publishes or grants need a click."
+				description="Connections are healthy, first-use setup is done, and no publishes or grants need a click."
 			>
 				<p mix={css({ margin: 0, color: colors.textMuted })}>
 					<a href={routes.accountActivity.href()}>Activity</a> is run history.{' '}

--- a/packages/worker/client/routes/account-waiting.tsx
+++ b/packages/worker/client/routes/account-waiting.tsx
@@ -101,7 +101,7 @@ function renderWaitingBody(items: Array<WaitingItem>) {
 		return (
 			<AccountManagementPanel
 				title="Nothing is waiting on you"
-				description="Connections are healthy, first-use setup is done, and no publishes or grants need a click."
+				description="Connections are healthy, and no publishes or grants need a click."
 			>
 				<p mix={css({ margin: 0, color: colors.textMuted })}>
 					<a href={routes.accountActivity.href()}>Activity</a> is run history.{' '}

--- a/packages/worker/src/discord/guild-membership.ts
+++ b/packages/worker/src/discord/guild-membership.ts
@@ -1,0 +1,144 @@
+/**
+ * Official Kody Discord membership as Waiting can see it: a linked Discord
+ * social-login snowflake plus a live guild member GET. Role writes stay in
+ * `guild-role.ts` so this probe does not pull that graph into MCP Waiting.
+ */
+
+export const DISCORD_MEMBERSHIP_REQUEST_TIMEOUT_MS = 8_000
+
+export type DiscordMembershipEnv = {
+	DISCORD_BOT_TOKEN?: string | undefined
+	DISCORD_GUILD_ID?: string | undefined
+}
+
+export type DiscordGuildMembershipSkipReason =
+	| 'not-configured'
+	| 'invalid-user-id'
+
+export type DiscordGuildMembershipResult =
+	| { status: 'member' }
+	| { status: 'not-in-guild' }
+	| { status: 'skipped'; reason: DiscordGuildMembershipSkipReason }
+	| { status: 'error'; message: string }
+
+const discordApiBaseUrl = 'https://discord.com/api/v10'
+const discordSnowflakePattern = /^\d{5,20}$/
+
+function isDiscordSnowflake(value: string) {
+	return discordSnowflakePattern.test(value)
+}
+
+function readOfficialGuildBotConfig(env: DiscordMembershipEnv) {
+	const botToken = env.DISCORD_BOT_TOKEN?.trim()
+	const guildId = env.DISCORD_GUILD_ID?.trim()
+	if (!botToken || !guildId || !isDiscordSnowflake(guildId)) return null
+	return { botToken, guildId }
+}
+
+function guildMemberUrl(guildId: string, discordUserId: string) {
+	return `${discordApiBaseUrl}/guilds/${guildId}/members/${discordUserId}`
+}
+
+async function readDiscordConnectionUserId(db: D1Database, userId: number) {
+	const row = await db
+		.prepare(
+			`SELECT provider_id FROM oauth_connections
+			 WHERE user_id = ? AND provider_name = 'discord'`,
+		)
+		.bind(userId)
+		.first<{ provider_id: string }>()
+	const providerId = row?.provider_id?.trim()
+	return providerId && providerId.length > 0 ? providerId : null
+}
+
+/**
+ * Read whether the Discord user is currently in the official guild. Failures
+ * are classified and never thrown. Callers treat `skipped` / `error` as
+ * unknown so a bot or network blip cannot invent a Waiting card.
+ */
+export async function readOfficialDiscordGuildMembership(input: {
+	env: DiscordMembershipEnv
+	discordUserId: string
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+}): Promise<DiscordGuildMembershipResult> {
+	if (!isDiscordSnowflake(input.discordUserId)) {
+		return { status: 'skipped', reason: 'invalid-user-id' }
+	}
+	const config = readOfficialGuildBotConfig(input.env)
+	if (!config) {
+		return { status: 'skipped', reason: 'not-configured' }
+	}
+
+	const fetchImpl = input.fetchImpl ?? fetch
+	const timeoutMs = input.timeoutMs ?? DISCORD_MEMBERSHIP_REQUEST_TIMEOUT_MS
+	try {
+		const response = await fetchImpl(
+			guildMemberUrl(config.guildId, input.discordUserId),
+			{
+				method: 'GET',
+				headers: {
+					Authorization: `Bot ${config.botToken}`,
+					'User-Agent': 'kody',
+				},
+				signal: AbortSignal.timeout(timeoutMs),
+			},
+		)
+		if (response.ok) {
+			return { status: 'member' }
+		}
+		if (response.status === 404) {
+			return { status: 'not-in-guild' }
+		}
+		return {
+			status: 'error',
+			message: `Discord guild membership lookup failed (${response.status}).`,
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		return { status: 'error', message }
+	}
+}
+
+/**
+ * Official-guild membership as Kody can see it: Discord social login plus a
+ * live member read. `false` means we know they have not linked Discord (or
+ * the bot confirmed they are not in the guild). `null` is unknown — bot
+ * unset, API blip, or a storage error — so Waiting must not invent a card.
+ */
+export async function readOfficialDiscordMembershipForUser(input: {
+	env: DiscordMembershipEnv & { APP_DB: D1Database }
+	userId: number
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+}): Promise<boolean | null> {
+	try {
+		const discordUserId = await readDiscordConnectionUserId(
+			input.env.APP_DB,
+			input.userId,
+		)
+		if (!discordUserId) return false
+		const membership = await readOfficialDiscordGuildMembership({
+			env: input.env,
+			discordUserId,
+			fetchImpl: input.fetchImpl,
+			timeoutMs: input.timeoutMs,
+		})
+		switch (membership.status) {
+			case 'member':
+				return true
+			case 'not-in-guild':
+				return false
+			case 'skipped':
+			case 'error':
+				return null
+			default: {
+				const exhaustive: never = membership
+				void exhaustive
+				return null
+			}
+		}
+	} catch {
+		return null
+	}
+}

--- a/packages/worker/src/discord/guild-membership.ts
+++ b/packages/worker/src/discord/guild-membership.ts
@@ -39,16 +39,20 @@ function guildMemberUrl(guildId: string, discordUserId: string) {
 	return `${discordApiBaseUrl}/guilds/${guildId}/members/${discordUserId}`
 }
 
-async function readDiscordConnectionUserId(db: D1Database, userId: number) {
-	const row = await db
+async function readDiscordConnectionUserIds(db: D1Database, userId: number) {
+	const result = await db
 		.prepare(
 			`SELECT provider_id FROM oauth_connections
 			 WHERE user_id = ? AND provider_name = 'discord'`,
 		)
 		.bind(userId)
-		.first<{ provider_id: string }>()
-	const providerId = row?.provider_id?.trim()
-	return providerId && providerId.length > 0 ? providerId : null
+		.all<{ provider_id: string }>()
+	const ids: Array<string> = []
+	for (const row of result.results ?? []) {
+		const providerId = row.provider_id?.trim()
+		if (providerId) ids.push(providerId)
+	}
+	return ids
 }
 
 /**
@@ -102,9 +106,10 @@ export async function readOfficialDiscordGuildMembership(input: {
 
 /**
  * Official-guild membership as Kody can see it: Discord social login plus a
- * live member read. `false` means we know they have not linked Discord (or
- * the bot confirmed they are not in the guild). `null` is unknown — bot
- * unset, API blip, or a storage error — so Waiting must not invent a card.
+ * live member read. A user can have more than one Discord identity. `true`
+ * means any linked identity is in the guild. `false` means none are linked,
+ * or every linked identity is confirmed out. `null` is unknown — bot unset,
+ * API blip, or a storage error — so Waiting must not invent a card.
  */
 export async function readOfficialDiscordMembershipForUser(input: {
 	env: DiscordMembershipEnv & { APP_DB: D1Database }
@@ -113,31 +118,36 @@ export async function readOfficialDiscordMembershipForUser(input: {
 	timeoutMs?: number
 }): Promise<boolean | null> {
 	try {
-		const discordUserId = await readDiscordConnectionUserId(
+		const discordUserIds = await readDiscordConnectionUserIds(
 			input.env.APP_DB,
 			input.userId,
 		)
-		if (!discordUserId) return false
-		const membership = await readOfficialDiscordGuildMembership({
-			env: input.env,
-			discordUserId,
-			fetchImpl: input.fetchImpl,
-			timeoutMs: input.timeoutMs,
-		})
-		switch (membership.status) {
-			case 'member':
-				return true
-			case 'not-in-guild':
-				return false
-			case 'skipped':
-			case 'error':
-				return null
-			default: {
-				const exhaustive: never = membership
-				void exhaustive
-				return null
+		if (discordUserIds.length === 0) return false
+		let sawUnknown = false
+		for (const discordUserId of discordUserIds) {
+			const membership = await readOfficialDiscordGuildMembership({
+				env: input.env,
+				discordUserId,
+				fetchImpl: input.fetchImpl,
+				timeoutMs: input.timeoutMs,
+			})
+			switch (membership.status) {
+				case 'member':
+					return true
+				case 'not-in-guild':
+					break
+				case 'skipped':
+				case 'error':
+					sawUnknown = true
+					break
+				default: {
+					const exhaustive: never = membership
+					void exhaustive
+					sawUnknown = true
+				}
 			}
 		}
+		return sawUnknown ? null : false
 	} catch {
 		return null
 	}

--- a/packages/worker/src/discord/guild-role.node.test.ts
+++ b/packages/worker/src/discord/guild-role.node.test.ts
@@ -288,6 +288,52 @@ test('official guild membership lookup classifies member, absent, and fail-open'
 			},
 		}),
 	).toBeNull()
+
+	const secondDiscordUserId = '555555555555555555'
+	await db
+		.prepare(
+			`INSERT INTO oauth_connections (user_id, provider_name, provider_id)
+			 VALUES (?, 'discord', ?)`,
+		)
+		.bind(11, secondDiscordUserId)
+		.run()
+	const multiCalls: Array<string> = []
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { ...configuredEnv, APP_DB: db },
+			userId: 11,
+			fetchImpl: async (input) => {
+				const url = String(input)
+				multiCalls.push(url)
+				if (url.includes(secondDiscordUserId)) {
+					return jsonResponse(200, { user: { id: secondDiscordUserId } })
+				}
+				return jsonResponse(404)
+			},
+		}),
+	).toBe(true)
+	expect(multiCalls.some((url) => url.includes(discordUserId))).toBe(true)
+	expect(multiCalls.some((url) => url.includes(secondDiscordUserId))).toBe(true)
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { ...configuredEnv, APP_DB: db },
+			userId: 11,
+			fetchImpl: async () => jsonResponse(404),
+		}),
+	).toBe(false)
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { ...configuredEnv, APP_DB: db },
+			userId: 11,
+			fetchImpl: async (input) => {
+				const url = String(input)
+				if (url.includes(secondDiscordUserId)) {
+					return jsonResponse(500)
+				}
+				return jsonResponse(404)
+			},
+		}),
+	).toBeNull()
 })
 
 test('assign and remove call the Discord member-role routes and classify outcomes', async () => {

--- a/packages/worker/src/discord/guild-role.node.test.ts
+++ b/packages/worker/src/discord/guild-role.node.test.ts
@@ -15,6 +15,8 @@ import {
 	maybeRemoveDiscordMemberRole,
 	maybeSyncDiscordGuildRolesForUser,
 	maybeSyncDiscordPlanRoles,
+	readOfficialDiscordGuildMembership,
+	readOfficialDiscordMembershipForUser,
 	removeDiscordMemberRole,
 	summarizeDiscordGuildRoleSync,
 	syncDiscordPlanRoles,
@@ -171,6 +173,121 @@ test('guild join uses the ephemeral access token once and classifies outcomes', 
 		status: 'error',
 		message: 'Discord guild join failed (500).',
 	})
+})
+
+test('official guild membership lookup classifies member, absent, and fail-open', async () => {
+	const calls: Array<{ url: string; method: string; authorization: string }> =
+		[]
+
+	async function fetchImpl(input: RequestInfo | URL, init?: RequestInit) {
+		calls.push({
+			url: String(input),
+			method: init?.method ?? 'GET',
+			authorization: new Headers(init?.headers).get('Authorization') ?? '',
+		})
+		return jsonResponse(200, { user: { id: discordUserId } })
+	}
+
+	expect(
+		await readOfficialDiscordGuildMembership({
+			env: configuredEnv,
+			discordUserId,
+			fetchImpl,
+		}),
+	).toEqual({ status: 'member' })
+	expect(calls).toEqual([
+		{
+			url: memberUrl(),
+			method: 'GET',
+			authorization: 'Bot bot-token-test',
+		},
+	])
+	expect(
+		await readOfficialDiscordGuildMembership({
+			env: configuredEnv,
+			discordUserId,
+			fetchImpl: async () => jsonResponse(404),
+		}),
+	).toEqual({ status: 'not-in-guild' })
+	expect(
+		await readOfficialDiscordGuildMembership({
+			env: {},
+			discordUserId,
+			fetchImpl,
+		}),
+	).toEqual({ status: 'skipped', reason: 'not-configured' })
+	expect(
+		await readOfficialDiscordGuildMembership({
+			env: configuredEnv,
+			discordUserId: 'mock-discord-user-1',
+			fetchImpl,
+		}),
+	).toEqual({ status: 'skipped', reason: 'invalid-user-id' })
+	expect(
+		await readOfficialDiscordGuildMembership({
+			env: configuredEnv,
+			discordUserId,
+			fetchImpl: async () => jsonResponse(500),
+		}),
+	).toEqual({
+		status: 'error',
+		message: 'Discord guild membership lookup failed (500).',
+	})
+
+	const sqlite = new DatabaseSync(':memory:')
+	sqlite.exec(`
+		CREATE TABLE oauth_connections (
+			user_id INTEGER NOT NULL,
+			provider_name TEXT NOT NULL,
+			provider_id TEXT NOT NULL
+		)
+	`)
+	const db = createD1FromSqlite(sqlite)
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { ...configuredEnv, APP_DB: db },
+			userId: 11,
+			fetchImpl,
+		}),
+	).toBe(false)
+
+	await db
+		.prepare(
+			`INSERT INTO oauth_connections (user_id, provider_name, provider_id)
+			 VALUES (?, 'discord', ?)`,
+		)
+		.bind(11, discordUserId)
+		.run()
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { ...configuredEnv, APP_DB: db },
+			userId: 11,
+			fetchImpl,
+		}),
+	).toBe(true)
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { ...configuredEnv, APP_DB: db },
+			userId: 11,
+			fetchImpl: async () => jsonResponse(404),
+		}),
+	).toBe(false)
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { APP_DB: db },
+			userId: 11,
+			fetchImpl,
+		}),
+	).toBeNull()
+	expect(
+		await readOfficialDiscordMembershipForUser({
+			env: { ...configuredEnv, APP_DB: db },
+			userId: 11,
+			fetchImpl: async () => {
+				throw new Error('discord down')
+			},
+		}),
+	).toBeNull()
 })
 
 test('assign and remove call the Discord member-role routes and classify outcomes', async () => {

--- a/packages/worker/src/discord/guild-role.ts
+++ b/packages/worker/src/discord/guild-role.ts
@@ -45,6 +45,16 @@ export type DiscordGuildJoinResult =
 	| { status: 'forbidden' }
 	| { status: 'error'; message: string }
 
+export type DiscordGuildMembershipSkipReason =
+	| 'not-configured'
+	| 'invalid-user-id'
+
+export type DiscordGuildMembershipResult =
+	| { status: 'member' }
+	| { status: 'not-in-guild' }
+	| { status: 'skipped'; reason: DiscordGuildMembershipSkipReason }
+	| { status: 'error'; message: string }
+
 export type DiscordMemberRoleSyncResult =
 	| { status: 'skipped'; reason: DiscordMemberRoleSkipReason }
 	| { status: 'assigned' }
@@ -146,6 +156,98 @@ function memberRoleUrl(guildId: string, discordUserId: string, roleId: string) {
 
 function guildMemberUrl(guildId: string, discordUserId: string) {
 	return `${discordApiBaseUrl}/guilds/${guildId}/members/${discordUserId}`
+}
+
+/**
+ * Read whether the Discord user is currently in the official guild. Failures
+ * are classified and never thrown. Callers treat `skipped` / `error` as
+ * unknown so a bot or network blip cannot invent a Waiting card.
+ */
+export async function readOfficialDiscordGuildMembership(input: {
+	env: DiscordGuildRoleEnv
+	discordUserId: string
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+}): Promise<DiscordGuildMembershipResult> {
+	if (!isDiscordSnowflake(input.discordUserId)) {
+		return { status: 'skipped', reason: 'invalid-user-id' }
+	}
+	const config = getDiscordGuildBotConfig(input.env)
+	if (!config) {
+		return { status: 'skipped', reason: 'not-configured' }
+	}
+
+	const fetchImpl = input.fetchImpl ?? fetch
+	const timeoutMs = input.timeoutMs ?? DISCORD_MEMBER_ROLE_REQUEST_TIMEOUT_MS
+	try {
+		const response = await fetchImpl(
+			guildMemberUrl(config.guildId, input.discordUserId),
+			{
+				method: 'GET',
+				headers: {
+					Authorization: `Bot ${config.botToken}`,
+					'User-Agent': 'kody',
+				},
+				signal: AbortSignal.timeout(timeoutMs),
+			},
+		)
+		if (response.ok) {
+			return { status: 'member' }
+		}
+		if (response.status === 404) {
+			return { status: 'not-in-guild' }
+		}
+		return {
+			status: 'error',
+			message: `Discord guild membership lookup failed (${response.status}).`,
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		return { status: 'error', message }
+	}
+}
+
+/**
+ * Official-guild membership as Kody can see it: Discord social login plus a
+ * live member read. `false` means we know they have not linked Discord (or
+ * the bot confirmed they are not in the guild). `null` is unknown — bot
+ * unset, API blip, or a storage error — so Waiting must not invent a card.
+ */
+export async function readOfficialDiscordMembershipForUser(input: {
+	env: DiscordGuildRoleEnv & { APP_DB: D1Database }
+	userId: number
+	fetchImpl?: typeof fetch
+	timeoutMs?: number
+}): Promise<boolean | null> {
+	try {
+		const discordUserId = await readDiscordConnectionUserId(
+			input.env.APP_DB,
+			input.userId,
+		)
+		if (!discordUserId) return false
+		const membership = await readOfficialDiscordGuildMembership({
+			env: input.env,
+			discordUserId,
+			fetchImpl: input.fetchImpl,
+			timeoutMs: input.timeoutMs,
+		})
+		switch (membership.status) {
+			case 'member':
+				return true
+			case 'not-in-guild':
+				return false
+			case 'skipped':
+			case 'error':
+				return null
+			default: {
+				const exhaustive: never = membership
+				void exhaustive
+				return null
+			}
+		}
+	} catch {
+		return null
+	}
 }
 
 /**

--- a/packages/worker/src/discord/guild-role.ts
+++ b/packages/worker/src/discord/guild-role.ts
@@ -15,6 +15,13 @@
 
 import { parseStripePlanName, type PlanName } from '#universal/plans.ts'
 
+export {
+	readOfficialDiscordGuildMembership,
+	readOfficialDiscordMembershipForUser,
+	type DiscordGuildMembershipResult,
+	type DiscordGuildMembershipSkipReason,
+} from './guild-membership.ts'
+
 export const DISCORD_MEMBER_ROLE_REQUEST_TIMEOUT_MS = 8_000
 
 export const discordPlanRoles = ['standard', 'pro'] as const
@@ -43,16 +50,6 @@ export type DiscordGuildJoinResult =
 	| { status: 'joined' }
 	| { status: 'already-member' }
 	| { status: 'forbidden' }
-	| { status: 'error'; message: string }
-
-export type DiscordGuildMembershipSkipReason =
-	| 'not-configured'
-	| 'invalid-user-id'
-
-export type DiscordGuildMembershipResult =
-	| { status: 'member' }
-	| { status: 'not-in-guild' }
-	| { status: 'skipped'; reason: DiscordGuildMembershipSkipReason }
 	| { status: 'error'; message: string }
 
 export type DiscordMemberRoleSyncResult =
@@ -156,98 +153,6 @@ function memberRoleUrl(guildId: string, discordUserId: string, roleId: string) {
 
 function guildMemberUrl(guildId: string, discordUserId: string) {
 	return `${discordApiBaseUrl}/guilds/${guildId}/members/${discordUserId}`
-}
-
-/**
- * Read whether the Discord user is currently in the official guild. Failures
- * are classified and never thrown. Callers treat `skipped` / `error` as
- * unknown so a bot or network blip cannot invent a Waiting card.
- */
-export async function readOfficialDiscordGuildMembership(input: {
-	env: DiscordGuildRoleEnv
-	discordUserId: string
-	fetchImpl?: typeof fetch
-	timeoutMs?: number
-}): Promise<DiscordGuildMembershipResult> {
-	if (!isDiscordSnowflake(input.discordUserId)) {
-		return { status: 'skipped', reason: 'invalid-user-id' }
-	}
-	const config = getDiscordGuildBotConfig(input.env)
-	if (!config) {
-		return { status: 'skipped', reason: 'not-configured' }
-	}
-
-	const fetchImpl = input.fetchImpl ?? fetch
-	const timeoutMs = input.timeoutMs ?? DISCORD_MEMBER_ROLE_REQUEST_TIMEOUT_MS
-	try {
-		const response = await fetchImpl(
-			guildMemberUrl(config.guildId, input.discordUserId),
-			{
-				method: 'GET',
-				headers: {
-					Authorization: `Bot ${config.botToken}`,
-					'User-Agent': 'kody',
-				},
-				signal: AbortSignal.timeout(timeoutMs),
-			},
-		)
-		if (response.ok) {
-			return { status: 'member' }
-		}
-		if (response.status === 404) {
-			return { status: 'not-in-guild' }
-		}
-		return {
-			status: 'error',
-			message: `Discord guild membership lookup failed (${response.status}).`,
-		}
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error)
-		return { status: 'error', message }
-	}
-}
-
-/**
- * Official-guild membership as Kody can see it: Discord social login plus a
- * live member read. `false` means we know they have not linked Discord (or
- * the bot confirmed they are not in the guild). `null` is unknown — bot
- * unset, API blip, or a storage error — so Waiting must not invent a card.
- */
-export async function readOfficialDiscordMembershipForUser(input: {
-	env: DiscordGuildRoleEnv & { APP_DB: D1Database }
-	userId: number
-	fetchImpl?: typeof fetch
-	timeoutMs?: number
-}): Promise<boolean | null> {
-	try {
-		const discordUserId = await readDiscordConnectionUserId(
-			input.env.APP_DB,
-			input.userId,
-		)
-		if (!discordUserId) return false
-		const membership = await readOfficialDiscordGuildMembership({
-			env: input.env,
-			discordUserId,
-			fetchImpl: input.fetchImpl,
-			timeoutMs: input.timeoutMs,
-		})
-		switch (membership.status) {
-			case 'member':
-				return true
-			case 'not-in-guild':
-				return false
-			case 'skipped':
-			case 'error':
-				return null
-			default: {
-				const exhaustive: never = membership
-				void exhaustive
-				return null
-			}
-		}
-	} catch {
-		return null
-	}
 }
 
 /**

--- a/packages/worker/src/mcp/capabilities/account/waiting-summary.node.test.ts
+++ b/packages/worker/src/mcp/capabilities/account/waiting-summary.node.test.ts
@@ -80,15 +80,20 @@ test('waitingSummary requires auth and stays self-scoped', async () => {
 		),
 	).rejects.toThrow(/Authenticated MCP user/)
 
-	const empty = await waitingSummaryCapability.handler(
+	const dismissed = await waitingSummaryCapability.handler(
 		{},
 		{ env, callerContext },
 	)
-	expect(empty).toEqual({
-		count: 0,
-		waiting_url: 'https://example.com/account/waiting',
-		items: [],
-	})
+	expect(dismissed.waiting_url).toBe('https://example.com/account/waiting')
+	expect(dismissed.items.every((item) => item.kind === 'first-use')).toBe(true)
+	expect(dismissed.items.map((item) => item.id)).toEqual([
+		'first-use:memory',
+		'first-use:job',
+		'first-use:integration',
+		'first-use:secret',
+		'first-use:discord',
+	])
+	expect(dismissed.count).toBe(dismissed.items.length)
 
 	const unverifiedDb = createWaitingTestDb({
 		email,
@@ -102,7 +107,6 @@ test('waitingSummary requires auth and stays self-scoped', async () => {
 			callerContext,
 		},
 	)
-	expect(unverified.count).toBe(1)
 	expect(unverified.items[0]).toMatchObject({
 		id: 'verify-email',
 		kind: 'verify-email',
@@ -111,6 +115,12 @@ test('waitingSummary requires auth and stays self-scoped', async () => {
 		href: 'https://example.com/pending-verification',
 		severity: 'block',
 	})
+	expect(unverified.count).toBe(1 + dismissed.count)
+	expect(
+		unverified.items
+			.filter((item) => item.kind === 'first-use')
+			.map((item) => item.id),
+	).toEqual(dismissed.items.map((item) => item.id))
 
 	const missing = await waitingSummaryCapability.handler(
 		{},

--- a/packages/worker/src/mcp/capabilities/account/waiting-summary.ts
+++ b/packages/worker/src/mcp/capabilities/account/waiting-summary.ts
@@ -22,7 +22,7 @@ export const waitingSummaryCapability = defineDomainCapability(
 	{
 		name: 'waitingSummary',
 		description:
-			'List things currently waiting on the signed-in human: email verification, OAuth reconnects, expired secrets, MCP reconnects, locked-package publishes, plan caps, unfinished setup, and an elevated open-error rate that still needs Activity triage. Ignored and resolved Activity errors do not keep that card around. This is a current-state queue, not run history — use runSummary for Activity. Vendor outages do not appear here.',
+			'List things currently waiting on the signed-in human: email verification, OAuth reconnects, expired secrets, MCP reconnects, locked-package publishes, plan caps, wizard resume, first-use setup (search, memory, execute, package, job, integration, secret, Discord membership), and an elevated open-error rate that still needs Activity triage. Ignored and resolved Activity errors do not keep that card around. This is a current-state queue, not run history — use runSummary for Activity. Vendor outages do not appear here.',
 		keywords: [
 			'waiting',
 			'inbox',
@@ -31,6 +31,8 @@ export const waitingSummaryCapability = defineDomainCapability(
 			'reconnect',
 			'needs you',
 			'onboarding',
+			'first use',
+			'discord',
 			'verify email',
 			'locked package',
 			'MCP disconnected',

--- a/packages/worker/src/mcp/tools/search-waiting.node.test.ts
+++ b/packages/worker/src/mcp/tools/search-waiting.node.test.ts
@@ -59,6 +59,13 @@ test('search waiting markdown omits setup and caps then points at waitingSummary
 			severity: 'setup',
 			href: '/onboarding',
 		}),
+		item({
+			id: 'first-use:discord',
+			kind: 'first-use',
+			title: 'Join the Kody Discord',
+			severity: 'setup',
+			href: '/discord',
+		}),
 	]
 	expect(selectSearchWaitingItems(items).map((row) => row.id)).toEqual([
 		'integration-auth:google',

--- a/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from 'vitest'
 import { createMemoryKvNamespace } from '#worker/test-support/memory-kv.ts'
 import { accountActivitySummaryWindowMs } from '#universal/account-activity-filters.ts'
-import { buildWaitingItems } from '#universal/waiting.ts'
+import { buildWaitingItems, waitingFirstUseIds } from '#universal/waiting.ts'
 import { collectWaitingSignals } from './derive-waiting.ts'
 
 const mockModule = vi.hoisted(() => ({
@@ -14,6 +14,12 @@ const mockModule = vi.hoisted(() => ({
 		running: 0,
 		bySurface: [],
 	})),
+	listJoinedIntegrations: vi.fn(async () => []),
+	listSecrets: vi.fn(async () => []),
+	listSavedPackagesByUserId: vi.fn(async () => []),
+	listMemoriesByUserId: vi.fn(async () => []),
+	countJobsForUser: vi.fn(async () => 0),
+	readOfficialDiscordMembershipForUser: vi.fn(async () => false),
 }))
 
 vi.mock('#worker/run-records/service.ts', () => ({
@@ -21,13 +27,78 @@ vi.mock('#worker/run-records/service.ts', () => ({
 		mockModule.summarizeRunRecords(...args),
 }))
 
-function createStubDb() {
+vi.mock('#worker/integrations/service.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#worker/integrations/service.ts')>()
 	return {
-		prepare() {
+		...actual,
+		listJoinedIntegrations: (...args: Array<unknown>) =>
+			mockModule.listJoinedIntegrations(...args),
+	}
+})
+
+vi.mock('#mcp/secrets/service.ts', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('#mcp/secrets/service.ts')>()
+	return {
+		...actual,
+		listSecrets: (...args: Array<unknown>) => mockModule.listSecrets(...args),
+	}
+})
+
+vi.mock('#worker/package-registry/repo.ts', () => ({
+	listSavedPackagesByUserId: (...args: Array<unknown>) =>
+		mockModule.listSavedPackagesByUserId(...args),
+}))
+
+vi.mock('#mcp/memory/repo.ts', () => ({
+	listMemoriesByUserId: (...args: Array<unknown>) =>
+		mockModule.listMemoriesByUserId(...args),
+}))
+
+vi.mock('#worker/jobs/jobs-data.ts', () => ({
+	jobsData: () => ({
+		countJobsForUser: (...args: Array<unknown>) =>
+			mockModule.countJobsForUser(...args),
+	}),
+}))
+
+vi.mock('#worker/discord/guild-role.ts', () => ({
+	readOfficialDiscordMembershipForUser: (...args: Array<unknown>) =>
+		mockModule.readOfficialDiscordMembershipForUser(...args),
+}))
+
+function createStubDb(stamps?: {
+	first_search_at?: string | null
+	first_execute_at?: string | null
+	first_saved_package_at?: string | null
+	onboarding_checklist_dismissed_at?: string | null
+}) {
+	return {
+		prepare(query: string) {
+			const normalized = query.replace(/\s+/g, ' ').trim().toLowerCase()
 			return {
 				bind() {
 					return {
 						async first() {
+							if (!stamps) return null
+							if (normalized.includes('first_search_at')) {
+								return { first_search_at: stamps.first_search_at ?? null }
+							}
+							if (normalized.includes('first_execute_at')) {
+								return { first_execute_at: stamps.first_execute_at ?? null }
+							}
+							if (normalized.includes('first_saved_package_at')) {
+								return {
+									first_saved_package_at: stamps.first_saved_package_at ?? null,
+								}
+							}
+							if (normalized.includes('onboarding_checklist_dismissed_at')) {
+								return {
+									onboarding_checklist_dismissed_at:
+										stamps.onboarding_checklist_dismissed_at ?? null,
+								}
+							}
 							return null
 						},
 						async all() {
@@ -38,6 +109,21 @@ function createStubDb() {
 			}
 		},
 	} as unknown as D1Database
+}
+
+function resetFirstUseMocks() {
+	mockModule.listJoinedIntegrations.mockReset()
+	mockModule.listJoinedIntegrations.mockResolvedValue([])
+	mockModule.listSecrets.mockReset()
+	mockModule.listSecrets.mockResolvedValue([])
+	mockModule.listSavedPackagesByUserId.mockReset()
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([])
+	mockModule.listMemoriesByUserId.mockReset()
+	mockModule.listMemoriesByUserId.mockResolvedValue([])
+	mockModule.countJobsForUser.mockReset()
+	mockModule.countJobsForUser.mockResolvedValue(0)
+	mockModule.readOfficialDiscordMembershipForUser.mockReset()
+	mockModule.readOfficialDiscordMembershipForUser.mockResolvedValue(false)
 }
 
 const user = {
@@ -131,4 +217,95 @@ test('waiting error-rate card uses open Activity errors, not monthly rollups', a
 			href: '/account/activity',
 		}),
 	)
+})
+
+test('waiting first-use signals emit cards only when the probe knows they are missing', async () => {
+	resetFirstUseMocks()
+	const env = {
+		APP_DB: createStubDb({
+			first_search_at: null,
+			first_execute_at: null,
+			first_saved_package_at: null,
+			onboarding_checklist_dismissed_at: '2026-09-01T00:00:00.000Z',
+		}),
+	} as Env
+
+	const missing = await collectWaitingSignals({ env, user })
+	expect(missing.firstUseMissing).toEqual([...waitingFirstUseIds])
+	expect(buildWaitingItems(missing).map((item) => item.id)).toEqual(
+		waitingFirstUseIds.map((id) => `first-use:${id}`),
+	)
+	expect(missing.onboardingDismissed).toBe(true)
+
+	mockModule.listMemoriesByUserId.mockResolvedValueOnce([
+		{ id: 'mem-1', subject: 'Commute' },
+	])
+	mockModule.listSavedPackagesByUserId.mockResolvedValueOnce([
+		{ id: 'pkg-1', name: 'demo', kodyId: 'demo', lockedAt: null },
+	])
+	mockModule.countJobsForUser.mockResolvedValueOnce(1)
+	mockModule.listJoinedIntegrations.mockResolvedValueOnce([
+		{ connection: { name: 'github', lastAuthFailure: null } },
+	])
+	mockModule.listSecrets.mockResolvedValueOnce([{ name: 'apiKey', ttlMs: 60 }])
+	mockModule.readOfficialDiscordMembershipForUser.mockResolvedValueOnce(true)
+	const present = await collectWaitingSignals({
+		env: {
+			APP_DB: createStubDb({
+				first_search_at: '2026-09-01T00:00:00.000Z',
+				first_execute_at: '2026-09-01T00:00:00.000Z',
+				first_saved_package_at: '2026-09-01T00:00:00.000Z',
+				onboarding_checklist_dismissed_at: '2026-09-01T00:00:00.000Z',
+			}),
+		} as Env,
+		user,
+	})
+	expect(present.firstUseMissing).toEqual([])
+	expect(
+		buildWaitingItems(present).filter((item) => item.kind === 'first-use'),
+	).toEqual([])
+
+	mockModule.listMemoriesByUserId.mockRejectedValueOnce(new Error('d1 blip'))
+	mockModule.countJobsForUser.mockRejectedValueOnce(new Error('jobs down'))
+	mockModule.listJoinedIntegrations.mockRejectedValueOnce(
+		new Error('integrations down'),
+	)
+	mockModule.listSecrets.mockRejectedValueOnce(new Error('secrets down'))
+	mockModule.listSavedPackagesByUserId.mockRejectedValueOnce(
+		new Error('packages down'),
+	)
+	mockModule.readOfficialDiscordMembershipForUser.mockResolvedValueOnce(null)
+	const unknown = await collectWaitingSignals({
+		env: { APP_DB: createStubDb() } as Env,
+		user,
+	})
+	expect(unknown.firstUseMissing).toEqual([])
+
+	resetFirstUseMocks()
+	mockModule.listMemoriesByUserId.mockResolvedValue([{ id: 'mem-1' }])
+	mockModule.listSavedPackagesByUserId.mockResolvedValue([
+		{ id: 'pkg-1', name: 'demo', kodyId: 'demo', lockedAt: null },
+	])
+	mockModule.countJobsForUser.mockResolvedValue(1)
+	mockModule.listJoinedIntegrations.mockResolvedValue([
+		{ connection: { name: 'github', lastAuthFailure: null } },
+	])
+	mockModule.listSecrets.mockResolvedValue([{ name: 'apiKey', ttlMs: 60 }])
+	mockModule.readOfficialDiscordMembershipForUser.mockResolvedValue(false)
+	const discordOpen = await collectWaitingSignals({
+		env: {
+			APP_DB: createStubDb({
+				first_search_at: '2026-09-01T00:00:00.000Z',
+				first_execute_at: '2026-09-01T00:00:00.000Z',
+				first_saved_package_at: '2026-09-01T00:00:00.000Z',
+				onboarding_checklist_dismissed_at: '2026-09-01T00:00:00.000Z',
+			}),
+		} as Env,
+		user,
+	})
+	expect(discordOpen.firstUseMissing).toEqual(['discord'])
+	expect(buildWaitingItems(discordOpen).map((item) => item.id)).toEqual([
+		'first-use:discord',
+	])
+	resetFirstUseMocks()
 })

--- a/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.node.test.ts
@@ -63,7 +63,7 @@ vi.mock('#worker/jobs/jobs-data.ts', () => ({
 	}),
 }))
 
-vi.mock('#worker/discord/guild-role.ts', () => ({
+vi.mock('#worker/discord/guild-membership.ts', () => ({
 	readOfficialDiscordMembershipForUser: (...args: Array<unknown>) =>
 		mockModule.readOfficialDiscordMembershipForUser(...args),
 }))

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -2,6 +2,7 @@ import {
 	deriveOnboardingChecklist,
 	readOnboardingChecklistDismissed,
 } from '#mcp/onboarding-checklist.ts'
+import { listMemoriesByUserId } from '#mcp/memory/repo.ts'
 import { listSecrets } from '#mcp/secrets/service.ts'
 import { getCachedMcpClientHubServers } from '#worker/mcp-client/hub-client.ts'
 import { type McpClientHubSnapshot } from '#worker/mcp-client/types.ts'
@@ -14,13 +15,17 @@ import { readEntitlementUsageSnapshot } from '#worker/entitlements/usage-snapsho
 import { getUserEntitlement } from '#worker/entitlements/service.ts'
 import { isSavedPackageLocked } from '#worker/package-registry/package-publish-lock.ts'
 import { listJoinedIntegrations } from '#worker/integrations/service.ts'
+import { jobsData } from '#worker/jobs/jobs-data.ts'
+import { readOfficialDiscordMembershipForUser } from '#worker/discord/guild-role.ts'
 import { summarizeRunRecords } from '#worker/run-records/service.ts'
 import { accountActivitySummaryWindowMs } from '#universal/account-activity-filters.ts'
 import {
 	buildWaitingItems,
 	isUnexpiredEpochMs,
 	isWaitingMcpServerState,
+	waitingFirstUseIds,
 	type WaitingExpiredSecretSignal,
+	type WaitingFirstUseId,
 	type WaitingIntegrationAuthSignal,
 	type WaitingItem,
 	type WaitingMcpServerSignal,
@@ -47,6 +52,7 @@ export async function deriveWaitingItems(input: {
 	env: WaitingEnv
 	user: DeriveWaitingUser
 	now?: Date
+	fetchImpl?: typeof fetch
 }): Promise<Array<WaitingItem>> {
 	const signals = await collectWaitingSignals(input)
 	return buildWaitingItems(signals)
@@ -93,6 +99,7 @@ export async function collectWaitingSignals(input: {
 	env: WaitingEnv
 	user: DeriveWaitingUser
 	now?: Date
+	fetchImpl?: typeof fetch
 }): Promise<WaitingSignals> {
 	const now = input.now ?? new Date()
 	const { env, user } = input
@@ -101,12 +108,18 @@ export async function collectWaitingSignals(input: {
 		onboardingDismissed,
 		hasMcpClient,
 		mcpServers,
-		integrationAuth,
-		expiredSecrets,
-		lockedPackages,
+		integrationsProbe,
+		secretsProbe,
+		packagesProbe,
 		pendingEmailChange,
 		errorRate,
 		entitlementCaps,
+		firstSearch,
+		firstExecute,
+		firstPackageStamp,
+		firstMemory,
+		firstJob,
+		discordJoined,
 	] = await Promise.all([
 		readOnboardingChecklistDismissed({
 			env,
@@ -114,12 +127,32 @@ export async function collectWaitingSignals(input: {
 		}).catch(() => true),
 		userHasMcpOAuthGrants(env, user.stableUserId),
 		collectMcpServerSignals(env, user.stableUserId),
-		collectIntegrationAuthSignals(env, user.stableUserId),
-		collectExpiredSecretSignals(env, user.stableUserId),
-		collectLockedPackageSignals(env, user.stableUserId),
+		probe(() => listJoinedIntegrations({ env, userId: user.stableUserId })),
+		probe(() =>
+			listSecrets({
+				env,
+				userId: user.stableUserId,
+				scope: 'user',
+			}),
+		),
+		probe(() =>
+			listSavedPackagesByUserId(env.APP_DB, {
+				userId: user.stableUserId,
+			}),
+		),
 		collectPendingEmailChange(env, user.userId, now),
 		collectErrorRate(env, user.stableUserId, now),
 		collectEntitlementCaps(env, user, now),
+		probeActivationStamp(env.APP_DB, user.stableUserId, 'search'),
+		probeActivationStamp(env.APP_DB, user.stableUserId, 'execute'),
+		probeActivationStamp(env.APP_DB, user.stableUserId, 'package'),
+		probeHasMemory(env.APP_DB, user.stableUserId),
+		probeHasJob(env, user.stableUserId),
+		readOfficialDiscordMembershipForUser({
+			env,
+			userId: user.userId,
+			fetchImpl: input.fetchImpl,
+		}),
 	])
 
 	const checklist = await deriveOnboardingChecklist({
@@ -141,13 +174,59 @@ export async function collectWaitingSignals(input: {
 			.filter((item) => !item.done)
 			.map((item) => item.id),
 		mcpServers,
-		integrationAuth,
-		expiredSecrets,
-		lockedPackages,
+		integrationAuth: integrationsProbe.ok
+			? reconnectableIntegrationAuth(integrationsProbe.value)
+			: [],
+		expiredSecrets: secretsProbe.ok
+			? expiredUserSecrets(secretsProbe.value)
+			: [],
+		lockedPackages: packagesProbe.ok
+			? lockedSavedPackages(packagesProbe.value)
+			: [],
 		pendingEmailChange,
 		errorRate,
 		entitlementCaps,
+		firstUseMissing: collectFirstUseMissing({
+			search: firstSearch,
+			memory: firstMemory,
+			execute: firstExecute,
+			package: combineFirstPackage(firstPackageStamp, packagesProbe),
+			job: firstJob,
+			integration: integrationsProbe.ok
+				? integrationsProbe.value.length > 0
+				: null,
+			secret: secretsProbe.ok ? secretsProbe.value.length > 0 : null,
+			discord: discordJoined,
+		}),
 	}
+}
+
+type Probe<T> = { ok: true; value: T } | { ok: false }
+
+async function probe<T>(fn: () => Promise<T>): Promise<Probe<T>> {
+	try {
+		return { ok: true, value: await fn() }
+	} catch {
+		return { ok: false }
+	}
+}
+
+function collectFirstUseMissing(
+	signals: Record<WaitingFirstUseId, boolean | null>,
+): Array<WaitingFirstUseId> {
+	return waitingFirstUseIds.filter((id) => signals[id] === false)
+}
+
+function combineFirstPackage(
+	stamp: boolean | null,
+	packagesProbe: Probe<Array<{ lockedAt: string | null }>>,
+): boolean | null {
+	const hasSavedPackage = packagesProbe.ok && packagesProbe.value.length > 0
+	if (stamp === true || hasSavedPackage) return true
+	if (stamp === false && packagesProbe.ok && packagesProbe.value.length === 0) {
+		return false
+	}
+	return null
 }
 
 /**
@@ -205,13 +284,9 @@ async function collectMcpServerSignals(
 	return items
 }
 
-async function collectIntegrationAuthSignals(
-	env: Env,
-	userId: string,
-): Promise<Array<WaitingIntegrationAuthSignal>> {
-	const rows = await listJoinedIntegrations({ env, userId }).catch(
-		() => [] as Awaited<ReturnType<typeof listJoinedIntegrations>>,
-	)
+function reconnectableIntegrationAuth(
+	rows: Awaited<ReturnType<typeof listJoinedIntegrations>>,
+): Array<WaitingIntegrationAuthSignal> {
 	const items: Array<WaitingIntegrationAuthSignal> = []
 	for (const joined of rows) {
 		const failure = joined.connection.lastAuthFailure
@@ -226,24 +301,17 @@ async function collectIntegrationAuthSignals(
 	return items
 }
 
-async function collectExpiredSecretSignals(
-	env: Env,
-	userId: string,
-): Promise<Array<WaitingExpiredSecretSignal>> {
-	const secrets = await listSecrets({
-		env,
-		userId,
-		scope: 'user',
-	}).catch(() => [] as Awaited<ReturnType<typeof listSecrets>>)
+function expiredUserSecrets(
+	secrets: Awaited<ReturnType<typeof listSecrets>>,
+): Array<WaitingExpiredSecretSignal> {
 	return secrets
 		.filter((secret) => secret.ttlMs != null && secret.ttlMs <= 0)
 		.map((secret) => ({ name: secret.name }))
 }
 
-async function collectLockedPackageSignals(env: Env, userId: string) {
-	const packages = await listSavedPackagesByUserId(env.APP_DB, {
-		userId,
-	}).catch(() => [] as Awaited<ReturnType<typeof listSavedPackagesByUserId>>)
+function lockedSavedPackages(
+	packages: Awaited<ReturnType<typeof listSavedPackagesByUserId>>,
+) {
 	return packages
 		.filter((pkg) => isSavedPackageLocked(pkg.lockedAt))
 		.map((pkg) => ({
@@ -251,6 +319,64 @@ async function collectLockedPackageSignals(env: Env, userId: string) {
 			name: pkg.name,
 			kodyId: pkg.kodyId,
 		}))
+}
+
+type ActivationStamp = 'search' | 'execute' | 'package'
+
+function activationStampColumn(stamp: ActivationStamp) {
+	switch (stamp) {
+		case 'search':
+			return 'first_search_at'
+		case 'execute':
+			return 'first_execute_at'
+		case 'package':
+			return 'first_saved_package_at'
+		default: {
+			const exhaustive: never = stamp
+			throw new Error(`Unknown activation stamp: ${String(exhaustive)}`)
+		}
+	}
+}
+
+async function probeActivationStamp(
+	db: D1Database,
+	userId: string,
+	stamp: ActivationStamp,
+): Promise<boolean | null> {
+	const column = activationStampColumn(stamp)
+	try {
+		const row = await db
+			.prepare(
+				`SELECT ${column}
+				 FROM users
+				 WHERE stable_user_id = ?
+				 LIMIT 1`,
+			)
+			.bind(userId)
+			.first<Record<string, string | null>>()
+		if (!row) return null
+		return Boolean(row[column])
+	} catch {
+		return null
+	}
+}
+
+async function probeHasMemory(db: D1Database, userId: string) {
+	try {
+		const rows = await listMemoriesByUserId(db, userId, { limit: 1 })
+		return rows.length > 0
+	} catch {
+		return null
+	}
+}
+
+async function probeHasJob(env: WaitingEnv, userId: string) {
+	try {
+		const count = await jobsData(env).countJobsForUser({ userId })
+		return count > 0
+	} catch {
+		return null
+	}
 }
 
 async function collectPendingEmailChange(env: Env, userId: number, now: Date) {

--- a/packages/worker/src/mcp/waiting/derive-waiting.ts
+++ b/packages/worker/src/mcp/waiting/derive-waiting.ts
@@ -16,7 +16,7 @@ import { getUserEntitlement } from '#worker/entitlements/service.ts'
 import { isSavedPackageLocked } from '#worker/package-registry/package-publish-lock.ts'
 import { listJoinedIntegrations } from '#worker/integrations/service.ts'
 import { jobsData } from '#worker/jobs/jobs-data.ts'
-import { readOfficialDiscordMembershipForUser } from '#worker/discord/guild-role.ts'
+import { readOfficialDiscordMembershipForUser } from '#worker/discord/guild-membership.ts'
 import { summarizeRunRecords } from '#worker/run-records/service.ts'
 import { accountActivitySummaryWindowMs } from '#universal/account-activity-filters.ts'
 import {

--- a/packages/worker/universal/waiting.node.test.ts
+++ b/packages/worker/universal/waiting.node.test.ts
@@ -1,9 +1,12 @@
 import { expect, test } from 'vitest'
+import { onboardingChecklistItems } from './onboarding-process.ts'
 import {
 	buildWaitingItems,
 	isElevatedUserErrorRate,
 	isUnexpiredEpochMs,
 	isWaitingMcpServerState,
+	waitingFirstUseIds,
+	type WaitingFirstUseId,
 	type WaitingSignals,
 } from './waiting.ts'
 
@@ -19,6 +22,7 @@ const emptySignals: WaitingSignals = {
 	pendingEmailChange: null,
 	errorRate: null,
 	entitlementCaps: [],
+	firstUseMissing: [],
 }
 
 test('waiting items are a current-state you-queue and skip noise', () => {
@@ -76,6 +80,7 @@ test('waiting items are a current-state you-queue and skip noise', () => {
 		pendingEmailChange: 'new@example.com',
 		errorRate: { errorCount: 12, eventCount: 20 },
 		entitlementCaps: [{ resource: 'saved_packages', label: 'Saved packages' }],
+		firstUseMissing: [],
 	})
 
 	expect(items.map((item) => item.id)).toEqual([
@@ -195,4 +200,79 @@ test('waiting items are a current-state you-queue and skip noise', () => {
 		href: '/connect/oauth?provider=google&loginHint=kent%40gmail.com',
 		severity: 'block',
 	})
+})
+
+test('waiting first-use cards are discrete, skip coarse checklist ids, and ignore dismiss', () => {
+	expect(
+		onboardingChecklistItems.some((item) =>
+			(waitingFirstUseIds as ReadonlyArray<string>).includes(item.id),
+		),
+	).toBe(false)
+
+	const allMissing = buildWaitingItems({
+		...emptySignals,
+		onboardingDismissed: true,
+		onboardingRemaining: ['give-access', 'install-starter', 'connect-agent'],
+		firstUseMissing: [...waitingFirstUseIds],
+	})
+	expect(allMissing.map((item) => item.id)).toEqual([
+		'first-use:search',
+		'first-use:memory',
+		'first-use:execute',
+		'first-use:package',
+		'first-use:job',
+		'first-use:integration',
+		'first-use:secret',
+		'first-use:discord',
+	])
+	expect(allMissing.every((item) => item.kind === 'first-use')).toBe(true)
+	expect(allMissing.every((item) => item.severity === 'setup')).toBe(true)
+	expect(allMissing.find((item) => item.id === 'onboarding:give-access')).toBe(
+		undefined,
+	)
+	expect(
+		allMissing.find((item) => item.id === 'onboarding:install-starter'),
+	).toBe(undefined)
+	expect(
+		allMissing.find((item) => item.id === 'onboarding:connect-agent'),
+	).toBe(undefined)
+
+	const wizardResume = buildWaitingItems({
+		...emptySignals,
+		onboardingDismissed: false,
+		onboardingRemaining: [
+			'connect-agent',
+			'give-access',
+			'connect-second-agent',
+			'install-starter',
+		],
+		firstUseMissing: ['search', 'discord'],
+	})
+	expect(wizardResume.map((item) => item.id)).toEqual([
+		'onboarding:connect-second-agent',
+		'onboarding:connect-agent',
+		'first-use:search',
+		'first-use:discord',
+	])
+
+	const discord = wizardResume.find((item) => item.id === 'first-use:discord')
+	expect(discord).toMatchObject({
+		title: 'Join the Kody Discord',
+		doLabel: 'Join Discord',
+		href: '/discord',
+		severity: 'setup',
+	})
+
+	const presentClearsCard: Array<WaitingFirstUseId> = [...waitingFirstUseIds]
+	for (const id of presentClearsCard) {
+		const remaining = presentClearsCard.filter((candidate) => candidate !== id)
+		const items = buildWaitingItems({
+			...emptySignals,
+			firstUseMissing: remaining,
+		})
+		expect(items.find((item) => item.id === `first-use:${id}`)).toBe(undefined)
+		expect(items.map((item) => item.id)).toEqual(
+			remaining.map((candidate) => `first-use:${candidate}`),
+		)
+	}
 })

--- a/packages/worker/universal/waiting.ts
+++ b/packages/worker/universal/waiting.ts
@@ -22,6 +22,7 @@ export const waitingItemKinds = [
 	'entitlement',
 	'error-rate',
 	'onboarding',
+	'first-use',
 ] as const
 
 type WaitingItemKind = (typeof waitingItemKinds)[number]
@@ -29,6 +30,36 @@ type WaitingItemKind = (typeof waitingItemKinds)[number]
 export const waitingSeverities = ['block', 'degraded', 'setup'] as const
 
 export type WaitingSeverity = (typeof waitingSeverities)[number]
+
+/**
+ * Discrete first-use gates on Waiting only. These are not `/onboarding`
+ * wizard steps and are not checklist ids.
+ */
+export const waitingFirstUseIds = [
+	'search',
+	'memory',
+	'execute',
+	'package',
+	'job',
+	'integration',
+	'secret',
+	'discord',
+] as const
+
+export type WaitingFirstUseId = (typeof waitingFirstUseIds)[number]
+
+/**
+ * Coarse checklist ids that would duplicate the broken-out first-use cards.
+ * The wizard still uses them; Waiting does not emit those onboarding cards.
+ */
+export const onboardingWaitingCoarseIds = [
+	'give-access',
+	'install-starter',
+] as const satisfies ReadonlyArray<OnboardingChecklistItemId>
+
+const onboardingWaitingCoarseIdSet = new Set<OnboardingChecklistItemId>(
+	onboardingWaitingCoarseIds,
+)
 
 /**
  * A current-state item the signed-in human can clear. Not a notification:
@@ -102,6 +133,11 @@ export type WaitingSignals = {
 	/** Open (untriaged) Activity errors vs runs in the Activity window. */
 	errorRate: { errorCount: number; eventCount: number } | null
 	entitlementCaps: Array<WaitingEntitlementCapSignal>
+	/**
+	 * First-use gates we know are still open. Unknown probes are omitted so
+	 * a storage blip cannot invent a card.
+	 */
+	firstUseMissing: Array<WaitingFirstUseId>
 }
 
 const severityRank: Record<WaitingSeverity, number> = {
@@ -120,7 +156,12 @@ const kindRank: Record<WaitingItemKind, number> = {
 	entitlement: 6,
 	'error-rate': 7,
 	onboarding: 8,
+	'first-use': 9,
 }
+
+const firstUseRank = Object.fromEntries(
+	waitingFirstUseIds.map((id, index) => [id, index]),
+) as Record<WaitingFirstUseId, number>
 
 const mcpHumanStates = new Set(['authenticating', 'failed', 'disconnected'])
 
@@ -264,6 +305,7 @@ export function buildWaitingItems(signals: WaitingSignals): Array<WaitingItem> {
 	if (!signals.onboardingDismissed) {
 		for (const step of signals.onboardingRemaining) {
 			if (step === 'verify-email' && !signals.emailVerified) continue
+			if (onboardingWaitingCoarseIdSet.has(step)) continue
 			items.push({
 				id: `onboarding:${step}`,
 				kind: 'onboarding',
@@ -277,15 +319,95 @@ export function buildWaitingItems(signals: WaitingSignals): Array<WaitingItem> {
 		}
 	}
 
+	for (const id of signals.firstUseMissing) {
+		items.push(buildFirstUseWaitingItem(id))
+	}
+
 	return items.sort((left, right) => {
 		const severity = severityRank[left.severity] - severityRank[right.severity]
 		if (severity !== 0) return severity
 		const kind = kindRank[left.kind] - kindRank[right.kind]
 		if (kind !== 0) return kind
+		if (left.kind === 'first-use' && right.kind === 'first-use') {
+			return firstUseItemRank(left.id) - firstUseItemRank(right.id)
+		}
 		if (left.id === 'secret-expired-more') return 1
 		if (right.id === 'secret-expired-more') return -1
 		return left.title.localeCompare(right.title)
 	})
+}
+
+function firstUseItemRank(itemId: string) {
+	const id = itemId.slice('first-use:'.length) as WaitingFirstUseId
+	return firstUseRank[id] ?? waitingFirstUseIds.length
+}
+
+function buildFirstUseWaitingItem(id: WaitingFirstUseId): WaitingItem {
+	const copy = waitingFirstUseCopy[id]
+	return {
+		id: `first-use:${id}`,
+		kind: 'first-use',
+		title: copy.title,
+		why: copy.why,
+		who: 'you',
+		doLabel: copy.doLabel,
+		href: copy.href,
+		severity: 'setup',
+	}
+}
+
+const waitingFirstUseCopy: Record<
+	WaitingFirstUseId,
+	{ title: string; why: string; doLabel: string; href: string }
+> = {
+	search: {
+		title: 'Try your first search',
+		why: 'Search is how your agent looks things up in Kody — capabilities, guides, packages, and more.',
+		doLabel: 'Read how search works',
+		href: routes.docDetail.href({ slug: 'search-and-execute' }),
+	},
+	memory: {
+		title: 'Save your first memory',
+		why: 'Memories persist facts your agents can reuse across hosts.',
+		doLabel: 'Open Memories',
+		href: routes.accountMemories.href(),
+	},
+	execute: {
+		title: 'Run your first execute',
+		why: 'Execute is how your agent does work in Kody — tools, packages, and jobs.',
+		doLabel: 'Read how execute works',
+		href: routes.docDetail.href({ slug: 'search-and-execute' }),
+	},
+	package: {
+		title: 'Persist your first package',
+		why: 'A saved package is reusable code your agents can keep and share.',
+		doLabel: 'Open Packages',
+		href: routes.accountPackages.href(),
+	},
+	job: {
+		title: 'Create your first job',
+		why: 'Jobs run on a schedule so your agents can keep working without you.',
+		doLabel: 'Open Jobs',
+		href: routes.accountJobs.href(),
+	},
+	integration: {
+		title: 'Connect your first integration',
+		why: 'An integration grant lets your agents call a connected third-party account.',
+		doLabel: 'Open Integrations',
+		href: routes.accountIntegrations.href(),
+	},
+	secret: {
+		title: 'Add your first secret',
+		why: 'User-scope secrets stay out of chat. Add one so your agents can use credentials safely.',
+		doLabel: 'Open Secrets',
+		href: routes.accountSecrets.href(),
+	},
+	discord: {
+		title: 'Join the Kody Discord',
+		why: 'Connect Discord to join the official server and pick up your member role.',
+		doLabel: 'Join Discord',
+		href: routes.discord.href(),
+	},
 }
 
 function buildMcpServerWaitingItem(

--- a/packages/worker/universal/waiting.ts
+++ b/packages/worker/universal/waiting.ts
@@ -52,7 +52,7 @@ export type WaitingFirstUseId = (typeof waitingFirstUseIds)[number]
  * Coarse checklist ids that would duplicate the broken-out first-use cards.
  * The wizard still uses them; Waiting does not emit those onboarding cards.
  */
-export const onboardingWaitingCoarseIds = [
+const onboardingWaitingCoarseIds = [
 	'give-access',
 	'install-starter',
 ] as const satisfies ReadonlyArray<OnboardingChecklistItemId>

--- a/tools/check-worker-startup-bundles.ts
+++ b/tools/check-worker-startup-bundles.ts
@@ -104,10 +104,11 @@ const startupBundles: ReadonlyArray<StartupBundleDefinition> = [
 		packageDir: 'packages/platform-worker',
 		entryFile: 'platform-worker.js',
 		bundler: 'wrangler',
-		// CI merge with current main is a deterministic 4_975_017 bytes
-		// (17 over the previous ratchet) on two Static runs. This PR does
-		// not touch platform-worker.
-		maxEntryBytes: 4_980_000,
+		// Waiting first-use probes (search, memory, execute, package, job,
+		// integration, secret, Discord membership) ship on platform because
+		// waitingSummary runs in the MCP Durable Object. Local dry-run after
+		// that change is 4_983_088 bytes.
+		maxEntryBytes: 4_990_000,
 		forbiddenSources: [
 			...sharedDeferredGuideSources,
 			oauthProviderPackageSourcePath,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Make **What’s waiting on me** show richer first-use setup — including **Join Discord** — without changing the `/onboarding` wizard.

## Why

The checklist’s `give-access` card is an OR of first search, memory, execute, and saved package. Kent asked to break those (plus job, integration, secret, and Discord membership) into separate Waiting items. They belong on Waiting only, not as wizard steps.

## Summary

- Waiting emits `kind: 'first-use'` setup cards for first **search**, **memory**, **execute**, **package**, **job**, **integration**, **secret**, and official **Discord** membership.
- Coarse `give-access` / `install-starter` checklist ids no longer become Waiting cards (they would duplicate the new ones). Wizard resume still shows `connect-agent` / `connect-second-agent` unless the checklist is dismissed or complete.
- First-use cards ignore checklist dismiss. Each card disappears when that probe knows the gate cleared. Probe errors are unknown: Waiting neither invents nor claims the gate cleared.
- Discord uses social-login linkage plus a live guild member GET across every linked Discord identity. Any member hides the card. All confirmed out shows it. A blip fails open.
- Wizard Steps 1–3 and `deriveOnboardingChecklist` are unchanged.
- Docs: `docs/use/waiting.md`, architecture onboarding notes, `waitingSummary` description.
- Discord membership GET lives in `guild-membership.ts` so Waiting does not pull role-sync into the platform startup bundle.

## Testing

- Focused node tests: waiting items, `collectWaitingSignals` present/absent/unknown, Discord membership (including multiple linked identities), wizard alignment, dismiss, `waitingSummary`.
- `test:push` (`test:node` + `test:workers`) passed on push.
- `npm run validate` green on the first-use implementation; review-fix commit re-ran `test:push`.
- Preview and local UI passes on the prior head confirmed first-use + Discord cards and an unchanged wizard.
- Review follow-up: empty-state copy no longer claims first-use setup is done when unknown probes omit cards.

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `79a9a1fc` · **Head:** `e06a47f2`

**Classification:** extends — Waiting gains a `first-use` kind and eight setup cards. The `/onboarding` wizard checklist is unchanged.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `app-ui` | surfaces | extends — Waiting cards, `waitingItemKinds`, empty-state copy |
| `mcp-server` | surfaces | extends — `collectWaitingSignals` first-use probes and `waitingSummary` |
| `app-sessions` | auth | extends — official-guild membership GET for the Discord card |
| `account-export` | assistant | composes — `waitingSummary` lives in this code root, export unchanged |

### Change flow

Signed-in Waiting (and `waitingSummary`) collect first-use probes in parallel, emit setup cards only when a probe knows the gate is still open, and skip coarse `give-access` / `install-starter` checklist cards.

```mermaid
sequenceDiagram
	actor User
	participant appUi as app-ui
	participant mcpServer as mcp-server
	participant appSessions as app-sessions
	User->>appUi: GET /account/waiting
	appUi->>mcpServer: deriveWaitingItems
	mcpServer->>mcpServer: probe search memory execute package job integration secret
	mcpServer->>appSessions: readOfficialDiscordMembershipForUser
	appSessions-->>mcpServer: joined unknown or not linked
	mcpServer-->>appUi: first-use cards plus wizard resume
	Note over mcpServer: unknown probes omit the card
	Note over appUi: give-access and install-starter stay off Waiting
```

### Before / after

```text
Before: Waiting maps unfinished checklist ids to kind onboarding
        (give-access OR of search|memory|execute|package).
After:  Waiting emits kind first-use per missing gate, plus Discord.
        Wizard checklist and Steps 1–3 stay the same.
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7156516b-b355-463c-9297-fcc5ae289bc0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7156516b-b355-463c-9297-fcc5ae289bc0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added distinct Waiting setup cards for first-use features, including search, memory, execution, packages, jobs, integrations, secrets, and official Discord membership.
  - Waiting now supports resuming incomplete onboarding steps without duplicate broad checklist cards.
  - Discord membership checks consider all linked Discord connections.

- **Bug Fixes**
  - Improved fail-open handling when setup status or Discord availability cannot be determined.
  - Updated the empty Waiting message to accurately describe healthy connections and pending actions.

- **Documentation**
  - Clarified Waiting cards, onboarding behavior, and first-use setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->