### PR TITLE
Stop baking execute params into Dynamic Worker harness

### DIFF
--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -216,10 +216,12 @@ contract changes), the `LOADER` binding name, the acting `userId` and
 graph (agent code plus the generated executor harness).
 
 Timeout, `allowOutboundFetch`, and the excluded fetch hostname are baked into
-that harness text, so they are not hashed again. Deploy SHA (`APP_COMMIT_SHA`),
-email, and other request-only `gatewayProps` fields are not part of the key: a
-parent deploy remints ids only when the harness or module graph actually
-changes.
+that harness text, so they are not hashed again. Execute `params`,
+`packageContext`, and live MCP connect/tool metadata arrive on `evaluate` RPC
+and are not part of the key: the same user and module graph reuse one isolate
+when only those per-call values change. Deploy SHA (`APP_COMMIT_SHA`), email,
+and other request-only `gatewayProps` fields are also omitted, so a parent
+deploy remints ids only when the harness or module graph actually changes.
 
 `userId` and `storageContext` stay in the key because `LOADER.get` reuses the
 first factory's WorkerCode for a given id, including the `KodyFetchGateway`

--- a/docs/contributing/architecture/usage-metering.md
+++ b/docs/contributing/architecture/usage-metering.md
@@ -217,11 +217,13 @@ graph (agent code plus the generated executor harness).
 
 Timeout, `allowOutboundFetch`, and the excluded fetch hostname are baked into
 that harness text, so they are not hashed again. Execute `params`,
