### PR TITLE
Cut RunLog DO SQLite rows-read via denormalized log_count

### DIFF
--- a/packages/worker/src/run-records/dedicated-state.workers.test.ts
+++ b/packages/worker/src/run-records/dedicated-state.workers.test.ts
@@ -18,6 +18,7 @@ import {
 	getAdminInsightsSnapshot,
 	getJobRunObservability,
 	getJobRunObservabilityBatch,
+	getSqlBillingStats,
 	getWorkflowProjection,
 	listActivationMilestones,
 	listPackageRunSuccesses,
@@ -1184,8 +1185,8 @@ function jobRunObservabilityColumnNames(state: DurableObjectState) {
 		.map((row) => String(row.name))
 }
 
-test('fresh schema v10 creates the final job_run_observability contract', async () => {
-	const userId = uniqueUserId('schema-v10-fresh')
+test('fresh schema v11 creates the final runs and job_run_observability contract', async () => {
+	const userId = uniqueUserId('schema-v11-fresh')
 	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
 	await runInDurableObject(stub, async (instance: RunLog, state) => {
 		expect(instance).toBeInstanceOf(RunLog)
@@ -1194,7 +1195,7 @@ test('fresh schema v10 creates the final job_run_observability contract', async 
 				`SELECT value FROM run_log_meta WHERE key = 'schema_version' LIMIT 1`,
 			)
 			.toArray()[0]
-		expect(Number(version?.value)).toBe(10)
+		expect(Number(version?.value)).toBe(11)
 
 		expect(jobRunObservabilityColumnNames(state)).toEqual([
 			'job_id',
@@ -1218,6 +1219,7 @@ test('fresh schema v10 creates the final job_run_observability contract', async 
 				'triage_note',
 				'triaged_at',
 				'triaged_by',
+				'log_count',
 			]),
 		)
 	})
@@ -1242,7 +1244,7 @@ test('fresh schema v10 creates the final job_run_observability contract', async 
 	})
 })
 
-test('warm schema v7 and v8 objects upgrade to v10 without losing job data', async () => {
+test('warm schema v7 and v8 objects upgrade to v11 without losing job data', async () => {
 	const retiredColumn = ['legacy', 'seeded'].join('_')
 	for (const installedVersion of [7, 8]) {
 		const userId = uniqueUserId(`schema-v${installedVersion}-warm`)
@@ -1302,7 +1304,7 @@ test('warm schema v7 and v8 objects upgrade to v10 without losing job data', asy
 					`SELECT value FROM run_log_meta WHERE key = 'schema_version' LIMIT 1`,
 				)
 				.toArray()[0]
-			expect(Number(version?.value)).toBe(10)
+			expect(Number(version?.value)).toBe(11)
 			expect(jobRunObservabilityColumnNames(state)).toEqual([
 				'job_id',
 				'last_run_at',
@@ -1351,7 +1353,7 @@ test('warm schema v7 and v8 objects upgrade to v10 without losing job data', asy
 	}
 })
 
-test('warm schema v9 objects upgrade to v10 with error triage columns', async () => {
+test('warm schema v9 objects upgrade to v11 with error triage and log_count columns', async () => {
 	const userId = uniqueUserId('schema-v9-warm-triage')
 	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
 	await runInDurableObject(stub, async (instance: RunLog, state) => {
@@ -1422,7 +1424,7 @@ test('warm schema v9 objects upgrade to v10 with error triage columns', async ()
 				`SELECT value FROM run_log_meta WHERE key = 'schema_version' LIMIT 1`,
 			)
 			.toArray()[0]
-		expect(Number(version?.value)).toBe(10)
+		expect(Number(version?.value)).toBe(11)
 		expect(
 			state.storage.sql
 				.exec<{ name: string }>(`PRAGMA table_info(runs)`)
@@ -1434,12 +1436,13 @@ test('warm schema v9 objects upgrade to v10 with error triage columns', async ()
 				'triage_note',
 				'triaged_at',
 				'triaged_by',
+				'log_count',
 			]),
 		)
 		expect(
 			state.storage.sql
 				.exec<Record<string, SqlStorageValue>>(
-					`SELECT id, status, error_message, error_triage, triage_note
+					`SELECT id, status, error_message, error_triage, triage_note, log_count
 					FROM runs WHERE id = ?`,
 					'run-warm-v9',
 				)
@@ -1450,8 +1453,115 @@ test('warm schema v9 objects upgrade to v10 with error triage columns', async ()
 			error_message: 'preserved',
 			error_triage: null,
 			triage_note: null,
+			log_count: 0,
 		})
 	})
+})
+
+test('warm schema v10 objects backfill denormalized log_count on upgrade to v11', async () => {
+	const userId = uniqueUserId('schema-v10-warm-log-count')
+	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+	await runInDurableObject(stub, async (instance: RunLog, state) => {
+		expect(instance).toBeInstanceOf(RunLog)
+		await state.storage.deleteAll()
+
+		state.storage.sql.exec(`
+			CREATE TABLE run_log_meta (
+				key TEXT PRIMARY KEY NOT NULL,
+				value INTEGER NOT NULL
+			)
+		`)
+		state.storage.sql.exec(
+			`INSERT INTO run_log_meta (key, value) VALUES ('schema_version', 10)`,
+		)
+		state.storage.sql.exec(`
+			CREATE TABLE runs (
+				id TEXT PRIMARY KEY NOT NULL,
+				surface TEXT NOT NULL,
+				status TEXT NOT NULL,
+				name TEXT,
+				package_id TEXT,
+				package_kody_id TEXT,
+				source_id TEXT,
+				published_commit TEXT,
+				storage_id TEXT,
+				job_id TEXT,
+				workflow_id TEXT,
+				invocation_id TEXT,
+				session_id TEXT,
+				idempotency_key TEXT,
+				parent_run_id TEXT,
+				started_at TEXT NOT NULL,
+				finished_at TEXT,
+				duration_ms INTEGER,
+				error_name TEXT,
+				error_message TEXT,
+				metadata_json TEXT NOT NULL DEFAULT '{}',
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL,
+				error_triage TEXT,
+				triage_note TEXT,
+				triaged_at TEXT,
+				triaged_by TEXT
+			)
+		`)
+		state.storage.sql.exec(`
+			CREATE TABLE run_logs (
+				run_id TEXT NOT NULL,
+				sequence INTEGER NOT NULL,
+				level TEXT NOT NULL,
+				message TEXT NOT NULL,
+				fields_json TEXT,
+				PRIMARY KEY (run_id, sequence)
+			)
+		`)
+		state.storage.sql.exec(
+			`INSERT INTO runs (
+				id, surface, status, name, started_at, finished_at, duration_ms,
+				error_name, error_message, metadata_json, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, '{}', ?, ?)`,
+			'run-warm-v10',
+			'execute',
+			'success',
+			'warm-v10',
+			'2026-07-01T00:00:00.000Z',
+			'2026-07-01T00:00:01.000Z',
+			1000,
+			'2026-07-01T00:00:00.000Z',
+			'2026-07-01T00:00:01.000Z',
+		)
+		state.storage.sql.exec(
+			`INSERT INTO run_logs (run_id, sequence, level, message, fields_json)
+			VALUES (?, 0, 'info', 'a', NULL), (?, 1, 'info', 'b', NULL), (?, 2, 'info', 'c', NULL)`,
+			'run-warm-v10',
+			'run-warm-v10',
+			'run-warm-v10',
+		)
+
+		const proto = Object.getPrototypeOf(instance) as {
+			initializeSchema: () => void
+		}
+		proto.initializeSchema.call(instance)
+
+		const version = state.storage.sql
+			.exec<{ value: number }>(
+				`SELECT value FROM run_log_meta WHERE key = 'schema_version' LIMIT 1`,
+			)
+			.toArray()[0]
+		expect(Number(version?.value)).toBe(11)
+		expect(
+			state.storage.sql
+				.exec<{ log_count: number }>(
+					`SELECT log_count FROM runs WHERE id = ?`,
+					'run-warm-v10',
+				)
+				.one(),
+		).toEqual({ log_count: 3 })
+	})
+
+	const page = await listRunRecords({ env, userId })
+	expect(page.runs).toHaveLength(1)
+	expect(page.runs[0]?.logCount).toBe(3)
 })
 
 test('getAdminInsightsSnapshot returns content-free workflow, job, and activation aggregates', async () => {
@@ -1590,4 +1700,40 @@ test('getAdminInsightsSnapshot returns content-free workflow, job, and activatio
 			'reachedAt',
 		])
 	}
+})
+
+test('getSqlBillingStats tracks listRuns rowsRead after denormalized log_count reads', async () => {
+	const userId = uniqueUserId('sql-billing')
+	const pending: Array<Promise<unknown>> = []
+	const handle = beginRunRecord({
+		env,
+		userId,
+		context: {
+			surface: 'job',
+			name: 'billing-job',
+			jobId: 'job-billing',
+		},
+		waitUntil: (promise) => {
+			pending.push(promise)
+		},
+	})
+	expect(handle).not.toBeNull()
+	await Promise.all(pending)
+	await finishRunRecord({
+		env,
+		handle,
+		status: 'success',
+		logs: ['one', 'two'],
+	})
+	await listRunRecords({ env, userId })
+
+	const stats = await getSqlBillingStats({ env, userId })
+	expect(stats.databaseSize).toBeGreaterThan(0)
+	expect(stats.rowsReadTotal).toBeGreaterThan(0)
+	expect(stats.ops.some((op) => op.op === 'listRuns' && op.calls >= 1)).toBe(
+		true,
+	)
+	expect(stats.ops.some((op) => op.op === 'finishRun' && op.calls >= 1)).toBe(
+		true,
+	)
 })

--- a/packages/worker/src/run-records/run-log-do.ts
+++ b/packages/worker/src/run-records/run-log-do.ts
@@ -76,7 +76,53 @@ const metaRunCountKey = 'run_count'
 const metaFinishesSinceRetentionKey = 'finishes_since_retention'
 const metaSchemaVersionKey = 'schema_version'
 /** Bump when initializeSchema's DDL set changes; warm objects skip DDL. */
-const runLogSchemaVersion = 10
+const runLogSchemaVersion = 11
+
+type RunLogSqlBillingOp =
+	| 'listRuns'
+	| 'getRun'
+	| 'summarize'
+	| 'enforceRetention'
+	| 'reconcileStaleRunning'
+	| 'finishRun'
+	| 'exportRuns'
+	| 'findRunByIdempotencyKey'
+	| 'healStaleRunning'
+	| 'updateRunErrorTriage'
+
+const runLogSqlBillingOps = [
+	'listRuns',
+	'getRun',
+	'summarize',
+	'enforceRetention',
+	'reconcileStaleRunning',
+	'finishRun',
+	'exportRuns',
+	'findRunByIdempotencyKey',
+	'healStaleRunning',
+	'updateRunErrorTriage',
+] as const satisfies ReadonlyArray<RunLogSqlBillingOp>
+
+function sqlBillingMetaKey(
+	op: RunLogSqlBillingOp,
+	kind: 'rr' | 'rw' | 'n',
+): string {
+	return `sql_${kind}_${op}`
+}
+
+export type RunLogSqlBillingOpStats = {
+	op: RunLogSqlBillingOp
+	rowsRead: number
+	rowsWritten: number
+	calls: number
+}
+
+export type RunLogSqlBillingStats = {
+	databaseSize: number
+	rowsReadTotal: number
+	rowsWrittenTotal: number
+	ops: Array<RunLogSqlBillingOpStats>
+}
 
 /**
  * Cursor namespaces for `exportRuns` phases after the raw run-id phase.
@@ -542,6 +588,15 @@ class RunLogBase extends DurableObject<Env> {
 	 */
 	private runCountCache: number | null = null
 	private finishesSinceRetentionCache: number | null = null
+	/**
+	 * Per-op SqlStorageCursor.rowsRead/rowsWritten accumulators for this
+	 * isolate. Durable totals use atomic run_log_meta increments (no new AE
+	 * dataset; USAGE_EVENTS would inflate billed overage).
+	 */
+	private sqlBillingByOp = new Map<
+		RunLogSqlBillingOp,
+		{ rowsRead: number; rowsWritten: number; calls: number }
+	>()
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env)
@@ -597,7 +652,8 @@ class RunLogBase extends DurableObject<Env> {
 				error_triage TEXT,
 				triage_note TEXT,
 				triaged_at TEXT,
-				triaged_by TEXT
+				triaged_by TEXT,
+				log_count INTEGER NOT NULL DEFAULT 0
 			)
 		`)
 		if (installedVersion != null && installedVersion < 10) {
@@ -645,6 +701,10 @@ class RunLogBase extends DurableObject<Env> {
 				PRIMARY KEY (run_id, sequence)
 			)
 		`)
+		// After run_logs exists: warm objects need the column + one-time backfill.
+		if (installedVersion != null && installedVersion < 11) {
+			this.migrateRunsLogCountForV11()
+		}
 		// Keyed package-invocation idempotency ledger (migrated from the D1
 		// package_invocations table). No user_id column: the DO identity is the
 		// user. The unique index is the exactly-once claim scope; unlike D1's
@@ -803,6 +863,27 @@ class RunLogBase extends DurableObject<Env> {
 		}
 	}
 
+	/**
+	 * Denormalized `runs.log_count` so list/get/export stop paying a correlated
+	 * `COUNT(*)` over `run_logs` per row (production rows-read hotspot).
+	 * One-time backfill may scan `run_logs`; afterward reads use the column.
+	 */
+	private migrateRunsLogCountForV11() {
+		try {
+			this.ctx.storage.sql.exec(
+				`ALTER TABLE runs ADD COLUMN log_count INTEGER NOT NULL DEFAULT 0`,
+			)
+		} catch {
+			// Column already present on a partially migrated object.
+		}
+		this.ctx.storage.sql.exec(
+			`UPDATE runs
+			SET log_count = (
+				SELECT COUNT(*) FROM run_logs l WHERE l.run_id = runs.id
+			)`,
+		)
+	}
+
 	private getMeta(key: string): number | null {
 		const row = this.ctx.storage.sql
 			.exec<{ value: number }>(
@@ -823,6 +904,74 @@ class RunLogBase extends DurableObject<Env> {
 		if (key === metaRunCountKey) this.runCountCache = value
 		if (key === metaFinishesSinceRetentionKey) {
 			this.finishesSinceRetentionCache = value
+		}
+	}
+
+	/** Atomic increment — no prior SELECT, so instrumentation stays cheap. */
+	private adjustMeta(key: string, delta: number) {
+		if (delta === 0) return
+		this.ctx.storage.sql.exec(
+			`INSERT INTO run_log_meta (key, value) VALUES (?, ?)
+			ON CONFLICT(key) DO UPDATE SET value = value + excluded.value`,
+			key,
+			delta,
+		)
+	}
+
+	private recordSqlBilling(
+		op: RunLogSqlBillingOp,
+		cursor: Pick<
+			SqlStorageCursor<Record<string, SqlStorageValue>>,
+			'rowsRead' | 'rowsWritten'
+		>,
+	) {
+		const rowsRead = Number(cursor.rowsRead) || 0
+		const rowsWritten = Number(cursor.rowsWritten) || 0
+		const prev = this.sqlBillingByOp.get(op) ?? {
+			rowsRead: 0,
+			rowsWritten: 0,
+			calls: 0,
+		}
+		prev.rowsRead += rowsRead
+		prev.rowsWritten += rowsWritten
+		prev.calls += 1
+		this.sqlBillingByOp.set(op, prev)
+		this.adjustMeta(sqlBillingMetaKey(op, 'rr'), rowsRead)
+		this.adjustMeta(sqlBillingMetaKey(op, 'rw'), rowsWritten)
+		this.adjustMeta(sqlBillingMetaKey(op, 'n'), 1)
+	}
+
+	/**
+	 * Run a SQL statement and attribute its cursor rowsRead/rowsWritten to `op`
+	 * after the cursor is consumed. Mutations that return no rows still expose
+	 * billing counters on the cursor after exec.
+	 */
+	private execSqlTracked<T extends Record<string, SqlStorageValue>>(
+		op: RunLogSqlBillingOp,
+		query: string,
+		...bindings: Array<SqlStorageValue>
+	): {
+		toArray: () => Array<T>
+		one: () => T
+		run: () => void
+	} {
+		const cursor = this.ctx.storage.sql.exec<T>(query, ...bindings)
+		return {
+			toArray: () => {
+				const rows = cursor.toArray()
+				this.recordSqlBilling(op, cursor)
+				return rows
+			},
+			one: () => {
+				const row = cursor.one()
+				this.recordSqlBilling(op, cursor)
+				return row
+			},
+			run: () => {
+				// Drain so rowsWritten/rowsRead settle for write statements.
+				cursor.toArray()
+				this.recordSqlBilling(op, cursor)
+			},
 		}
 	}
 
@@ -904,17 +1053,15 @@ class RunLogBase extends DurableObject<Env> {
 			clauses.push('r.surface = ?')
 			params.push(input.surface)
 		}
-		const row = this.ctx.storage.sql
-			.exec<Record<string, SqlStorageValue>>(
-				`SELECT r.*,
-					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
-				FROM runs r
-				WHERE ${clauses.join(' AND ')}
-				ORDER BY (r.status = 'running') DESC, r.started_at DESC, r.id DESC
-				LIMIT 1`,
-				...params,
-			)
-			.toArray()[0]
+		const row = this.execSqlTracked<Record<string, SqlStorageValue>>(
+			'findRunByIdempotencyKey',
+			`SELECT r.*
+			FROM runs r
+			WHERE ${clauses.join(' AND ')}
+			ORDER BY (r.status = 'running') DESC, r.started_at DESC, r.id DESC
+			LIMIT 1`,
+			...params,
+		).toArray()[0]
 		if (!row) return null
 		return mapRunRow(row, Number(row['log_count'] ?? 0) || 0)
 	}
@@ -1041,15 +1188,21 @@ class RunLogBase extends DurableObject<Env> {
 	}
 
 	private replaceLogs(runId: string, logs: Array<RunLogEntryInput>) {
-		this.ctx.storage.sql.exec(`DELETE FROM run_logs WHERE run_id = ?`, runId)
+		this.execSqlTracked(
+			'finishRun',
+			`DELETE FROM run_logs WHERE run_id = ?`,
+			runId,
+		).run()
 		const kept = logs.slice(-runRecordMaxLogEntriesPerRun)
+		let insertRowsRead = 0
+		let insertRowsWritten = 0
 		for (const [index, log] of kept.entries()) {
 			const message = truncateUtf8(String(log.message), runRecordMaxTextBytes)
 			const fieldsJson =
 				log.fieldsJson == null
 					? null
 					: clampMetadataJson(String(log.fieldsJson))
-			this.ctx.storage.sql.exec(
+			const cursor = this.ctx.storage.sql.exec(
 				`INSERT INTO run_logs (run_id, sequence, level, message, fields_json)
 				VALUES (?, ?, ?, ?, ?)`,
 				runId,
@@ -1058,7 +1211,22 @@ class RunLogBase extends DurableObject<Env> {
 				message,
 				fieldsJson,
 			)
+			cursor.toArray()
+			insertRowsRead += Number(cursor.rowsRead) || 0
+			insertRowsWritten += Number(cursor.rowsWritten) || 0
 		}
+		if (kept.length > 0) {
+			this.recordSqlBilling('finishRun', {
+				rowsRead: insertRowsRead,
+				rowsWritten: insertRowsWritten,
+			})
+		}
+		this.execSqlTracked(
+			'finishRun',
+			`UPDATE runs SET log_count = ? WHERE id = ?`,
+			kept.length,
+			runId,
+		).run()
 	}
 
 	private deleteRunsByIds(ids: Array<string>) {
@@ -1153,28 +1321,27 @@ class RunLogBase extends DurableObject<Env> {
 		const longLivedCutoff = new Date(
 			nowMs - runRecordStaleRunningTtlMsForSurface('workflow'),
 		).toISOString()
-		const candidates = this.ctx.storage.sql
-			.exec<{
-				id: string
-				started_at: string
-				surface: RunSurface
-				idempotency_key: string | null
-			}>(
-				`SELECT id, started_at, surface, idempotency_key FROM runs
-				WHERE status = 'running' AND (
-					(surface IN ('execute', 'export', 'retriever', 'webhook', 'subscription', 'app_fetch', 'app_realtime')
-						AND started_at < ?)
-					OR (surface = 'job' AND started_at < ?)
-					OR (surface = 'workflow' AND started_at < ?)
-				)
-				ORDER BY started_at ASC
-				LIMIT ?`,
-				shortLivedCutoff,
-				jobCutoff,
-				longLivedCutoff,
-				maxStaleRunningReconcilesPerPass,
+		const candidates = this.execSqlTracked<{
+			id: string
+			started_at: string
+			surface: RunSurface
+			idempotency_key: string | null
+		}>(
+			'reconcileStaleRunning',
+			`SELECT id, started_at, surface, idempotency_key FROM runs
+			WHERE status = 'running' AND (
+				(surface IN ('execute', 'export', 'retriever', 'webhook', 'subscription', 'app_fetch', 'app_realtime')
+					AND started_at < ?)
+				OR (surface = 'job' AND started_at < ?)
+				OR (surface = 'workflow' AND started_at < ?)
 			)
-			.toArray()
+			ORDER BY started_at ASC
+			LIMIT ?`,
+			shortLivedCutoff,
+			jobCutoff,
+			longLivedCutoff,
+			maxStaleRunningReconcilesPerPass,
+		).toArray()
 		let reconciled = 0
 		for (const row of candidates) {
 			if (
@@ -1219,16 +1386,14 @@ class RunLogBase extends DurableObject<Env> {
 			idempotencyKey: run.idempotencyKey,
 			startedAt: run.startedAt,
 		})
-		const healed = this.ctx.storage.sql
-			.exec<Record<string, SqlStorageValue>>(
-				`SELECT r.*,
-					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
-				FROM runs r
-				WHERE r.id = ?
-				LIMIT 1`,
-				run.id,
-			)
-			.toArray()[0]
+		const healed = this.execSqlTracked<Record<string, SqlStorageValue>>(
+			'healStaleRunning',
+			`SELECT r.*
+			FROM runs r
+			WHERE r.id = ?
+			LIMIT 1`,
+			run.id,
+		).toArray()[0]
 		if (!healed) return run
 		return mapRunRow(healed, Number(healed['log_count'] ?? 0) || 0)
 	}
@@ -1375,15 +1540,15 @@ class RunLogBase extends DurableObject<Env> {
 		this.reconcileStaleRunning()
 
 		const cutoff = new Date(Date.now() - retentionMs).toISOString()
-		const expired = this.ctx.storage.sql
-			.exec<{ id: string }>(
-				`SELECT id FROM runs
-				WHERE started_at < ? AND status != 'running'
-				ORDER BY started_at ASC
-				LIMIT ?`,
-				cutoff,
-				maxAgeDeletesPerFinish,
-			)
+		const expired = this.execSqlTracked<{ id: string }>(
+			'enforceRetention',
+			`SELECT id FROM runs
+			WHERE started_at < ? AND status != 'running'
+			ORDER BY started_at ASC
+			LIMIT ?`,
+			cutoff,
+			maxAgeDeletesPerFinish,
+		)
 			.toArray()
 			.map((row) => row.id)
 		this.deleteRunsByIds(expired)
@@ -2530,6 +2695,36 @@ class RunLogBase extends DurableObject<Env> {
 		}
 	}
 
+	/**
+	 * RunLog-only SQLite billing counters (SqlStorageCursor.rowsRead /
+	 * rowsWritten) for hot ops. Durable totals live in run_log_meta; the
+	 * isolate map is a fast path for the current lifetime.
+	 */
+	async getSqlBillingStats(): Promise<RunLogSqlBillingStats> {
+		const ops: Array<RunLogSqlBillingOpStats> = []
+		let rowsReadTotal = 0
+		let rowsWrittenTotal = 0
+		for (const op of runLogSqlBillingOps) {
+			const cached = this.sqlBillingByOp.get(op)
+			const rowsRead =
+				this.getMeta(sqlBillingMetaKey(op, 'rr')) ?? cached?.rowsRead ?? 0
+			const rowsWritten =
+				this.getMeta(sqlBillingMetaKey(op, 'rw')) ?? cached?.rowsWritten ?? 0
+			const calls =
+				this.getMeta(sqlBillingMetaKey(op, 'n')) ?? cached?.calls ?? 0
+			if (rowsRead === 0 && rowsWritten === 0 && calls === 0) continue
+			ops.push({ op, rowsRead, rowsWritten, calls })
+			rowsReadTotal += rowsRead
+			rowsWrittenTotal += rowsWritten
+		}
+		return {
+			databaseSize: this.ctx.storage.sql.databaseSize,
+			rowsReadTotal,
+			rowsWrittenTotal,
+			ops,
+		}
+	}
+
 	private getJobRunObservabilitySync(
 		jobId: string,
 	): JobRunObservabilityRecord | null {
@@ -2641,17 +2836,15 @@ class RunLogBase extends DurableObject<Env> {
 			}
 		}
 		params.push(limit + 1)
-		const rows = this.ctx.storage.sql
-			.exec<Record<string, SqlStorageValue>>(
-				`SELECT r.*,
-					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
-				FROM runs r
-				WHERE ${clauses.join(' AND ')}
-				ORDER BY r.started_at DESC, r.id DESC
-				LIMIT ?`,
-				...params,
-			)
-			.toArray()
+		const rows = this.execSqlTracked<Record<string, SqlStorageValue>>(
+			'listRuns',
+			`SELECT r.*
+			FROM runs r
+			WHERE ${clauses.join(' AND ')}
+			ORDER BY r.started_at DESC, r.id DESC
+			LIMIT ?`,
+			...params,
+		).toArray()
 		const hasMore = rows.length > limit
 		const pageRows = hasMore ? rows.slice(0, limit) : rows
 		const runs = pageRows.map((row) =>
@@ -2671,25 +2864,23 @@ class RunLogBase extends DurableObject<Env> {
 	async getRun(input: {
 		runId: string
 	}): Promise<{ run: RunRecord; logs: Array<RunRecordLog> } | null> {
-		const row = this.ctx.storage.sql
-			.exec<Record<string, SqlStorageValue>>(
-				`SELECT r.*,
-					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
-				FROM runs r
-				WHERE r.id = ?
-				LIMIT 1`,
-				input.runId,
-			)
-			.toArray()[0]
+		const row = this.execSqlTracked<Record<string, SqlStorageValue>>(
+			'getRun',
+			`SELECT r.*
+			FROM runs r
+			WHERE r.id = ?
+			LIMIT 1`,
+			input.runId,
+		).toArray()[0]
 		if (!row) return null
 		const run = this.healStaleRunningRecord(
 			mapRunRow(row, Number(row['log_count'] ?? 0) || 0),
 		)
-		const logs = this.ctx.storage.sql
-			.exec<Record<string, SqlStorageValue>>(
-				`SELECT * FROM run_logs WHERE run_id = ? ORDER BY sequence ASC`,
-				input.runId,
-			)
+		const logs = this.execSqlTracked<Record<string, SqlStorageValue>>(
+			'getRun',
+			`SELECT * FROM run_logs WHERE run_id = ? ORDER BY sequence ASC`,
+			input.runId,
+		)
 			.toArray()
 			.map(mapLogRow)
 		return {
@@ -2701,44 +2892,46 @@ class RunLogBase extends DurableObject<Env> {
 	async summarize(input: { since: string }): Promise<RunRecordSummary> {
 		this.reconcileStaleRunning()
 		const since = input.since
-		const totals = this.ctx.storage.sql
-			.exec<{
-				total: number
-				errors: number
-				ignored: number
-				resolved: number
-				running: number
-			}>(
-				`SELECT
-					COUNT(*) AS total,
-					SUM(CASE
-						WHEN status = 'error' AND error_triage IS NULL THEN 1
-						ELSE 0
-					END) AS errors,
-					SUM(CASE WHEN error_triage = 'ignored' THEN 1 ELSE 0 END) AS ignored,
-					SUM(CASE WHEN error_triage = 'resolved' THEN 1 ELSE 0 END) AS resolved,
-					SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running
-				FROM runs
-				WHERE started_at >= ?`,
-				since,
-			)
-			.one()
-		const bySurfaceRows = this.ctx.storage.sql
-			.exec<{ surface: string; total: number; errors: number }>(
-				`SELECT
-					surface,
-					COUNT(*) AS total,
-					SUM(CASE
-						WHEN status = 'error' AND error_triage IS NULL THEN 1
-						ELSE 0
-					END) AS errors
-				FROM runs
-				WHERE started_at >= ?
-				GROUP BY surface
-				ORDER BY surface ASC`,
-				since,
-			)
-			.toArray()
+		const totals = this.execSqlTracked<{
+			total: number
+			errors: number
+			ignored: number
+			resolved: number
+			running: number
+		}>(
+			'summarize',
+			`SELECT
+				COUNT(*) AS total,
+				SUM(CASE
+					WHEN status = 'error' AND error_triage IS NULL THEN 1
+					ELSE 0
+				END) AS errors,
+				SUM(CASE WHEN error_triage = 'ignored' THEN 1 ELSE 0 END) AS ignored,
+				SUM(CASE WHEN error_triage = 'resolved' THEN 1 ELSE 0 END) AS resolved,
+				SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running
+			FROM runs
+			WHERE started_at >= ?`,
+			since,
+		).one()
+		const bySurfaceRows = this.execSqlTracked<{
+			surface: string
+			total: number
+			errors: number
+		}>(
+			'summarize',
+			`SELECT
+				surface,
+				COUNT(*) AS total,
+				SUM(CASE
+					WHEN status = 'error' AND error_triage IS NULL THEN 1
+					ELSE 0
+				END) AS errors
+			FROM runs
+			WHERE started_at >= ?
+			GROUP BY surface
+			ORDER BY surface ASC`,
+			since,
+		).toArray()
 		return {
 			since,
 			total: Number(totals.total ?? 0) || 0,
@@ -2766,16 +2959,14 @@ class RunLogBase extends DurableObject<Env> {
 	async updateRunErrorTriage(
 		input: UpdateRunErrorTriageInput,
 	): Promise<UpdateRunErrorTriageResult> {
-		const existing = this.ctx.storage.sql
-			.exec<Record<string, SqlStorageValue>>(
-				`SELECT r.*,
-					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
-				FROM runs r
-				WHERE r.id = ?
-				LIMIT 1`,
-				input.runId,
-			)
-			.toArray()[0]
+		const existing = this.execSqlTracked<Record<string, SqlStorageValue>>(
+			'updateRunErrorTriage',
+			`SELECT r.*
+			FROM runs r
+			WHERE r.id = ?
+			LIMIT 1`,
+			input.runId,
+		).toArray()[0]
 		if (!existing) return { ok: false, reason: 'not_found' }
 
 		const current = mapRunRow(existing, Number(existing['log_count'] ?? 0) || 0)
@@ -2829,16 +3020,14 @@ class RunLogBase extends DurableObject<Env> {
 			input.runId,
 		)
 
-		const updated = this.ctx.storage.sql
-			.exec<Record<string, SqlStorageValue>>(
-				`SELECT r.*,
-					(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
-				FROM runs r
-				WHERE r.id = ?
-				LIMIT 1`,
-				input.runId,
-			)
-			.toArray()[0]
+		const updated = this.execSqlTracked<Record<string, SqlStorageValue>>(
+			'updateRunErrorTriage',
+			`SELECT r.*
+			FROM runs r
+			WHERE r.id = ?
+			LIMIT 1`,
+			input.runId,
+		).toArray()[0]
 		if (!updated) return { ok: false, reason: 'not_found' }
 		return {
 			ok: true,
@@ -3266,9 +3455,9 @@ class RunLogBase extends DurableObject<Env> {
 			case 'runs': {
 				const rows = (
 					input.startAfterId
-						? this.ctx.storage.sql.exec<Record<string, SqlStorageValue>>(
-								`SELECT r.*,
-									(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
+						? this.execSqlTracked<Record<string, SqlStorageValue>>(
+								'exportRuns',
+								`SELECT r.*
 								FROM runs r
 								WHERE r.id > ?
 								ORDER BY r.id ASC
@@ -3276,9 +3465,9 @@ class RunLogBase extends DurableObject<Env> {
 								input.startAfterId,
 								limit + 1,
 							)
-						: this.ctx.storage.sql.exec<Record<string, SqlStorageValue>>(
-								`SELECT r.*,
-									(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count
+						: this.execSqlTracked<Record<string, SqlStorageValue>>(
+								'exportRuns',
+								`SELECT r.*
 								FROM runs r
 								ORDER BY r.id ASC
 								LIMIT ?`,
@@ -3292,11 +3481,11 @@ class RunLogBase extends DurableObject<Env> {
 				)
 				const logs: Array<RunRecordLog> = []
 				for (const run of runs) {
-					const runLogs = this.ctx.storage.sql
-						.exec<Record<string, SqlStorageValue>>(
-							`SELECT * FROM run_logs WHERE run_id = ? ORDER BY sequence ASC`,
-							run.id,
-						)
+					const runLogs = this.execSqlTracked<Record<string, SqlStorageValue>>(
+						'exportRuns',
+						`SELECT * FROM run_logs WHERE run_id = ? ORDER BY sequence ASC`,
+						run.id,
+					)
 						.toArray()
 						.map(mapLogRow)
 					logs.push(...runLogs)
@@ -3437,6 +3626,7 @@ class RunLogBase extends DurableObject<Env> {
 		this.retentionIdleConfirmed = true
 		this.runCountCache = null
 		this.finishesSinceRetentionCache = null
+		this.sqlBillingByOp.clear()
 		this.initializeSchema()
 		this.setMeta(metaRunCountKey, 0)
 		this.setMeta(metaFinishesSinceRetentionKey, 0)
@@ -3538,6 +3728,7 @@ export type RunLogRpc = DurableObjectPitrRpc & {
 		jobIds: Array<string>
 	}) => Promise<Array<JobRunObservabilityRecord>>
 	getAdminInsightsSnapshot: () => Promise<RunLogAdminInsightsSnapshot>
+	getSqlBillingStats: () => Promise<RunLogSqlBillingStats>
 	listPackageRunSuccesses: () => Promise<Array<PackageRunSuccessRecord>>
 	listActivationMilestones: () => Promise<Array<ActivationMilestoneRecord>>
 	summarize: (input: { since: string }) => Promise<RunRecordSummary>

--- a/packages/worker/src/run-records/run-records.workers.test.ts
+++ b/packages/worker/src/run-records/run-records.workers.test.ts
@@ -290,6 +290,18 @@ test('logs round-trip in sequence order and keep only the newest 200', async () 
 	expect(detail?.logs.at(-1)?.sequence).toBe(runRecordMaxLogEntriesPerRun - 1)
 	expect(detail?.logs.at(-1)?.message).toBe(`log-${totalLogs - 1}`)
 	expect(detail?.run.logCount).toBe(runRecordMaxLogEntriesPerRun)
+
+	const stub = env.RUN_LOG.get(env.RUN_LOG.idFromName(userId))
+	await runInDurableObject(stub, async (_instance: RunLog, state) => {
+		expect(
+			state.storage.sql
+				.exec<{ log_count: number }>(
+					`SELECT log_count FROM runs WHERE id = ?`,
+					handle!.id,
+				)
+				.one(),
+		).toEqual({ log_count: runRecordMaxLogEntriesPerRun })
+	})
 })
 
 test('listRunRecords filters by surface/status/jobId/name and paginates with cursors', async () => {

--- a/packages/worker/src/run-records/service.node.test.ts
+++ b/packages/worker/src/run-records/service.node.test.ts
@@ -13,6 +13,12 @@ const mocks = vi.hoisted(() => ({
 		activationMilestones: [],
 		jobRunCounts: { success: 0, error: 0 },
 	})),
+	getSqlBillingStats: vi.fn(async () => ({
+		databaseSize: 0,
+		rowsReadTotal: 0,
+		rowsWrittenTotal: 0,
+		ops: [],
+	})),
 }))
 
 vi.mock('./package-subscriptions.ts', () => ({
@@ -23,6 +29,7 @@ const {
 	beginRunRecord,
 	finishRunRecord,
 	getAdminInsightsSnapshot,
+	getSqlBillingStats,
 	listActivationMilestones,
 	listPackageRunSuccesses,
 	recordRunRecord,
@@ -38,6 +45,7 @@ function createEnv(overrides: Partial<Env> = {}) {
 				listPackageRunSuccesses: mocks.listPackageRunSuccesses,
 				listActivationMilestones: mocks.listActivationMilestones,
 				getAdminInsightsSnapshot: mocks.getAdminInsightsSnapshot,
+				getSqlBillingStats: mocks.getSqlBillingStats,
 			}),
 		},
 		APP_DB: {},
@@ -294,5 +302,25 @@ test('getAdminInsightsSnapshot requires RUN_LOG and forwards the RPC', async () 
 				packageId: 'pkg-1',
 			},
 		],
+	})
+})
+
+test('getSqlBillingStats requires RUN_LOG and forwards the RPC', async () => {
+	await expect(
+		getSqlBillingStats({ env: {} as Env, userId: 'user-1' }),
+	).rejects.toThrow('RUN_LOG Durable Object binding is not configured.')
+
+	mocks.getSqlBillingStats.mockResolvedValueOnce({
+		databaseSize: 4096,
+		rowsReadTotal: 12,
+		rowsWrittenTotal: 3,
+		ops: [{ op: 'listRuns', rowsRead: 12, rowsWritten: 0, calls: 1 }],
+	})
+	const env = createEnv()
+	await expect(getSqlBillingStats({ env, userId: 'user-1' })).resolves.toEqual({
+		databaseSize: 4096,
+		rowsReadTotal: 12,
+		rowsWrittenTotal: 3,
+		ops: [{ op: 'listRuns', rowsRead: 12, rowsWritten: 0, calls: 1 }],
 	})
 })

--- a/packages/worker/src/run-records/service.ts
+++ b/packages/worker/src/run-records/service.ts
@@ -18,6 +18,7 @@ import {
 	type RunLogEntryInput,
 	type RunLogRowInput,
 	type RunLogRpc,
+	type RunLogSqlBillingStats,
 } from './run-log-do.ts'
 import {
 	type WorkflowProjectionRecord,
@@ -1108,6 +1109,23 @@ export async function getAdminInsightsSnapshot(input: {
 		env: input.env,
 		userId: input.userId,
 	}).getAdminInsightsSnapshot()
+}
+
+/**
+ * RunLog-only SQLite rowsRead/rowsWritten counters for cost diagnosis.
+ * Propagates binding/RPC errors. Never returns user content.
+ */
+export async function getSqlBillingStats(input: {
+	env: Env
+	userId: string
+}): Promise<RunLogSqlBillingStats> {
+	if (!runLogBinding(input.env)) {
+		throw new Error('RUN_LOG Durable Object binding is not configured.')
+	}
+	return await runLogRpc({
+		env: input.env,
+		userId: input.userId,
+	}).getSqlBillingStats()
 }
 
 export async function getJobRunObservabilityBatch(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop RunLog Durable Object SQLite from burning ~98% of account rows-read on correlated `COUNT(*)` over `run_logs` for every list/get/export (hottest object: kentcdodds).

## Why

Production GraphQL attribution (Aug–Sep) showed RunLog ≈ 97.8–99.8% of DO SQLite rows-read. The hot SQL pattern was `(SELECT COUNT(*) FROM run_logs l WHERE l.run_id = r.id) AS log_count` on `listRuns` / `getRun` / heal / triage / export.

## Summary

- Schema **v11**: denormalized `runs.log_count INTEGER NOT NULL DEFAULT 0`
- One-time warm backfill; `replaceLogs` maintains the column on insert/replace
- Dropped correlated subquery from all read paths (`SELECT r.*` + column)
- RunLog-only SQL billing counters via `execSqlTracked` → atomic `run_log_meta` increments + `getSqlBillingStats` RPC (no new Analytics Engine dataset; `USAGE_EVENTS` would inflate billed overage)
- Tests: schema migrate/backfill, denormalized column after finish, billing RPC forwarding

## Testing

- `vitest` run-records suites: 48 passed (dedicated-state, run-records, continuity, invocation-ledger, service.node)
- Pre-push `worker:test-workers`: 349 passed
- `npm run typecheck` / commit hooks green

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends run-records</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `79a9a1fc` · **Head:** `9374c7bd`

**Classification:** extends — changes RunLog SQLite schema and read SQL for the run-records primitive; no new primitives.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `run-records` | storage | extends — denormalized `runs.log_count`, schema v11 migrate/backfill, remove correlated `run_logs` COUNT on list/get/export; add RunLog-only SQL billing meta + `getSqlBillingStats` |

### Change flow

List/get no longer scan `run_logs` per row for `logCount`; finish writes maintain the column.

```mermaid
sequenceDiagram
	participant reader as listRuns/getRun/export
	participant runLog as RunLog DO
	participant runs as runs.log_count
	participant logs as run_logs
	reader->>runLog: list/get/export
	runLog->>runs: SELECT r.* (log_count column)
	Note over runLog,logs: no correlated COUNT(*)
	participant finish as finishRun/replaceLogs
	finish->>logs: DELETE+INSERT kept logs
	finish->>runs: UPDATE log_count = kept.length
```

### Before / after

| Before | After |
| --- | --- |
| Every list/get row pays `COUNT(*)` over that run’s `run_logs` | `log_count` column on `runs`; one-time v11 backfill |
| No per-op rowsRead visibility on RunLog | `getSqlBillingStats` + `run_log_meta` `sql_{rr,rw,n}_*` |

### Risk and invariants

- Medium: warm migrate scans `run_logs` once per object on first visit after deploy
- Per-user DO isolation unchanged; only RunLog class instrumented
- No price/plan changes; no new AE dataset

### Docs / follow-ups

- After deploy, call `getSqlBillingStats` on the hot user DO to confirm listRuns rowsRead drops vs pre-fix GraphQL window

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-032834ca-94ba-4006-8d74-3394aa0df825?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-032834ca-94ba-4006-8d74-3394aa0df825&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL usage statistics for diagnosing database activity, including rows read, rows written, and operation counts.
  * Added a service API for retrieving SQL billing statistics.
  * Run records now maintain log counts for faster list, search, export, and detail views.

* **Bug Fixes**
  * Existing records are automatically updated with accurate log counts during migration.
  * Log count values now remain accurate when logs are added or capped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->