-`packageContext`, and live MCP connect/tool metadata arrive on `evaluate` RPC
-and are not part of the key: the same user and module graph reuse one isolate
-when only those per-call values change. Deploy SHA (`APP_COMMIT_SHA`), email,
-and other request-only `gatewayProps` fields are also omitted, so a parent
-deploy remints ids only when the harness or module graph actually changes.
+`packageContext`, live MCP connect/tool metadata, and the unstamped
+`packageSecrets` binding (present only when that evaluate's package id is set)
+arrive on `evaluate` RPC and are not part of the key: the same user and module
+graph reuse one isolate when only those per-call values change. Deploy SHA
+(`APP_COMMIT_SHA`), email, and other request-only `gatewayProps` fields are also
+omitted, so a parent deploy remints ids only when the harness or module graph
+actually changes.
 
 `userId` and `storageContext` stay in the key because `LOADER.get` reuses the
 first factory's WorkerCode for a given id, including the `KodyFetchGateway`

--- a/docs/guides/platform-efficiency.md
+++ b/docs/guides/platform-efficiency.md
@@ -50,7 +50,8 @@ The same meter is tagged with the surface that minted the isolate:
 
 Saved packages, jobs, and other durable surfaces reuse a stable isolate when the
 published module graph stays the same. Ad hoc `execute` identity follows the
-module graph of that execute run — put varying args in `params`, not literals in
+acting user plus the module graph of that execute run. Varying `params` and
+`packageContext` reuse that isolate — put args in `params`, not literals in
 `code`:
 
 ```ts

--- a/docs/use/execute.md
+++ b/docs/use/execute.md
@@ -303,8 +303,8 @@ limit, current usage, upgrade hint). Daily quota denials add compact `used` and
 results omit `entitlement`.
 
 Dynamic Worker identity for an execute run follows the acting user and that
-module graph, so the same user and graph reuse one isolate for the UTC day. The
-cost model is documented once in
+module graph. The same user and graph reuse one isolate for the UTC day when
+only `params` or `packageContext` change. The cost model is documented once in
 [Platform efficiency](../guides/platform-efficiency.md).
 
 For memory mutations, the workflow is explicit and strict:

--- a/packages/worker/src/mcp/dynamic-worker-id.node.test.ts
+++ b/packages/worker/src/mcp/dynamic-worker-id.node.test.ts
@@ -35,7 +35,7 @@ async function mintId(input: {
 	})
 }
 
-test('createStableDynamicWorkerId is stable for the same modules, user, and storage context', async () => {
+test('createStableDynamicWorkerId is stable for the same modules, user, and storage context and ignores evaluate-time params', async () => {
 	const modules = {
 		'executor.js': 'export default class Executor { evaluate() { return 1 } }',
 	}
@@ -49,6 +49,8 @@ test('createStableDynamicWorkerId is stable for the same modules, user, and stor
 	const second = await mintId({ modules, storageContext })
 	expect(first).toBe(second)
 	expect(first).toMatch(/^kody-[A-Za-z0-9_-]{43}$/)
+	// Same modules + user + storage mint one id. Evaluate-time params and
+	// packageContext are not hash inputs; they must not appear in `modules`.
 
 	expect(await mintId({ modules, storageContext, userId: 'user-1' })).toBe(
 		first,

--- a/packages/worker/src/mcp/dynamic-worker-id.ts
+++ b/packages/worker/src/mcp/dynamic-worker-id.ts
@@ -9,7 +9,7 @@ export const dynamicWorkerIdPrefix = 'kody-'
  * Sandbox-contract / cache-key version. Bump only when the executor harness
  * or LOADER identity contract changes — not on every parent commit.
  */
-export const dynamicWorkerCacheKeyVersion = 6
+export const dynamicWorkerCacheKeyVersion = 7
 
 export type DynamicWorkerIdOptions = {
 	compatibilityDate: string

--- a/packages/worker/src/mcp/dynamic-worker-id.ts
+++ b/packages/worker/src/mcp/dynamic-worker-id.ts
@@ -9,7 +9,7 @@ export const dynamicWorkerIdPrefix = 'kody-'
  * Sandbox-contract / cache-key version. Bump only when the executor harness
  * or LOADER identity contract changes — not on every parent commit.
  */
-export const dynamicWorkerCacheKeyVersion = 5
+export const dynamicWorkerCacheKeyVersion = 6
 
 export type DynamicWorkerIdOptions = {
 	compatibilityDate: string
@@ -25,8 +25,9 @@ export type DynamicWorkerIdOptions = {
  * knobs, an explicit contract version, and the acting-user facets bound on
  * `globalOutbound` (`userId`, `storageContext`). `LOADER.get` reuses the
  * first factory's WorkerCode for a given id, including that gateway stub, so
- * those facets stay in the key. Deploy SHA, email, and other request-only
- * gateway fields do not.
+ * those facets stay in the key. Deploy SHA, email, execute `params`,
+ * `packageContext`, live MCP connect/tool metadata, and other request-only
+ * fields do not — those arrive on `evaluate` RPC.
  *
  * UUID fallback when modules are not deterministically hashable.
  */

--- a/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
+++ b/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
@@ -114,3 +114,83 @@ test(
 		})
 	},
 )
+
+test(
+	'sequential executes with the same code and different params reuse the isolate and deliver params',
+	{ timeout: 60_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		const bundle = await buildKodyModuleBundle({
+			env: reuseEnv,
+			baseUrl: 'https://kody.dev',
+			userId: 'user-reuse-test',
+			sourceFiles: {
+				'entry.ts': [
+					"import { kody, packageContext } from 'kody:runtime'",
+					'export default async function main(params) {',
+					'\treturn {',
+					'\t\tparams,',
+					'\t\tpackageId: packageContext?.packageId ?? null,',
+					'\t\tping: await kody.ping_capability({ query: params.room }),',
+					'\t}',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+
+		const runOnce = async (
+			label: string,
+			params: { room: string },
+			packageContext?: { packageId: string; kodyId: string },
+		) =>
+			await runBundledModuleWithRegistry(
+				reuseEnv,
+				createCaller(),
+				{
+					mainModule: bundle.mainModule,
+					modules: bundle.modules,
+				},
+				params,
+				{
+					skipCapabilityRegistry: true,
+					...(packageContext ? { packageContext } : {}),
+					additionalTools: {
+						ping_capability: async (args: unknown) => ({
+							ok: true,
+							label,
+							args,
+						}),
+					},
+				},
+			)
+
+		const first = await runOnce('first', { room: 'office' })
+		expect(first.error).toBeUndefined()
+		expect(first.result).toEqual({
+			params: { room: 'office' },
+			packageId: null,
+			ping: { ok: true, label: 'first', args: { query: 'office' } },
+		})
+
+		const second = await runOnce('second', { room: 'kitchen' })
+		expect(second.error).toBeUndefined()
+		expect(second.result).toEqual({
+			params: { room: 'kitchen' },
+			packageId: null,
+			ping: { ok: true, label: 'second', args: { query: 'kitchen' } },
+		})
+
+		const third = await runOnce(
+			'third',
+			{ room: 'office' },
+			{ packageId: 'pkg-reuse', kodyId: 'bot-reuse' },
+		)
+		expect(third.error).toBeUndefined()
+		expect(third.result).toEqual({
+			params: { room: 'office' },
+			packageId: 'pkg-reuse',
+			ping: { ok: true, label: 'third', args: { query: 'office' } },
+		})
+	},
+)

--- a/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
+++ b/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
@@ -198,3 +198,105 @@ test(
 		})
 	},
 )
+
+test(
+	'module-scope packageContext capture still late-binds across evaluate reuse',
+	{ timeout: 60_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		const bundle = await buildKodyModuleBundle({
+			env: reuseEnv,
+			baseUrl: 'https://kody.dev',
+			userId: 'user-reuse-test',
+			sourceFiles: {
+				'entry.ts': [
+					"import { packageContext } from 'kody:runtime'",
+					'const capturedContext = packageContext',
+					'export default async function main() {',
+					'\treturn { packageId: capturedContext?.packageId ?? null }',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+
+		const runOnce = async (packageContext: {
+			packageId: string
+			kodyId: string
+		}) =>
+			await runBundledModuleWithRegistry(
+				reuseEnv,
+				createCaller(),
+				{
+					mainModule: bundle.mainModule,
+					modules: bundle.modules,
+				},
+				undefined,
+				{
+					skipCapabilityRegistry: true,
+					packageContext,
+				},
+			)
+
+		const first = await runOnce({ packageId: 'pkg-a', kodyId: 'bot-a' })
+		const second = await runOnce({ packageId: 'pkg-b', kodyId: 'bot-b' })
+		expect(first.error).toBeUndefined()
+		expect(second.error).toBeUndefined()
+		expect(first.result).toEqual({ packageId: 'pkg-a' })
+		expect(second.result).toEqual({ packageId: 'pkg-b' })
+	},
+)
+
+test(
+	'mutating packageContext.packageId cannot retarget unstamped packageSecrets',
+	{ timeout: 60_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		const bundle = await buildKodyModuleBundle({
+			env: reuseEnv,
+			baseUrl: 'https://kody.dev',
+			userId: 'user-reuse-test',
+			sourceFiles: {
+				'entry.ts': [
+					"import { packageContext, packageSecrets } from 'kody:runtime'",
+					'export default async function main() {',
+					'\tlet mutationError = null',
+					'\ttry {',
+					"\t\tpackageContext.packageId = 'pkg-attacker'",
+					'\t} catch (error) {',
+					'\t\tmutationError = error instanceof Error ? error.message : String(error)',
+					'\t}',
+					'\treturn {',
+					'\t\tpackageId: packageContext?.packageId ?? null,',
+					'\t\tsecretsBound: "get" in packageSecrets,',
+					'\t\tmutationError,',
+					'\t}',
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+
+		const result = await runBundledModuleWithRegistry(
+			reuseEnv,
+			createCaller(),
+			{
+				mainModule: bundle.mainModule,
+				modules: bundle.modules,
+			},
+			undefined,
+			{
+				skipCapabilityRegistry: true,
+				packageContext: { packageId: 'pkg-trusted', kodyId: 'bot-trusted' },
+			},
+		)
+		expect(result.error).toBeUndefined()
+		expect(result.result).toEqual({
+			packageId: 'pkg-trusted',
+			secretsBound: true,
+			mutationError: expect.stringMatching(
+				/trap returned falsish|cannot assign|read.only|frozen/i,
+			),
+		})
+	},
+)

--- a/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
+++ b/packages/worker/src/mcp/execute-dynamic-worker-reuse.workers.test.ts
@@ -126,11 +126,12 @@ test(
 			userId: 'user-reuse-test',
 			sourceFiles: {
 				'entry.ts': [
-					"import { kody, packageContext } from 'kody:runtime'",
+					"import { kody, packageContext, packageSecrets } from 'kody:runtime'",
 					'export default async function main(params) {',
 					'\treturn {',
 					'\t\tparams,',
 					'\t\tpackageId: packageContext?.packageId ?? null,',
+					'\t\tsecretsBound: "get" in packageSecrets,',
 					'\t\tping: await kody.ping_capability({ query: params.room }),',
 					'\t}',
 					'}',
@@ -170,6 +171,7 @@ test(
 		expect(first.result).toEqual({
 			params: { room: 'office' },
 			packageId: null,
+			secretsBound: false,
 			ping: { ok: true, label: 'first', args: { query: 'office' } },
 		})
 
@@ -178,6 +180,7 @@ test(
 		expect(second.result).toEqual({
 			params: { room: 'kitchen' },
 			packageId: null,
+			secretsBound: false,
 			ping: { ok: true, label: 'second', args: { query: 'kitchen' } },
 		})
 
@@ -190,6 +193,7 @@ test(
 		expect(third.result).toEqual({
 			params: { room: 'office' },
 			packageId: 'pkg-reuse',
+			secretsBound: true,
 			ping: { ok: true, label: 'third', args: { query: 'office' } },
 		})
 	},

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -1751,6 +1751,17 @@ test('executor maps secret errors, formats guidance, extracts raw content, and t
 		kind: 'runtime_helper_unbound',
 		helperName: 'secretHeaders',
 	})
+	expect(
+		getExecutionErrorDetails(
+			new Error(
+				'kody:runtime export "packageSecrets" is not available in this execution context.',
+			),
+		),
+	).toMatchObject({
+		kind: 'runtime_helper_unbound',
+		helperName: 'packageSecrets',
+		suggestedAction: { type: 'fix_code' },
+	})
 	// The bare TypeError alone stays unhinted: without the rewrite marker the
 	// undefined value may be any user-code bug.
 	expect(

--- a/packages/worker/src/mcp/executor.node.test.ts
+++ b/packages/worker/src/mcp/executor.node.test.ts
@@ -43,9 +43,10 @@ type FakeWorkerOptions = Record<string, unknown>
 function createFakeWorkerLoader() {
 	const ids: Array<string> = []
 	const createdOptions = new Map<string, FakeWorkerOptions>()
-	const evaluations: Array<
-		Record<string, { call: typeof ToolDispatcherCall }>
-	> = []
+	const evaluations: Array<{
+		dispatchers: Record<string, { call: typeof ToolDispatcherCall }>
+		invocation: unknown
+	}> = []
 	let factoryCallCount = 0
 	const loader = {
 		get(id: string, factory: () => FakeWorkerOptions) {
@@ -61,8 +62,9 @@ function createFakeWorkerLoader() {
 					return {
 						async evaluate(
 							dispatchers: Record<string, { call: typeof ToolDispatcherCall }>,
+							invocation?: unknown,
 						) {
-							evaluations.push(dispatchers)
+							evaluations.push({ dispatchers, invocation })
 							return {
 								result: id,
 								logs: [],
@@ -242,98 +244,22 @@ test('kody namespaced proxy enumerates advertised tools on a disconnected server
 	)
 })
 
-test('generated kody provider source projects namespaced proxy metadata', () => {
+test('generated kody provider source reads MCP metadata from evaluate invocation', () => {
 	const source = createKodyProviderProxySource({
 		providerName: 'kody',
-		mcpServers: [
-			{
-				name: 'docs',
-				serverId: 'docs-server',
-				status: {
-					state: 'connected',
-					connected: true,
-					toolCount: 2,
-					message: 'The MCP server "docs" is connected.',
-					unavailableMessage: 'The MCP server "docs" is connected.',
-				},
-				capabilities: [
-					{
-						name: 'search',
-						dispatchName: 'mcpdocssearch',
-					},
-				],
-			},
-			{
-				name: 'home',
-				serverId: 'home-server',
-				status: {
-					state: 'connected',
-					connected: true,
-					toolCount: 1,
-					message: 'The MCP server "home" is connected.',
-					unavailableMessage: 'The MCP server "home" is connected.',
-				},
-				capabilities: [
-					{
-						name: 'set_pin',
-						dispatchName: 'mcphomeset_pin',
-					},
-				],
-			},
-		],
 	})
 
-	expect(source).toContain('"unavailableMessage":')
-	expect(source).toContain('"toolCount":')
-	expect(source).toContain('"dispatchName":"mcphomeset_pin"')
-	expect(source).toContain('"dispatchName":"mcpdocssearch"')
-})
-
-test('generated kody provider source ignores volatile metadata fields for script identity', () => {
-	const baseServers = [
-		{
-			name: 'home',
-			serverId: 'home-a',
-			status: {
-				state: 'connected' as const,
-				connected: true,
-				toolCount: 1,
-				message: 'status prose A',
-				unavailableMessage: 'The MCP server "home" is connected.',
-			},
-			capabilities: [
-				{
-					name: 'set_pin',
-					dispatchName: 'mcphomeset_pin',
-				},
-			],
-		},
-	]
-	const first = createKodyProviderProxySource({
-		providerName: 'kody',
-		mcpServers: [...baseServers],
-	})
-	const second = createKodyProviderProxySource({
-		providerName: 'kody',
-		mcpServers: [
-			{
-				...baseServers[0]!,
-				serverId: 'home-b',
-				status: {
-					...baseServers[0]!.status,
-					state: 'degraded',
-					message: 'status prose B — different volatile text',
-				},
-			},
-		],
-	})
-	expect(second).toBe(first)
+	expect(source).toContain('__invocation.mcpServers')
+	expect(source).toBe(
+		createKodyProviderProxySource({
+			providerName: 'kody',
+		}),
+	)
 })
 
 test('generated kody provider and executor module sources stay bundle-safe', () => {
 	const source = createKodyProviderProxySource({
 		providerName: 'kody',
-		mcpServers: [],
 	})
 	assertGeneratedExecutorSourceIsBundleSafe(source)
 
@@ -354,6 +280,11 @@ test('generated kody provider and executor module sources stay bundle-safe', () 
 	expect(moduleSource).toContain('.call("recordFetch", "[]")')
 	expect(moduleSource).toContain('const __kodyMcp =')
 	expect(moduleSource).toContain('getOwnPropertyDescriptor')
+	expect(moduleSource).toContain(
+		'async evaluate(__dispatchers = {}, __invocation = {})',
+	)
+	expect(moduleSource).toContain(')(__invocation)')
+	expect(moduleSource).toContain('__invocation.mcpServers')
 })
 
 test('closed-world executor module rejects fetch in the sandbox before outbound RPC', () => {
@@ -390,34 +321,39 @@ test('generated kody provider source wires mcp proxy dispatch', async () => {
 	const calls: Array<{ name: string; argsJson: string }> = []
 	const source = createKodyProviderProxySource({
 		providerName: 'kody',
-		mcpServers: [
-			{
-				name: 'home',
-				serverId: 'home',
-				status: {
-					state: 'connected',
-					connected: true,
-					toolCount: 1,
-					message: 'The MCP server "home" is connected.',
-					unavailableMessage: 'The MCP server "home" is connected.',
-				},
-				capabilities: [
-					{
-						name: 'set_pin',
-						dispatchName: 'mcphomeset_pin',
-					},
-				],
-			},
-		],
 	})
-	const kody = new Function('__dispatchers', `${source}; return kody;`)({
-		kody: {
-			async call(name: string, argsJson: string) {
-				calls.push({ name, argsJson })
-				return JSON.stringify({ result: { ok: true } })
+	const kody = new Function(
+		'__dispatchers',
+		'__invocation',
+		`${source}; return kody;`,
+	)(
+		{
+			kody: {
+				async call(name: string, argsJson: string) {
+					calls.push({ name, argsJson })
+					return JSON.stringify({ result: { ok: true } })
+				},
 			},
 		},
-	}) as {
+		{
+			mcpServers: [
+				{
+					name: 'home',
+					status: {
+						connected: true,
+						toolCount: 1,
+						unavailableMessage: 'The MCP server "home" is connected.',
+					},
+					capabilities: [
+						{
+							name: 'set_pin',
+							dispatchName: 'mcphomeset_pin',
+						},
+					],
+				},
+			],
+		},
+	) as {
 		mcp: Record<string, Record<string, (args: unknown) => Promise<unknown>>>
 		[key: string]: unknown
 	}
@@ -908,6 +844,139 @@ test('createExecuteExecutor reuses stable dynamic worker ids until binding conte
 	expect(nonHashableModuleLoader.ids).toHaveLength(2)
 	expect(new Set(nonHashableModuleLoader.ids).size).toBe(2)
 	expect(nonHashableModuleLoader.factoryCallCount).toBe(2)
+
+	const invocationLoader = createFakeWorkerLoader()
+	const invocationEnv = createExecutorTestEnv(invocationLoader.loader)
+	const invocationCode = 'async (__invocation = {}) => __invocation.params'
+	for (const invocation of [
+		{ params: { room: 'office' } },
+		{ params: { room: 'kitchen' } },
+		{
+			params: { room: 'office' },
+			packageContext: { packageId: 'pkg-1', kodyId: 'bot' },
+		},
+	] as const) {
+		await createExecuteExecutor({
+			env: invocationEnv,
+			exports,
+			gatewayProps: createGatewayProps('user-1'),
+		}).execute(invocationCode, scopedProviders, invocation)
+	}
+	expect(invocationLoader.ids).toHaveLength(3)
+	expect(new Set(invocationLoader.ids).size).toBe(1)
+	expect(invocationLoader.factoryCallCount).toBe(1)
+	expect(invocationLoader.evaluations.map((entry) => entry.invocation)).toEqual(
+		[
+			{
+				params: { room: 'office' },
+				packageContext: null,
+				mcpServers: [],
+			},
+			{
+				params: { room: 'kitchen' },
+				packageContext: null,
+				mcpServers: [],
+			},
+			{
+				params: { room: 'office' },
+				packageContext: { packageId: 'pkg-1', kodyId: 'bot' },
+				mcpServers: [],
+			},
+		],
+	)
+
+	const otherCode = await createExecuteExecutor({
+		env: invocationEnv,
+		exports,
+		gatewayProps: createGatewayProps('user-1'),
+	}).execute('async () => "other"', scopedProviders)
+	expect(otherCode.result).not.toBe(invocationLoader.ids[0])
+	expect(new Set(invocationLoader.ids).size).toBe(2)
+
+	const mcpStatusLoader = createFakeWorkerLoader()
+	const mcpStatusEnv = createExecutorTestEnv(mcpStatusLoader.loader)
+	const connectedHome = {
+		name: 'home',
+		serverId: 'home',
+		status: {
+			state: 'connected' as const,
+			connected: true,
+			toolCount: 1,
+			message: 'The MCP server "home" is connected.',
+			unavailableMessage: 'The MCP server "home" is connected.',
+		},
+		capabilities: [{ name: 'set_pin', dispatchName: 'mcphomeset_pin' }],
+	}
+	await createExecuteExecutor({
+		env: mcpStatusEnv,
+		exports,
+		gatewayProps: createGatewayProps('user-1'),
+	}).execute(invocationCode, [
+		{
+			name: 'kody',
+			fns: {},
+			kodyMcpServers: [connectedHome],
+		} as never,
+	])
+	await createExecuteExecutor({
+		env: mcpStatusEnv,
+		exports,
+		gatewayProps: createGatewayProps('user-1'),
+	}).execute(invocationCode, [
+		{
+			name: 'kody',
+			fns: {},
+			kodyMcpServers: [
+				{
+					...connectedHome,
+					status: {
+						state: 'disconnected',
+						connected: false,
+						toolCount: 0,
+						message: 'The MCP server "home" is not connected.',
+						unavailableMessage:
+							'The MCP server "home" is not connected. Kody cannot use this server until it reconnects.',
+					},
+				},
+			],
+		} as never,
+	])
+	expect(mcpStatusLoader.ids).toHaveLength(2)
+	expect(new Set(mcpStatusLoader.ids).size).toBe(1)
+	expect(mcpStatusLoader.factoryCallCount).toBe(1)
+	expect(mcpStatusLoader.evaluations.map((entry) => entry.invocation)).toEqual([
+		{
+			params: undefined,
+			packageContext: null,
+			mcpServers: [
+				{
+					name: 'home',
+					status: {
+						connected: true,
+						toolCount: 1,
+						unavailableMessage: 'The MCP server "home" is connected.',
+					},
+					capabilities: [{ name: 'set_pin', dispatchName: 'mcphomeset_pin' }],
+				},
+			],
+		},
+		{
+			params: undefined,
+			packageContext: null,
+			mcpServers: [
+				{
+					name: 'home',
+					status: {
+						connected: false,
+						toolCount: 0,
+						unavailableMessage:
+							'The MCP server "home" is not connected. Kody cannot use this server until it reconnects.',
+					},
+					capabilities: [{ name: 'set_pin', dispatchName: 'mcphomeset_pin' }],
+				},
+			],
+		},
+	])
 })
 
 test('createExecuteExecutor records one usage event per sandbox run with duration and outcome', async () => {
@@ -1239,7 +1308,7 @@ test('createExecuteExecutor disables dispatchers after execution completes', asy
 			},
 		},
 	])
-	const dispatchers = fakeLoader.evaluations[0]
+	const dispatchers = fakeLoader.evaluations[0]?.dispatchers
 	const result = await dispatchers?.kody?.call('search', '{}')
 
 	expect(JSON.parse(result ?? '{}')).toEqual({

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -1560,7 +1560,7 @@ const unboundRuntimeHelperNextSteps: Record<string, string> = {
 	events:
 		"`events` is only bound in saved-package runtime contexts that can dispatch package events; statically import the owning package's export so it runs in that context, or guard with `if (events) { ... }`.",
 	packageSecrets:
-		"`packageSecrets` is bound on stamped saved-package modules (including static `kody:@` imports) and in saved-package runtime contexts. Ad hoc execute entry code stays unbound; import the owning package's export so its stamp reads the mounts, or guard with `if (packageSecrets) { ... }`.",
+		"`packageSecrets` is bound on stamped saved-package modules (including static `kody:@` imports) and in saved-package runtime contexts. Ad hoc execute entry code stays unbound; import the owning package's export so its stamp reads the mounts, or guard with `'get' in packageSecrets` / `packageContext?.packageId` (the late-bound export is always a proxy).",
 	email:
 		'`email` is only bound for email-triggered runs; guard with `if (email) { ... }` when the code can also run outside an email context.',
 }

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -53,7 +53,11 @@ import {
 	type KodyMcpServerMetadata,
 	type KodyResolvedProvider,
 } from '#mcp/kody-remote-types.ts'
-import { createKodyProviderProxySource } from '#mcp/kody-provider-proxy-source.ts'
+import {
+	createKodyProviderProxySource,
+	projectKodyRemoteProxyMetadata,
+	type KodyRemoteProxyEvaluateMetadata,
+} from '#mcp/kody-provider-proxy-source.ts'
 import {
 	grantedSecretAuthorityPackageIdSet,
 	runWithCurrentSecretAuthority,
@@ -98,6 +102,7 @@ const dynamicWorkerMainModule = 'executor.js'
 const hostEvaluationDrainGraceMs = 100
 const reservedProviderNames = new Set([
 	'__dispatchers',
+	'__invocation',
 	'__logs',
 	hostSideEffectProviderName,
 ])
@@ -187,13 +192,54 @@ type DynamicWorkerExecutorInput = {
 	waitUntil?: (promise: Promise<unknown>) => void
 }
 
+export type DynamicWorkerEvaluatePackageContext = {
+	packageId: string
+	kodyId: string
+	sourceId?: string | null
+} | null
+
+/**
+ * Per-evaluate payload. Must stay out of WorkerCode so LOADER ids reuse
+ * across different `params` / `packageContext` / live MCP status.
+ */
+export type DynamicWorkerEvaluateInvocation = {
+	params?: unknown
+	packageContext?: DynamicWorkerEvaluatePackageContext
+	mcpServers?: Array<KodyRemoteProxyEvaluateMetadata>
+}
+
 type DynamicWorkerEntrypoint = {
-	evaluate(dispatchers: Record<string, ToolDispatcher>): Promise<{
+	evaluate(
+		dispatchers: Record<string, ToolDispatcher>,
+		invocation?: DynamicWorkerEvaluateInvocation,
+	): Promise<{
 		result: unknown
 		error?: string
 		logs?: Array<string>
 		rawFetchHosts?: Array<string>
 	}>
+}
+
+function cloneEvaluateJsonValue<T>(value: T): T {
+	if (value === undefined) return value
+	return JSON.parse(JSON.stringify(value)) as T
+}
+
+function resolveEvaluateInvocation(
+	providers: Array<ResolvedProvider>,
+	invocation?: DynamicWorkerEvaluateInvocation,
+): DynamicWorkerEvaluateInvocation {
+	const kodyProvider = providers.find(
+		(provider) => provider.name === 'kody',
+	) as KodyResolvedProvider | undefined
+	return {
+		params: cloneEvaluateJsonValue(invocation?.params),
+		packageContext:
+			cloneEvaluateJsonValue(invocation?.packageContext ?? null) ?? null,
+		mcpServers: projectKodyRemoteProxyMetadata(
+			invocation?.mcpServers ?? kodyProvider?.kodyMcpServers ?? [],
+		),
+	}
 }
 
 export type ExecuteResultWithHostSideEffects = ExecuteResult & {
@@ -542,6 +588,7 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 		async execute(
 			code: string,
 			providers: Array<ResolvedProvider>,
+			invocation?: DynamicWorkerEvaluateInvocation,
 		): Promise<ExecuteResultWithHostSideEffects> {
 			const sideEffects = createEvaluationSideEffectTracker()
 			const validationError = validateProviders(providers)
@@ -555,6 +602,10 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 				)
 			}
 			const excludedHostname = readBaseUrlHostname(input.gatewayProps.baseUrl)
+			const evaluateInvocation = resolveEvaluateInvocation(
+				providers,
+				invocation,
+			)
 			const executorModule = createExecutorModule({
 				code,
 				providers,
@@ -610,7 +661,8 @@ function createStableDynamicWorkerExecutor(input: DynamicWorkerExecutorInput) {
 									grantedSecretAuthorityPackageIdSet(
 										input.gatewayProps.grantedSecretAuthorityPackageIds,
 									)
-								const evaluate = () => entrypoint.evaluate(dispatchers)
+								const evaluate = () =>
+									entrypoint.evaluate(dispatchers, evaluateInvocation)
 								return grantedSecretAuthorityPackageIds
 									? await runWithSecretAuthorityScope(
 											grantedSecretAuthorityPackageIds,
@@ -830,9 +882,9 @@ function createExecutorModule(input: {
 		? [
 				'        (async (globalThis, self, global) => (',
 				normalized,
-				')())(__kodySandboxGlobal, __kodySandboxGlobal, __kodySandboxGlobal),',
+				')(__invocation))(__kodySandboxGlobal, __kodySandboxGlobal, __kodySandboxGlobal),',
 			]
-		: ['        (', normalized, ')(),']
+		: ['        (', normalized, ')(__invocation),']
 	return [
 		'import { WorkerEntrypoint } from "cloudflare:workers";',
 		'import { AsyncLocalStorage } from "node:async_hooks";',
@@ -854,7 +906,7 @@ function createExecutorModule(input: {
 		'}',
 		'',
 		'export default class CodeExecutor extends WorkerEntrypoint {',
-		'  async evaluate(__dispatchers = {}) {',
+		'  async evaluate(__dispatchers = {}, __invocation = {}) {',
 		'    const __logs = [];',
 		'    const __kodyRawFetchHosts = [];',
 		`    const __kodyExcludedFetchHost = ${excludedHostname};`,
@@ -909,11 +961,9 @@ export function createExecutorModuleSource(input: {
 }
 
 function createProviderProxySource(provider: ResolvedProvider) {
-	const kodyProvider = provider as KodyResolvedProvider
 	if (provider.name === 'kody') {
 		return createKodyProviderProxySource({
 			providerName: provider.name,
-			mcpServers: kodyProvider.kodyMcpServers ?? [],
 		})
 	}
 	return `    const ${provider.name} = new Proxy({}, {\n      get: (_, toolName) => async (...args) => {\n        const resJson = await __dispatchers.${provider.name}.call(String(toolName), JSON.stringify(args));\n        const data = JSON.parse(resJson);\n        if (data.error) throw new Error(data.error);\n        return data.result;\n      }\n    });`

--- a/packages/worker/src/mcp/executor.ts
+++ b/packages/worker/src/mcp/executor.ts
@@ -232,10 +232,12 @@ function resolveEvaluateInvocation(
 	const kodyProvider = providers.find(
 		(provider) => provider.name === 'kody',
 	) as KodyResolvedProvider | undefined
+	const packageContext =
+		cloneEvaluateJsonValue(invocation?.packageContext ?? null) ?? null
 	return {
 		params: cloneEvaluateJsonValue(invocation?.params),
 		packageContext:
-			cloneEvaluateJsonValue(invocation?.packageContext ?? null) ?? null,
+			packageContext == null ? null : Object.freeze({ ...packageContext }),
 		mcpServers: projectKodyRemoteProxyMetadata(
 			invocation?.mcpServers ?? kodyProvider?.kodyMcpServers ?? [],
 		),

--- a/packages/worker/src/mcp/kody-provider-proxy-source.ts
+++ b/packages/worker/src/mcp/kody-provider-proxy-source.ts
@@ -1,4 +1,3 @@
-import { type KodyMcpServerMetadata } from '#mcp/kody-remote-types.ts'
 import {
 	assertGeneratedExecutorSourceIsBundleSafe,
 	kodyRemoteProxyFactorySource,
@@ -9,9 +8,25 @@ import {
 	kodyCapabilityNamespaceConfigs,
 } from '#mcp/kody-capability-accessors.ts'
 
-// Keep only fields the sandbox proxy reads so inlined executor scripts stay
-// smaller and volatile status prose does not churn the stable worker-ID hash.
-function projectKodyRemoteProxyMetadata(
+export type KodyRemoteProxyEvaluateMetadata = {
+	name: string
+	status: {
+		connected: boolean
+		toolCount: number
+		unavailableMessage: string
+	}
+	capabilities: Array<{
+		name: string
+		dispatchName: string
+	}>
+}
+
+/**
+ * Fields the sandbox MCP proxy reads. Live `connected` / `toolCount` /
+ * `unavailableMessage` travel on `evaluate` RPC so they do not remint
+ * WorkerCode.
+ */
+export function projectKodyRemoteProxyMetadata(
 	entries: ReadonlyArray<{
 		name: string
 		status: {
@@ -24,7 +39,7 @@ function projectKodyRemoteProxyMetadata(
 			dispatchName: string
 		}>
 	}>,
-) {
+): Array<KodyRemoteProxyEvaluateMetadata> {
 	return entries.map((entry) => ({
 		name: entry.name,
 		status: {
@@ -39,13 +54,7 @@ function projectKodyRemoteProxyMetadata(
 	}))
 }
 
-export function createKodyProviderProxySource(input: {
-	providerName: string
-	mcpServers?: Array<KodyMcpServerMetadata>
-}) {
-	const mcpMetadataJson = JSON.stringify(
-		projectKodyRemoteProxyMetadata(input.mcpServers ?? []),
-	)
+export function createKodyProviderProxySource(input: { providerName: string }) {
 	const mcpFlatNameMessage = buildKodyFlatCapabilityUnavailableMessage({
 		namespace: 'mcp',
 		flatToolName: '${normalizedToolName}',
@@ -75,7 +84,7 @@ export function createKodyProviderProxySource(input: {
       return data.result;
     };
     const __kodyMcp = __kodyCreateRemoteProxy({
-      entries: ${mcpMetadataJson},
+      entries: Array.isArray(__invocation.mcpServers) ? __invocation.mcpServers : [],
       entityLabel: "MCP server",
       shortEntityLabel: "MCP server",
       capabilityLabel: "MCP tool",

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -1170,3 +1170,135 @@ export default async function main() { return await whatShipped({}) }`
 		recordSpy.mockRestore()
 	}
 })
+
+test('runModuleWithRegistry keeps WorkerCode stable across params and packageContext', async () => {
+	silenceIncidentalRuntimeWarnings()
+	const env = {} as Env
+	const callerContext = createMcpCallerContext({
+		baseUrl: 'https://app.example.com',
+		user: {
+			userId: 'user-1',
+			email: 'me@example.com',
+			displayName: 'Me',
+		},
+		storageContext: null,
+	})
+	const getRegistrySpy = vi
+		.spyOn(
+			await import('#mcp/capabilities/registry.ts'),
+			'getCapabilityRegistryForContext',
+		)
+		.mockResolvedValue({
+			capabilityHandlers: {},
+			capabilityMap: {},
+			toolSets: {},
+			capabilityPreludes: {},
+		} as never)
+	const wrappedSources: Array<string> = []
+	const invocations: Array<unknown> = []
+	const executorModules: Array<Record<string, string>> = []
+	const createExecuteExecutorSpy = vi
+		.spyOn(mcpExecutor, 'createExecuteExecutor')
+		.mockImplementation((input) => {
+			executorModules.push(input.modules as Record<string, string>)
+			return {
+				async execute(wrapped, _providers, invocation) {
+					wrappedSources.push(String(wrapped))
+					invocations.push(invocation)
+					return { result: 'ok', logs: [] }
+				},
+			} as never
+		})
+	const bundleSpy = vi
+		.mocked(buildKodyModuleBundle)
+		.mockImplementation(async (input) => ({
+			mainModule: 'entry.js',
+			modules: {
+				'entry.js':
+					input.sourceFiles['entry.ts'] ??
+					'export default async function main() { return null }',
+			},
+		}))
+
+	try {
+		const code = `import { kody } from 'kody:runtime'
+export default async function main(params) { return params }`
+		const firstParams = { sentinel: 'param-sentinel-9f3-office' }
+		const secondParams = { sentinel: 'param-sentinel-9f3-kitchen' }
+		const packageContext = { packageId: 'pkg-9f3', kodyId: 'bot-9f3' }
+
+		await runModuleWithRegistry(env, callerContext, code, firstParams)
+		await runModuleWithRegistry(env, callerContext, code, secondParams)
+		await runModuleWithRegistry(env, callerContext, code, firstParams, {
+			packageContext,
+		})
+
+		expect(wrappedSources).toHaveLength(3)
+		expect(wrappedSources[1]).toBe(wrappedSources[0])
+		expect(wrappedSources[2]).toBe(wrappedSources[0])
+		expect(executorModules[1]).toEqual(executorModules[0])
+		expect(executorModules[2]).toEqual(executorModules[0])
+		expect(wrappedSources[0]).toContain('__invocation.params')
+		expect(wrappedSources[0]).toContain('__invocation.packageContext')
+		expect(JSON.stringify(wrappedSources[0])).not.toContain(
+			firstParams.sentinel,
+		)
+		expect(JSON.stringify(wrappedSources[0])).not.toContain(
+			secondParams.sentinel,
+		)
+		expect(JSON.stringify(wrappedSources[0])).not.toContain(
+			packageContext.packageId,
+		)
+		expect(invocations).toEqual([
+			{ params: firstParams, packageContext: null },
+			{ params: secondParams, packageContext: null },
+			{ params: firstParams, packageContext },
+		])
+
+		const otherCode = `import { kody } from 'kody:runtime'
+export default async function main(params) { return { other: true, ...params } }`
+		await runModuleWithRegistry(env, callerContext, otherCode, firstParams)
+		expect(executorModules[3]).not.toEqual(executorModules[0])
+
+		const { createExecutorModuleSource } = mcpExecutor
+		const { createStableDynamicWorkerId } =
+			await import('#mcp/dynamic-worker-id.ts')
+		const { createDynamicWorkerCompatibilityOptions } =
+			await import('#worker/dynamic-worker-compatibility.ts')
+		const mintFromRun = async (
+			wrapped: string,
+			modules: Record<string, string>,
+		) =>
+			await createStableDynamicWorkerId({
+				userId: 'user-1',
+				storageContext: null,
+				workerOptions: {
+					...createDynamicWorkerCompatibilityOptions(),
+					mainModule: 'executor.js',
+					modules: {
+						...modules,
+						'executor.js': createExecutorModuleSource({
+							code: wrapped,
+							providers: [{ name: 'kody', fns: {} }],
+							shadowGlobalThis: false,
+							timeoutMs: 1_000,
+						}),
+					},
+				},
+			})
+		const firstId = await mintFromRun(wrappedSources[0]!, executorModules[0]!)
+		expect(await mintFromRun(wrappedSources[1]!, executorModules[1]!)).toBe(
+			firstId,
+		)
+		expect(await mintFromRun(wrappedSources[2]!, executorModules[2]!)).toBe(
+			firstId,
+		)
+		expect(await mintFromRun(wrappedSources[3]!, executorModules[3]!)).not.toBe(
+			firstId,
+		)
+	} finally {
+		bundleSpy.mockRestore()
+		createExecuteExecutorSpy.mockRestore()
+		getRegistrySpy.mockRestore()
+	}
+})

--- a/packages/worker/src/mcp/run-kody-registry.node.test.ts
+++ b/packages/worker/src/mcp/run-kody-registry.node.test.ts
@@ -1239,7 +1239,8 @@ export default async function main(params) { return params }`
 		expect(executorModules[1]).toEqual(executorModules[0])
 		expect(executorModules[2]).toEqual(executorModules[0])
 		expect(wrappedSources[0]).toContain('__invocation.params')
-		expect(wrappedSources[0]).toContain('__invocation.packageContext')
+		expect(wrappedSources[0]).toContain('__kodyTrustedPackageId')
+		expect(wrappedSources[0]).toContain('Object.freeze')
 		expect(JSON.stringify(wrappedSources[0])).not.toContain(
 			firstParams.sentinel,
 		)

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1033,6 +1033,21 @@ export async function runBundledModuleWithRegistry(
 		const runtimeHelperRuntimePropertySource =
 			createRuntimeHelperRuntimePropertySource()
 		const wrapped = `async (__invocation = {}) => {
+  const __kodyTrustedPackageContext = (() => {
+    const incoming = __invocation.packageContext;
+    if (incoming == null || typeof incoming !== 'object') return null;
+    const snapshot = {
+      packageId: incoming.packageId,
+      kodyId: incoming.kodyId,
+    };
+    if ('sourceId' in incoming) snapshot.sourceId = incoming.sourceId;
+    return Object.freeze(snapshot);
+  })();
+  const __kodyTrustedPackageId =
+    typeof __kodyTrustedPackageContext?.packageId === 'string' &&
+    __kodyTrustedPackageContext.packageId.trim() !== ''
+      ? __kodyTrustedPackageContext.packageId
+      : null;
 ${runtimeHelperPreludeSource}
   const { AsyncLocalStorage: __KodyAsyncLocalStorage } = await import('node:async_hooks');
   const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
@@ -1043,7 +1058,7 @@ ${runtimeHelperPreludeSource}
   const __kodyRuntime = {
     kody,
 ${runtimeHelperRuntimePropertySource}
-    packageContext: __invocation.packageContext ?? null,
+    packageContext: __kodyTrustedPackageContext,
   };
   try {
     return await __kodyRuntimeStorage.run(__kodyRuntime, async () => {

--- a/packages/worker/src/mcp/run-kody-registry.ts
+++ b/packages/worker/src/mcp/run-kody-registry.ts
@@ -1032,10 +1032,7 @@ export async function runBundledModuleWithRegistry(
 			createUnboundOptionalRuntimeHelperNames(runtimeHelperContext)
 		const runtimeHelperRuntimePropertySource =
 			createRuntimeHelperRuntimePropertySource()
-		const entrypointInputJson = JSON.stringify(params)
-		const entrypointInputSource =
-			entrypointInputJson === undefined ? 'undefined' : entrypointInputJson
-		const wrapped = `async () => {
+		const wrapped = `async (__invocation = {}) => {
 ${runtimeHelperPreludeSource}
   const { AsyncLocalStorage: __KodyAsyncLocalStorage } = await import('node:async_hooks');
   const __kodyRuntimeStorageSymbol = Symbol.for('kody.runtimeStorage');
@@ -1046,7 +1043,7 @@ ${runtimeHelperPreludeSource}
   const __kodyRuntime = {
     kody,
 ${runtimeHelperRuntimePropertySource}
-    packageContext: ${JSON.stringify(options?.packageContext ?? null)},
+    packageContext: __invocation.packageContext ?? null,
   };
   try {
     return await __kodyRuntimeStorage.run(__kodyRuntime, async () => {
@@ -1055,7 +1052,7 @@ ${runtimeHelperRuntimePropertySource}
       if (typeof __kodyEntrypoint !== 'function') {
         throw new Error('Kody execute modules must default export a function.');
       }
-      return await __kodyEntrypoint(${entrypointInputSource});
+      return await __kodyEntrypoint(__invocation.params);
     });
   } finally {
     // Deliver buffered static package export call usage events while the
@@ -1086,7 +1083,11 @@ ${runtimeHelperRuntimePropertySource}
 			let result: ExecuteResult
 			try {
 				result = await runWithTransientDurableObjectResetRetry({
-					operation: () => executor.execute(wrapped, providers),
+					operation: () =>
+						executor.execute(wrapped, providers, {
+							params,
+							packageContext: options?.packageContext ?? null,
+						}),
 					retryableResultError: (executeResult) => executeResult.error ?? null,
 					shouldRetry: ({ result: executeResult }) =>
 						!evaluationHasHostMediatedSideEffects(

--- a/packages/worker/src/mcp/runtime-helper-manifest.node.test.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.node.test.ts
@@ -66,8 +66,7 @@ test('packageSecrets prelude reads the run package id from evaluate invocation',
 		},
 	}).join('\n')
 	expect(first).toBe(second)
-	expect(first).toContain('__invocation.packageContext?.packageId')
-	expect(first).toContain(
-		'__kodyPackageSecrets(__invocation.packageContext.packageId)',
-	)
+	expect(first).toContain('__kodyTrustedPackageId')
+	expect(first).toContain('__kodyPackageSecrets(__kodyTrustedPackageId)')
+	expect(first).not.toContain('__invocation.packageContext')
 })

--- a/packages/worker/src/mcp/runtime-helper-manifest.node.test.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.node.test.ts
@@ -43,3 +43,31 @@ test('packages helper forwards string-first invoke and rejects the removed objec
 	).rejects.toThrow('Object-only packages.invoke was removed')
 	expect(invoke).toHaveBeenCalledTimes(2)
 })
+
+test('packageSecrets prelude reads the run package id from evaluate invocation', () => {
+	const first = createRuntimeHelperPreludes({
+		env: {} as Env,
+		callerContext: { user: { userId: 'user-1' } } as never,
+		capabilityMap: {},
+		packageSecretTools: {
+			get: async () => '',
+			has: async () => false,
+			runPackageId: 'pkg-a',
+		},
+	}).join('\n')
+	const second = createRuntimeHelperPreludes({
+		env: {} as Env,
+		callerContext: { user: { userId: 'user-1' } } as never,
+		capabilityMap: {},
+		packageSecretTools: {
+			get: async () => '',
+			has: async () => false,
+			runPackageId: 'pkg-b',
+		},
+	}).join('\n')
+	expect(first).toBe(second)
+	expect(first).toContain('__invocation.packageContext?.packageId')
+	expect(first).toContain(
+		'__kodyPackageSecrets(__invocation.packageContext.packageId)',
+	)
+})

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -212,8 +212,8 @@ const __kodyPackageSecrets = (packageId) => ({
 
 function createPackageSecretsBindingPrelude() {
 	return `
-const packageSecrets = __invocation.packageContext?.packageId
-  ? __kodyPackageSecrets(__invocation.packageContext.packageId)
+const packageSecrets = __kodyTrustedPackageId
+  ? __kodyPackageSecrets(__kodyTrustedPackageId)
   : null;
 	`.trim()
 }

--- a/packages/worker/src/mcp/runtime-helper-manifest.ts
+++ b/packages/worker/src/mcp/runtime-helper-manifest.ts
@@ -162,6 +162,13 @@ type RuntimeHelperManifestEntry = {
 	runtimeBindings: Array<RuntimeHelperRuntimeBinding>
 	unboundNames: Array<string>
 	isBound: (context: RuntimeHelperManifestContext) => boolean
+	/**
+	 * When set, overrides `!isBound` for the host-side unbound-helper rewrite.
+	 * Use when a prelude is always emitted (stable WorkerCode) but the helper
+	 * is still unbound for this run — for example `packageSecrets` on ad hoc
+	 * execute, where the package id arrives on evaluate RPC.
+	 */
+	unboundWhen?: (context: RuntimeHelperManifestContext) => boolean
 	createPrelude?: (context: RuntimeHelperManifestContext) => string
 	createKodyTools?: (
 		context: RuntimeHelperManifestContext,
@@ -203,10 +210,11 @@ const __kodyPackageSecrets = (packageId) => ({
 	`.trim()
 }
 
-function createPackageSecretsBindingPrelude(input: { runPackageId: string }) {
-	const runPackageIdJson = JSON.stringify(input.runPackageId)
+function createPackageSecretsBindingPrelude() {
 	return `
-const packageSecrets = __kodyPackageSecrets(${runPackageIdJson});
+const packageSecrets = __invocation.packageContext?.packageId
+  ? __kodyPackageSecrets(__invocation.packageContext.packageId)
+  : null;
 	`.trim()
 }
 
@@ -520,12 +528,9 @@ const runtimeHelperManifest: Array<RuntimeHelperManifestEntry> = [
 		runtimeName: 'packageSecrets',
 		runtimeBindings: [{ runtimeName: 'packageSecrets', absentValue: 'null' }],
 		unboundNames: ['packageSecrets'],
-		isBound: (context) => Boolean(context.packageSecretTools?.runPackageId),
-		createPrelude: (context) => {
-			const runPackageId = context.packageSecretTools?.runPackageId
-			if (!runPackageId) return ''
-			return createPackageSecretsBindingPrelude({ runPackageId })
-		},
+		isBound: (context) => Boolean(context.packageSecretTools),
+		unboundWhen: (context) => !context.packageSecretTools?.runPackageId,
+		createPrelude: () => createPackageSecretsBindingPrelude(),
 	},
 	{
 		runtimeName: 'email',
@@ -652,9 +657,12 @@ export function createUnboundOptionalRuntimeHelperNames(
 	context: RuntimeHelperManifestContext,
 ) {
 	return new Set(
-		runtimeHelperManifest.flatMap((entry) =>
-			entry.isBound(context) ? [] : entry.unboundNames,
-		),
+		runtimeHelperManifest.flatMap((entry) => {
+			const unbound = entry.unboundWhen
+				? entry.unboundWhen(context)
+				: !entry.isBound(context)
+			return unbound ? entry.unboundNames : []
+		}),
 	)
 }
 

--- a/packages/worker/src/mcp/unbound-runtime-helpers-bundle.workers.test.ts
+++ b/packages/worker/src/mcp/unbound-runtime-helpers-bundle.workers.test.ts
@@ -55,3 +55,46 @@ test(
 		expect(parseUnboundRuntimeHelperMessage(result.error ?? '')).toBe('email')
 	},
 )
+
+test(
+	'guard-less unbound packageSecrets access in a real bundle gets the bound-context hint',
+	{ timeout: 60_000 },
+	async () => {
+		silenceIncidentalRuntimeWarnings()
+		const callerContext = createMcpCallerContext({
+			baseUrl: 'https://kody.dev',
+			user: {
+				userId: 'user-unbound-secrets',
+				email: 'secrets@example.com',
+				displayName: 'Secrets',
+			},
+		})
+		const bundle = await buildKodyModuleBundle({
+			env,
+			baseUrl: 'https://kody.dev',
+			userId: 'user-unbound-secrets',
+			sourceFiles: {
+				'entry.ts': [
+					"import { packageSecrets } from 'kody:runtime'",
+					'export default async function main() {',
+					"\treturn await packageSecrets.get('token')",
+					'}',
+				].join('\n'),
+			},
+			entryPoint: 'entry.ts',
+		})
+		const result = await runBundledModuleWithRegistry(
+			env,
+			callerContext,
+			bundle,
+			undefined,
+			{ skipCapabilityRegistry: true },
+		)
+		expect(result.error).toContain(
+			'kody:runtime export "packageSecrets" is not available in this execution context.',
+		)
+		expect(parseUnboundRuntimeHelperMessage(result.error ?? '')).toBe(
+			'packageSecrets',
+		)
+	},
+)

--- a/packages/worker/src/package-runtime/module-graph.workers.test.ts
+++ b/packages/worker/src/package-runtime/module-graph.workers.test.ts
@@ -286,7 +286,7 @@ test('ad hoc execute runtime exposes only packages.invoke', async () => {
 				'\t\tremovedObjectInvoke = String(error?.message ?? error);',
 				'\t}',
 				'\treturn {',
-				'\t\tpackageContextIsNull: packageContext === null,',
+				'\t\tpackageContextIsNull: packageContext?.packageId == null,',
 				'\t\tdirectKodyInvokeChecked,',
 				'\t\tremovedObjectInvoke,',
 				'\t\tinvoked: await packages?.invoke(',
@@ -503,7 +503,8 @@ test(
 			targetMarkerVisible: boolean
 		}
 		// The target ran in its own runtime (packageContext bound to the target
-		// package) and each key-less invoke got a fresh isolate.
+		// package). Same user + published graph reuse one isolate; params arrive
+		// on evaluate RPC, so the second invoke sees the module-level counter.
 		expect(payload.first).toEqual({
 			marker: 'first',
 			isolateCallCount: 1,
@@ -512,7 +513,7 @@ test(
 		})
 		expect(payload.second).toEqual({
 			marker: 'second',
-			isolateCallCount: 1,
+			isolateCallCount: 2,
 			targetKodyId: 'lean-target',
 			callerMarkerVisible: false,
 		})

--- a/packages/worker/src/package-runtime/package-secret-authority.workers.test.ts
+++ b/packages/worker/src/package-runtime/package-secret-authority.workers.test.ts
@@ -564,7 +564,7 @@ test(
 					'entry.ts': [
 						"import { packageSecrets } from 'kody:runtime'",
 						'export default async function main() {',
-						'\treturn { bound: packageSecrets != null }',
+						'\treturn { bound: "get" in packageSecrets }',
 						'}',
 					].join('\n'),
 				},

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -191,6 +191,7 @@ test('optional runtime exports stay falsy when the wrapper omits them', async ()
 		] = sharedStorage
 
 		let captured: RuntimeModule | null = null
+		let observedPackageContext: Record<string, unknown> | null = null
 		await sharedStorage.run(
 			// Intentionally omit `email`, `kody` from the runtime payload to
 			// mirror an execute call that did not bind any of those helpers.
@@ -198,6 +199,9 @@ test('optional runtime exports stay falsy when the wrapper omits them', async ()
 			async () => {
 				const url = await writeRuntimeFile()
 				captured = (await import(url)) as RuntimeModule
+				observedPackageContext = {
+					...(captured as RuntimeModule).packageContext,
+				}
 			},
 		)
 
@@ -212,8 +216,8 @@ test('optional runtime exports stay falsy when the wrapper omits them', async ()
 		expect(Boolean(mod.kody)).toBe(false)
 		expect(Boolean(mod.codemode)).toBe(false)
 		expect(Boolean(mod.capabilities)).toBe(false)
-		// Provided exports survive.
-		expect(mod.packageContext).toEqual({ packageId: 'pkg-1' })
+		// packageContext is late-bound; read it inside the store run.
+		expect(observedPackageContext).toEqual({ packageId: 'pkg-1' })
 	})
 })
 
@@ -269,6 +273,22 @@ test('preloaded kody exports resolve from the active runtime store', async () =>
 			ok: true,
 			args: { value: 'default-active-store' },
 		})
+
+		const firstPackageId = await sharedStorage.run(
+			{ packageContext: { packageId: 'pkg-a' } },
+			() => mod.packageContext?.packageId ?? null,
+		)
+		const secondPackageId = await sharedStorage.run(
+			{ packageContext: { packageId: 'pkg-b' } },
+			() => mod.packageContext?.packageId ?? null,
+		)
+		const absentPackageId = await sharedStorage.run(
+			{ packageContext: null },
+			() => mod.packageContext?.packageId ?? null,
+		)
+		expect(firstPackageId).toBe('pkg-a')
+		expect(secondPackageId).toBe('pkg-b')
+		expect(absentPackageId).toBeNull()
 	})
 })
 

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -36,6 +36,7 @@ type RuntimeModule = {
 	capabilities?: unknown
 	email: { getMessage: (id: string) => Promise<unknown> } | null
 	packageContext: Record<string, unknown> | null
+	packageSecrets: { get: (alias: string) => Promise<string> } | null
 	default: {
 		kody?: { tool_call: (args: unknown) => Promise<unknown> }
 		codemode?: unknown
@@ -289,6 +290,45 @@ test('preloaded kody exports resolve from the active runtime store', async () =>
 		expect(firstPackageId).toBe('pkg-a')
 		expect(secondPackageId).toBe('pkg-b')
 		expect(absentPackageId).toBeNull()
+
+		const firstSecretsBound = await sharedStorage.run(
+			{
+				packageSecrets: {
+					async get(alias: string) {
+						return `a:${alias}`
+					},
+				},
+			},
+			() => 'get' in mod.packageSecrets,
+		)
+		const firstSecretValue = await sharedStorage.run(
+			{
+				packageSecrets: {
+					async get(alias: string) {
+						return `a:${alias}`
+					},
+				},
+			},
+			() => mod.packageSecrets.get('token'),
+		)
+		const secondSecretValue = await sharedStorage.run(
+			{
+				packageSecrets: {
+					async get(alias: string) {
+						return `b:${alias}`
+					},
+				},
+			},
+			() => mod.packageSecrets.get('token'),
+		)
+		const absentSecretsBound = await sharedStorage.run(
+			{ packageSecrets: null },
+			() => 'get' in mod.packageSecrets,
+		)
+		expect(firstSecretsBound).toBe(true)
+		expect(firstSecretValue).toBe('a:token')
+		expect(secondSecretValue).toBe('b:token')
+		expect(absentSecretsBound).toBe(false)
 	})
 })
 

--- a/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
+++ b/packages/worker/src/package-runtime/runtime-isolation.node.test.ts
@@ -36,7 +36,7 @@ type RuntimeModule = {
 	capabilities?: unknown
 	email: { getMessage: (id: string) => Promise<unknown> } | null
 	packageContext: Record<string, unknown> | null
-	packageSecrets: { get: (alias: string) => Promise<string> } | null
+	packageSecrets: { get: (alias: string) => Promise<string> }
 	default: {
 		kody?: { tool_call: (args: unknown) => Promise<unknown> }
 		codemode?: unknown

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -488,6 +488,15 @@ function __kodyCreateRuntimeRecordExport(exportName) {
 				value: value[property],
 			};
 		},
+		set() {
+			return false;
+		},
+		defineProperty() {
+			return false;
+		},
+		deleteProperty() {
+			return false;
+		},
 	});
 }
 

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -58,6 +58,9 @@ export function createRuntimeModuleSource() {
 	// Helper *presence* is decided by the generated wrapper source, which is
 	// part of the worker id hash, so presence observed on the first in-run
 	// evaluation is identical for every later run of the same worker.
+	// \`packageContext\` is the exception on *value*: the same wrapper is reused
+	// across evaluate calls, and the current package id arrives on evaluate
+	// RPC, so the export must re-read AsyncLocalStorage on each access.
 	//
 	// \`kody\` is always exported as a late-bound proxy: every
 	// execute/package runtime provides it, and Worker module loaders may
@@ -443,6 +446,48 @@ function __kodyOptionalRuntimeFunctionExport(exportName) {
 	return __kodyCreateRuntimeFunctionExport(exportName);
 }
 
+function __kodyCreateRuntimeRecordExport(exportName) {
+	return new Proxy({}, {
+		get(_target, property) {
+			if (__kodyIsRuntimeProxyInspectionProperty(property)) {
+				return __kodyRuntimeProxyInspectionValue(exportName, property);
+			}
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const value = currentRuntime?.[exportName] ?? null;
+			if (value == null) return undefined;
+			return value[property];
+		},
+		has(_target, property) {
+			if (__kodyIsRuntimeProxyInspectionProperty(property)) return false;
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const value = currentRuntime?.[exportName] ?? null;
+			return value != null && property in value;
+		},
+		ownKeys() {
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const value = currentRuntime?.[exportName] ?? null;
+			return value == null ? [] : Reflect.ownKeys(value);
+		},
+		getOwnPropertyDescriptor(_target, property) {
+			if (__kodyIsRuntimeProxyInspectionProperty(property)) return undefined;
+			const currentRuntime = __kodyRuntimeStorage.getStore();
+			const value = currentRuntime?.[exportName] ?? null;
+			if (value == null) return undefined;
+			const descriptor = Reflect.getOwnPropertyDescriptor(value, property);
+			if (descriptor !== undefined) {
+				return { ...descriptor, configurable: true };
+			}
+			if (!(property in value)) return undefined;
+			return {
+				configurable: true,
+				enumerable: true,
+				writable: true,
+				value: value[property],
+			};
+		},
+	});
+}
+
 function __kodyResolvePackageStorage(packageId) {
 	const currentRuntime = __kodyRuntimeStorage.getStore();
 	const factory = currentRuntime?.__kodyPackageStorage;
@@ -595,7 +640,7 @@ export const kody =
 export const createAuthenticatedFetch = __kodyOptionalRuntimeFunctionExport('createAuthenticatedFetch');
 export const secretHeaders = __kodyOptionalRuntimeObjectExport('secretHeaders', undefined);
 export const oauthClientCredentials = __kodyOptionalRuntimeFunctionExport('oauthClientCredentials');
-export const packageContext = __kodyInitialRuntime?.packageContext ?? null;
+export const packageContext = __kodyCreateRuntimeRecordExport('packageContext');
 export const packageSecrets = __kodyOptionalRuntimeObjectExport('packageSecrets', null);
 export const email = __kodyOptionalRuntimeObjectExport('email', null);
 export const workflows = __kodyOptionalRuntimeObjectExport('workflows', null);

--- a/packages/worker/src/package-runtime/runtime-source-modules.ts
+++ b/packages/worker/src/package-runtime/runtime-source-modules.ts
@@ -52,15 +52,18 @@ export function createRuntimeModuleSource() {
 	// instead late-bound: it re-reads the current AsyncLocalStorage store on
 	// each property access / call.
 	//
-	// Optional helpers (\`email\`, \`packageSecrets\`, ...) still preserve their
+	// Optional helpers (\`email\`, \`workflows\`, ...) still preserve their
 	// absent value (\`undefined\` / \`null\`) so \`if (email) { ... }\`
 	// guards stay falsy when a wrapper intentionally omits that export.
 	// Helper *presence* is decided by the generated wrapper source, which is
 	// part of the worker id hash, so presence observed on the first in-run
 	// evaluation is identical for every later run of the same worker.
-	// \`packageContext\` is the exception on *value*: the same wrapper is reused
-	// across evaluate calls, and the current package id arrives on evaluate
-	// RPC, so the export must re-read AsyncLocalStorage on each access.
+	// \`packageContext\` and unstamped \`packageSecrets\` are the exceptions:
+	// the same wrapper is reused across evaluate calls, and the current
+	// package id arrives on evaluate RPC, so those exports must re-read
+	// AsyncLocalStorage on each access. \`if (packageSecrets)\` is therefore
+	// always truthy on the late-bound export; presence is \`'get' in
+	// packageSecrets\` or \`packageContext?.packageId\`.
 	//
 	// \`kody\` is always exported as a late-bound proxy: every
 	// execute/package runtime provides it, and Worker module loaders may
@@ -641,7 +644,7 @@ export const createAuthenticatedFetch = __kodyOptionalRuntimeFunctionExport('cre
 export const secretHeaders = __kodyOptionalRuntimeObjectExport('secretHeaders', undefined);
 export const oauthClientCredentials = __kodyOptionalRuntimeFunctionExport('oauthClientCredentials');
 export const packageContext = __kodyCreateRuntimeRecordExport('packageContext');
-export const packageSecrets = __kodyOptionalRuntimeObjectExport('packageSecrets', null);
+export const packageSecrets = __kodyCreateRuntimeObjectProxy('packageSecrets');
 export const email = __kodyOptionalRuntimeObjectExport('email', null);
 export const workflows = __kodyOptionalRuntimeObjectExport('workflows', null);
 export const packages = __kodyOptionalRuntimeObjectExport('packages', null);

--- a/packages/worker/src/package-runtime/unbound-runtime-helpers.node.test.ts
+++ b/packages/worker/src/package-runtime/unbound-runtime-helpers.node.test.ts
@@ -154,6 +154,23 @@ export default async () => await runtime.oauthClientCredentials({})`,
 		helperName: 'oauthClientCredentials',
 		reference: 'oauthClientCredentials',
 	})
+
+	// Late-bound optional exports (packageSecrets) throw this instead of a
+	// null-property TypeError when the evaluate store omits the helper.
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage:
+				'kody:runtime export "packageSecrets" is not available in this execution context.',
+			modules: {
+				'entry.js': `import { packageSecrets } from 'kody:runtime'
+export default async () => await packageSecrets.get('token')`,
+			},
+			unboundHelperNames: allOptionalHelperNames,
+		}),
+	).toEqual({
+		helperName: 'packageSecrets',
+		reference: 'packageSecrets',
+	})
 })
 
 test('findUnboundRuntimeHelperAccess leaves unrelated errors and bound helpers unhinted', () => {
@@ -212,6 +229,18 @@ export default async () => (await storage.sql('select 1')).rows`,
 			unboundHelperNames: allOptionalHelperNames,
 		}),
 	).toBeNull()
+
+	expect(
+		findUnboundRuntimeHelperAccess({
+			errorMessage:
+				'kody:runtime export "packageSecrets" is not available in this execution context.',
+			modules: {
+				'entry.js': `import { packageSecrets } from 'kody:runtime'
+export default async () => await packageSecrets.get('token')`,
+			},
+			unboundHelperNames: new Set(['email']),
+		}),
+	).toBeNull()
 })
 
 test('createUnboundRuntimeHelperMessage round-trips through parseUnboundRuntimeHelperMessage', () => {
@@ -236,4 +265,10 @@ test('createUnboundRuntimeHelperMessage round-trips through parseUnboundRuntimeH
 			"Cannot read properties of undefined (reading 'sql')",
 		),
 	).toBeNull()
+
+	expect(
+		parseUnboundRuntimeHelperMessage(
+			'kody:runtime export "packageSecrets" is not available in this execution context.',
+		),
+	).toBe('packageSecrets')
 })

--- a/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
+++ b/packages/worker/src/package-runtime/unbound-runtime-helpers.ts
@@ -30,6 +30,8 @@ const notAFunctionErrorPattern =
 
 const unboundRuntimeHelperMessagePattern =
 	/The optional kody:runtime export "([\w$]+)" is not bound in this execution context/
+const lateBoundUnavailableExportPattern =
+	/kody:runtime export "([\w$]+)" is not available in this execution context/
 
 export function createUnboundRuntimeHelperMessage(input: {
 	originalMessage: string
@@ -47,7 +49,11 @@ export function createUnboundRuntimeHelperMessage(input: {
 }
 
 export function parseUnboundRuntimeHelperMessage(message: string) {
-	return unboundRuntimeHelperMessagePattern.exec(message)?.[1] ?? null
+	return (
+		unboundRuntimeHelperMessagePattern.exec(message)?.[1] ??
+		lateBoundUnavailableExportPattern.exec(message)?.[1] ??
+		null
+	)
 }
 
 /**
@@ -62,6 +68,15 @@ export function findUnboundRuntimeHelperAccess(input: {
 	unboundHelperNames: ReadonlySet<string>
 }): UnboundRuntimeHelperAccess | null {
 	if (input.unboundHelperNames.size === 0) return null
+	const lateBoundExport = lateBoundUnavailableExportPattern.exec(
+		input.errorMessage,
+	)?.[1]
+	if (lateBoundExport && input.unboundHelperNames.has(lateBoundExport)) {
+		return {
+			helperName: lateBoundExport,
+			reference: lateBoundExport,
+		}
+	}
 	const propertyName =
 		propertyReadErrorPattern.exec(input.errorMessage)?.[1] ?? null
 	const calledExpression = propertyName


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop reminting Dynamic Worker LOADER ids when only execute `params` or `packageContext` change, so the same user and module graph reuse one isolate.

## Why

After deploy SHA left the identity hash (#2215), execute `params` and `packageContext` were still JSON-stringified into the wrapper passed to `executor.execute`. `createExecutorModule` embeds that wrapper, `createStableDynamicWorkerId` hashes modules, and `evaluate()` only received dispatchers. Docs and the execute tool claimed `params` reuse isolates. That was false, and it is the primary Dynamic Workers thrash left after #2215.

## Summary

- Pass `params`, `packageContext`, and live MCP proxy metadata (`connected` / `toolCount` / advertised tools) on `evaluate` RPC, not WorkerCode.
- Keep the default export signature `main(params)`.
- Bump `dynamicWorkerCacheKeyVersion` from 5 to 7.
- Keep `userId` (and `storageContext`) in the LOADER key. Thin-child / strip-userId is later.
- Late-bind `kody:runtime` `packageContext` and unstamped `packageSecrets` so a reused isolate reads the current evaluate payload instead of the first import snapshot.
- Read the package-secrets run id from `__invocation.packageContext` so that prelude does not remint.
- Garden usage-metering, platform-efficiency, and execute docs to match.

No pricing or entitlement changes. No UI surface, so preview-manual UI is not applicable.

## Testing

- Local `test:push` after the Bugbot fix: node-unit 977 files / 3152 tests, workers-unit 96 files / 348 tests.
- Preview smoke on `https://kody-pr-2277.kody-a99.workers.dev`: `/health` (merge of `e21a5102` parent `aecb1eea`), login, `/account`, `/admin` 403, `/mcp` 401. Origin/runtime/platform health matched.
- Focused coverage:
  - `dynamic-worker-id.node.test.ts` — same modules + user + storage stay stable, evaluate-time params are not hash inputs.
  - `executor.node.test.ts` — same code + different params / packageContext / MCP connect status → same worker id, evaluate receives the invocation, different code → different id.
  - `run-kody-registry.node.test.ts` — wrapper source is stable across params and packageContext, minted ids match.
  - `execute-dynamic-worker-reuse.workers.test.ts` — real LOADER reuse delivers different params, packageContext, and unstamped `packageSecrets` presence on the same isolate.
  - `runtime-isolation.node.test.ts` — preloaded `packageSecrets` late-binds across evaluates.

## Measure plan

After this ships, compare:

1. Analytics Engine `buildUniqueWorkerDayBySurfaceQuery` — execute share of unique worker days (`sumIf(_sample_interval, blob6 = 'execute') / sum(_sample_interval)` on `dynamic_worker_day` for the month), preview dataset `kody_usage_events_preview` then production.
2. Cloudflare billable Dynamic Workers (unique worker ids per UTC day).

Expect execute-surface UWD share to drop when agents vary `params` on a stable `code` graph. Do not treat other surfaces as in-scope for this change.

## Follow-up (not this PR)

- Strip `userId` from the LOADER key (thin-child / shared isolate). Explicitly out of scope here.

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `79a9a1fc` · **Head:** `e21a5102`

**Classification:** extends — LOADER identity no longer hashes execute `params`, `packageContext`, or live MCP connect/tool metadata. Unstamped `packageSecrets` is late-bound per evaluate. `userId` stays in the key.

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `capabilities-execute` | runtime | extends — wrapper reads evaluate invocation instead of baking params |
| `mcp-server` | surfaces | extends — `evaluate(dispatchers, invocation)` plus cache-key version 7 |
| `package-runtime` | runtime | extends — `kody:runtime` `packageContext` and unstamped `packageSecrets` are late-bound per evaluate |

### Change flow

Execute still default-exports `main(params)`. The host now sends `params`, `packageContext`, and live MCP proxy metadata on `evaluate` RPC so the same user and module graph reuse one LOADER id. Reused isolates re-read ALS for `packageContext` and unstamped `packageSecrets`.

```mermaid
sequenceDiagram
	actor Agent
	participant mcpServer as mcp-server
	participant capabilitiesExecute as capabilities-execute
	participant packageRuntime as package-runtime
	Agent->>mcpServer: execute code plus params
	mcpServer->>capabilitiesExecute: runBundledModuleWithRegistry
	Note over capabilitiesExecute: wrapper source omits params and packageContext
	capabilitiesExecute->>mcpServer: execute wrapped providers invocation
	mcpServer->>mcpServer: hash userId storageContext modules version 7
	mcpServer->>packageRuntime: LOADER.get stable id
	mcpServer->>packageRuntime: evaluate dispatchers plus params packageContext mcpServers
	packageRuntime->>capabilitiesExecute: ALS run then main(params)
```

### Before / after

```
Before: wrapper embeds JSON.stringify(params) and packageContext
After:  evaluate({ params, packageContext, mcpServers })
```

Same user + same modules + different params → same worker id. Different code → different id. `userId` remains in the hash.

### Invariants

Per-user isolation: `userId` and `storageContext` stay in the LOADER key because `globalOutbound` is reused with the first factory's WorkerCode.

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa47508f-5dc6-47a2-b4c9-a01670c709f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa47508f-5dc6-47a2-b4c9-a01670c709f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Execute runs now reuse the same worker isolate when code, user, and module graph remain unchanged, even when parameters or package context differ.
  - Each invocation receives its own parameters, package context, package-secret availability, and current MCP connection metadata.

- **Bug Fixes**
  - Runtime values and MCP capabilities now reliably reflect the active execution across reused isolates.
  - Package context is protected from changes that could affect package-secret access.
  - Improved handling and error reporting when package secrets are unavailable.

- **Documentation**
  - Updated guidance explains worker identity, isolate reuse, and recommended parameter usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->