### PR TITLE
Stamp RFC 9207 iss on OAuth authorize client redirects

### DIFF
--- a/docs/contributing/architecture/authentication.md
+++ b/docs/contributing/architecture/authentication.md
@@ -672,8 +672,17 @@ routed from `packages/worker/src/index.ts`.
   `env.OAUTH_PROVIDER` there (or on UserInfo/logout, which run before
   `oauthProvider.fetch`), so those OIDC helpers come from `resolveOAuthHelpers`
   over `OAUTH_KV`. Implicit and Hybrid response types are not advertised or
-  accepted. Kody is not OpenID Certified. `/api/me` remains the OAuth-protected
-  JSON helper for grant props; it is not the OIDC UserInfo endpoint.
+  accepted. Authorization responses that send the client back to `redirect_uri`
+  (successful `code` redirects and OAuth/OIDC error redirects) include RFC 9207
+  `iss` equal to the discovery issuer (`getAppBaseUrl`). Authorization-server
+  metadata advertises `authorization_response_iss_parameter_supported: true`.
+  `@cloudflare/workers-oauth-provider` adds `iss` on success only when
+  `AuthRequest.issuer` is set; Kody assigns that field from `getAppBaseUrl` and
+  stamps `iss` on every outbound client redirect so a missing provider field
+  cannot omit it. Local HTML or JSON authorize errors that do not redirect to
+  the client do not include `iss`. Kody is not OpenID Certified. `/api/me`
+  remains the OAuth-protected JSON helper for grant props; it is not the OIDC
+  UserInfo endpoint.
 - On `/oauth/authorize`, unauthenticated users can log in inline or via top-nav
   auth links; those links preserve the full authorize URL in `redirectTo` so
   successful login returns to the original OAuth request. Password signup lands

--- a/packages/worker/src/oauth-authorization-response.node.test.ts
+++ b/packages/worker/src/oauth-authorization-response.node.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest'
+import {
+	stampAuthorizationResponseIssuer,
+	withAuthorizationResponseIssuer,
+} from './oauth-authorization-response.ts'
+
+test('authorization redirects stamp RFC 9207 iss to the discovery issuer', () => {
+	const issuer = 'https://kody.codes'
+	const success = new URL(
+		withAuthorizationResponseIssuer(
+			'https://chatgpt.com/connector/oauth/vG3-MLZWUV83?code=abc&state=s',
+			issuer,
+		),
+	)
+	expect(success.origin + success.pathname).toBe(
+		'https://chatgpt.com/connector/oauth/vG3-MLZWUV83',
+	)
+	expect(success.searchParams.get('code')).toBe('abc')
+	expect(success.searchParams.get('state')).toBe('s')
+	expect(success.searchParams.get('iss')).toBe(issuer)
+
+	const denied = new URL(
+		withAuthorizationResponseIssuer(
+			'https://chatgpt.com/connector/oauth/vG3-MLZWUV83?error=access_denied&state=s',
+			issuer,
+		),
+	)
+	expect(denied.searchParams.get('error')).toBe('access_denied')
+	expect(denied.searchParams.get('iss')).toBe(issuer)
+
+	const drifted = new URL(
+		withAuthorizationResponseIssuer(
+			'https://chatgpt.com/callback?code=abc&iss=https%3A%2F%2Fwrong.example',
+			issuer,
+		),
+	)
+	expect(drifted.searchParams.get('iss')).toBe(issuer)
+	expect(drifted.searchParams.get('code')).toBe('abc')
+
+	const stamped = new URL(
+		stampAuthorizationResponseIssuer(
+			'https://codex.example/callback?code=demo',
+			{
+				env: {},
+				requestUrl: 'https://kody.codes/oauth/authorize?client_id=codex',
+			},
+		),
+	)
+	expect(stamped.searchParams.get('code')).toBe('demo')
+	expect(stamped.searchParams.get('iss')).toBe('https://kody.codes')
+})

--- a/packages/worker/src/oauth-authorization-response.ts
+++ b/packages/worker/src/oauth-authorization-response.ts
@@ -1,0 +1,38 @@
+import { getAppBaseUrl } from '#worker/app-base-url.ts'
+
+/**
+ * RFC 9207 `iss` on an authorization response (success or error) sent to the
+ * client's `redirect_uri`. The value must match the discovery issuer
+ * (`getAppBaseUrl` / `/.well-known/openid-configuration` and
+ * `/.well-known/oauth-authorization-server`).
+ *
+ * `@cloudflare/workers-oauth-provider` advertises
+ * `authorization_response_iss_parameter_supported: true` and adds `iss` on
+ * success only when `AuthRequest.issuer` is set. Hand-rolled client redirects
+ * never went through that helper. Stamp every outbound client redirect here so
+ * a missing provider field cannot omit `iss`.
+ */
+export function withAuthorizationResponseIssuer(
+	redirectTo: string,
+	issuer: string,
+) {
+	const redirectUrl = new URL(redirectTo)
+	redirectUrl.searchParams.set('iss', issuer)
+	return redirectUrl.toString()
+}
+
+export function stampAuthorizationResponseIssuer(
+	redirectTo: string,
+	input: {
+		env: Parameters<typeof getAppBaseUrl>[0]['env']
+		requestUrl: string | URL
+	},
+) {
+	return withAuthorizationResponseIssuer(
+		redirectTo,
+		getAppBaseUrl({
+			env: input.env,
+			requestUrl: input.requestUrl,
+		}),
+	)
+}

--- a/packages/worker/src/oauth-handlers.ts
+++ b/packages/worker/src/oauth-handlers.ts
@@ -33,6 +33,7 @@ import { getUsernameFormatValidationError } from '#worker/identity/username.ts'
 import { getPkceValidationError } from '#worker/oauth-pkce.ts'
 import { oauthPaths } from '#universal/oauth-paths.ts'
 import { getAppBaseUrl } from '#worker/app-base-url.ts'
+import { stampAuthorizationResponseIssuer } from '#worker/oauth-authorization-response.ts'
 import { mcpResourcePath } from './mcp-auth.ts'
 import {
 	listUserOAuthGrantsForClient,
@@ -311,6 +312,13 @@ async function resolveAuthRequest(
 			return { error: 'Unknown OAuth client.' }
 		}
 		defaultMcpResourceForAuthRequest(authRequest, request, env)
+		// RFC 9207: completeAuthorization only adds `iss` when this field is
+		// set. Always use the discovery issuer (`getAppBaseUrl`) so it cannot
+		// drift from `/.well-known/openid-configuration`.
+		authRequest.issuer = getAppBaseUrl({
+			env,
+			requestUrl: request.url,
+		})
 		return { authRequest, client }
 	} catch (error) {
 		if (isCimdMetadataResolutionError(error)) {
@@ -605,20 +613,38 @@ async function handleResetClientRequest(
 	}
 }
 
-function createAccessDeniedRedirectUrl(request: AuthRequest) {
-	if (!request.redirectUri) {
+function stampClientAuthorizationRedirect(
+	redirectTo: string,
+	request: Request,
+	env: Env,
+) {
+	return stampAuthorizationResponseIssuer(redirectTo, {
+		env,
+		requestUrl: request.url,
+	})
+}
+
+function createAccessDeniedRedirectUrl(
+	authRequest: AuthRequest,
+	request: Request,
+	env: Env,
+) {
+	if (!authRequest.redirectUri) {
 		return null
 	}
-	const redirectUrl = new URL(request.redirectUri)
+	const redirectUrl = new URL(authRequest.redirectUri)
 	redirectUrl.searchParams.set('error', 'access_denied')
-	if (request.state) redirectUrl.searchParams.set('state', request.state)
-	return redirectUrl.toString()
+	if (authRequest.state)
+		redirectUrl.searchParams.set('state', authRequest.state)
+	return stampClientAuthorizationRedirect(redirectUrl.toString(), request, env)
 }
 
 function createOidcClientErrorRedirectUrl(
 	authRequest: AuthRequest,
 	errorCode: string,
 	description: string,
+	request: Request,
+	env: Env,
 ) {
 	if (!authRequest.redirectUri) return null
 	const redirectUrl = new URL(authRequest.redirectUri)
@@ -626,7 +652,7 @@ function createOidcClientErrorRedirectUrl(
 	redirectUrl.searchParams.set('error_description', description)
 	if (authRequest.state)
 		redirectUrl.searchParams.set('state', authRequest.state)
-	return redirectUrl.toString()
+	return stampClientAuthorizationRedirect(redirectUrl.toString(), request, env)
 }
 
 function createAuthorizeErrorRedirect(
@@ -921,12 +947,25 @@ async function tryHandleSilentOidcAuthorize(
 			.filter(Boolean) ?? []
 	if (!prompts.includes('none')) return null
 
+	const oidcClientErrorRedirect = (
+		authRequest: AuthRequest,
+		errorCode: string,
+		description: string,
+	) =>
+		createOidcClientErrorRedirectUrl(
+			authRequest,
+			errorCode,
+			description,
+			request,
+			env,
+		)
+
 	const oidcParamsOrError = parseOidcAuthorizeParams(request)
 	if (isOidcAuthorizeParamsParseError(oidcParamsOrError)) {
 		const helpers = getOAuthHelpers(env)
 		const resolution = await resolveAuthRequest(helpers, request, env)
 		if (!('error' in resolution)) {
-			const redirectTo = createOidcClientErrorRedirectUrl(
+			const redirectTo = oidcClientErrorRedirect(
 				resolution.authRequest,
 				oidcParamsOrError.errorCode,
 				oidcParamsOrError.error,
@@ -964,7 +1003,7 @@ async function tryHandleSilentOidcAuthorize(
 		env,
 	})
 	if (!oidcGate.ok) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			oidcGate.errorCode,
 			oidcGate.error,
@@ -984,7 +1023,7 @@ async function tryHandleSilentOidcAuthorize(
 		codeChallengeMethod: authRequest.codeChallengeMethod,
 	})
 	if (pkceError) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			'invalid_request',
 			pkceError,
@@ -994,7 +1033,7 @@ async function tryHandleSilentOidcAuthorize(
 	}
 
 	if (!authorizeSession.email || !authorizeSession.stableUserId) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			'login_required',
 			'Login required.',
@@ -1013,7 +1052,7 @@ async function tryHandleSilentOidcAuthorize(
 		where: { stable_user_id: authorizeSession.stableUserId },
 	})
 	if (!userRecord) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			'login_required',
 			'Signed-in user not found.',
@@ -1023,7 +1062,7 @@ async function tryHandleSilentOidcAuthorize(
 	}
 	const username = getValidOAuthUsername(userRecord.username)
 	if (!username) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			'interaction_required',
 			'Username is required.',
@@ -1040,7 +1079,7 @@ async function tryHandleSilentOidcAuthorize(
 		stableUserId: approvedUserId,
 	})
 	if (!emailVerified) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			'interaction_required',
 			oauthEmailVerificationRequiredMessage,
@@ -1056,7 +1095,7 @@ async function tryHandleSilentOidcAuthorize(
 
 	const resolvedScopes = resolveScopes(authRequest.scope)
 	if (!Array.isArray(resolvedScopes)) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			'invalid_scope',
 			resolvedScopes.error,
@@ -1074,7 +1113,7 @@ async function tryHandleSilentOidcAuthorize(
 		resolvedScopes.every((scope) => grant.scope.includes(scope)),
 	)
 	if (!hasMatchingConsent) {
-		const redirectTo = createOidcClientErrorRedirectUrl(
+		const redirectTo = oidcClientErrorRedirect(
 			authRequest,
 			'consent_required',
 			'Consent is required for this client.',
@@ -1091,23 +1130,29 @@ async function tryHandleSilentOidcAuthorize(
 	const authTime = authorizeSession.issuedAt
 		? Math.floor(authorizeSession.issuedAt / 1000)
 		: Math.floor(Date.now() / 1000)
-	const { redirectTo } = await helpers.completeAuthorization({
-		request: authRequest,
-		userId: approvedUserId,
-		metadata: {
-			email: approvedEmail,
-			clientId: authRequest.clientId,
-		},
-		scope: resolvedScopes,
-		props: {
+	const { redirectTo: providerRedirectTo } =
+		await helpers.completeAuthorization({
+			request: authRequest,
 			userId: approvedUserId,
-			email: approvedEmail,
-			username,
-			displayName: username,
-			authTime,
-			...(oidcParams.nonce ? { nonce: oidcParams.nonce } : {}),
-		},
-	})
+			metadata: {
+				email: approvedEmail,
+				clientId: authRequest.clientId,
+			},
+			scope: resolvedScopes,
+			props: {
+				userId: approvedUserId,
+				email: approvedEmail,
+				username,
+				displayName: username,
+				authTime,
+				...(oidcParams.nonce ? { nonce: oidcParams.nonce } : {}),
+			},
+		})
+	const redirectTo = stampClientAuthorizationRedirect(
+		providerRedirectTo,
+		request,
+		env,
+	)
 	void logAuditEvent({
 		db: auditDatabaseFromEnv(env),
 		category: 'oauth',
@@ -1219,7 +1264,7 @@ export async function handleAuthorizeRequest(
 	}
 
 	if (decision === 'deny') {
-		const redirectTo = createAccessDeniedRedirectUrl(authRequest)
+		const redirectTo = createAccessDeniedRedirectUrl(authRequest, request, env)
 		if (!redirectTo) {
 			return respondAuthorizeError(
 				request,
@@ -1421,23 +1466,29 @@ export async function handleAuthorizeRequest(
 			: authorizeSession.issuedAt
 				? Math.floor(authorizeSession.issuedAt / 1000)
 				: Math.floor(Date.now() / 1000)
-		const { redirectTo } = await helpers.completeAuthorization({
-			request: authRequest,
-			userId,
-			metadata: {
-				email: approvedEmail,
-				clientId: authRequest.clientId,
-			},
-			scope: resolvedScopes,
-			props: {
+		const { redirectTo: providerRedirectTo } =
+			await helpers.completeAuthorization({
+				request: authRequest,
 				userId,
-				email: approvedEmail,
-				username: approvedUsername,
-				displayName,
-				authTime,
-				...(oidcParams.nonce ? { nonce: oidcParams.nonce } : {}),
-			},
-		})
+				metadata: {
+					email: approvedEmail,
+					clientId: authRequest.clientId,
+				},
+				scope: resolvedScopes,
+				props: {
+					userId,
+					email: approvedEmail,
+					username: approvedUsername,
+					displayName,
+					authTime,
+					...(oidcParams.nonce ? { nonce: oidcParams.nonce } : {}),
+				},
+			})
+		const redirectTo = stampClientAuthorizationRedirect(
+			providerRedirectTo,
+			request,
+			env,
+		)
 		void logAuditEvent({
 			db: auditDatabaseFromEnv(env),
 			category: 'oauth',

--- a/packages/worker/src/oauth-handlers.workers.test.ts
+++ b/packages/worker/src/oauth-handlers.workers.test.ts
@@ -340,6 +340,22 @@ function getCookiePair(setCookie: string) {
 	return setCookie.split(';', 1)[0] ?? setCookie
 }
 
+function expectClientAuthorizationRedirect(
+	redirectTo: string,
+	expected: {
+		originPath: string
+		params: Record<string, string>
+		iss: string
+	},
+) {
+	const redirectUrl = new URL(redirectTo)
+	expect(redirectUrl.origin + redirectUrl.pathname).toBe(expected.originPath)
+	for (const [key, value] of Object.entries(expected.params)) {
+		expect(redirectUrl.searchParams.get(key)).toBe(value)
+	}
+	expect(redirectUrl.searchParams.get('iss')).toBe(expected.iss)
+}
+
 test('authorize info, denial, approval, and default scopes follow the OAuth workflow', async () => {
 	const successResponse = await handleAuthorizeInfo(
 		new Request(
@@ -403,12 +419,11 @@ test('authorize info, denial, approval, and default scopes follow the OAuth work
 	expect(denyResponse.status).toBe(302)
 	const location = denyResponse.headers.get('Location')
 	expect(location).toBeTruthy()
-	const redirectUrl = new URL(location as string)
-	const expectedRedirect = new URL(baseAuthRequest.redirectUri)
-	expect(redirectUrl.origin).toBe(expectedRedirect.origin)
-	expect(redirectUrl.pathname).toBe(expectedRedirect.pathname)
-	expect(redirectUrl.searchParams.get('error')).toBe('access_denied')
-	expect(redirectUrl.searchParams.get('state')).toBe('demo')
+	expectClientAuthorizationRedirect(location as string, {
+		originPath: 'https://example.com/callback',
+		params: { error: 'access_denied', state: 'demo' },
+		iss: 'https://example.com',
+	})
 
 	const missingPasswordResponse = await handleAuthorizeRequest(
 		createFormRequest(
@@ -451,12 +466,18 @@ test('authorize info, denial, approval, and default scopes follow the OAuth work
 	)
 
 	expect(sessionResponse.status).toBe(200)
-	const sessionPayload = await sessionResponse.json()
-	expect(sessionPayload).toEqual({
-		ok: true,
-		redirectTo: 'https://example.com/callback?code=session',
+	const sessionPayload = (await sessionResponse.json()) as {
+		ok: boolean
+		redirectTo: string
+	}
+	expect(sessionPayload.ok).toBe(true)
+	expectClientAuthorizationRedirect(sessionPayload.redirectTo, {
+		originPath: 'https://example.com/callback',
+		params: { code: 'session' },
+		iss: 'https://example.com',
 	})
 	expect(capturedOptions).not.toBeNull()
+	expect(capturedOptions?.request.issuer).toBe('https://example.com')
 
 	let resolveCapturedOptions:
 		| ((value: CompleteAuthorizationOptions) => void)
@@ -487,11 +508,71 @@ test('authorize info, denial, approval, and default scopes follow the OAuth work
 	)
 
 	expect(defaultScopeResponse.status).toBe(302)
-	expect(defaultScopeResponse.headers.get('Location')).toBe(
-		'https://example.com/callback?code=ok',
+	expectClientAuthorizationRedirect(
+		defaultScopeResponse.headers.get('Location') ?? '',
+		{
+			originPath: 'https://example.com/callback',
+			params: { code: 'ok' },
+			iss: 'https://example.com',
+		},
 	)
 	const defaultScopeOptions = await capturedOptionsPromise
 	expect(defaultScopeOptions.scope).toEqual(oauthScopes)
+	expect(defaultScopeOptions.request.issuer).toBe('https://example.com')
+})
+
+test('authorize success and deny redirects include RFC 9207 iss for the kody.codes issuer', async () => {
+	const authorizeUrl =
+		'https://kody.codes/oauth/authorize?response_type=code&client_id=client-123&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&scope=profile&state=demo'
+	const helpers = createHelpers({
+		async completeAuthorization() {
+			return { redirectTo: 'https://example.com/callback?code=codex' }
+		},
+	})
+	const approveResponse = await handleAuthorizeRequest(
+		new Request(authorizeUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				decision: 'approve',
+				email: 'user@example.com',
+				password: 'password123',
+			}),
+		}),
+		createEnv(helpers, await createDatabase('password123')),
+	)
+	expect(approveResponse.status).toBe(200)
+	const approvePayload = (await approveResponse.json()) as {
+		ok: boolean
+		redirectTo: string
+	}
+	expect(approvePayload.ok).toBe(true)
+	expectClientAuthorizationRedirect(approvePayload.redirectTo, {
+		originPath: 'https://example.com/callback',
+		params: { code: 'codex' },
+		iss: 'https://kody.codes',
+	})
+
+	const denyResponse = await handleAuthorizeRequest(
+		new Request(authorizeUrl, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({ decision: 'deny' }),
+		}),
+		createEnv(createHelpers()),
+	)
+	expect(denyResponse.status).toBe(302)
+	expectClientAuthorizationRedirect(
+		denyResponse.headers.get('Location') ?? '',
+		{
+			originPath: 'https://example.com/callback',
+			params: { error: 'access_denied', state: 'demo' },
+			iss: 'https://kody.codes',
+		},
+	)
 })
 
 test('Claude-shaped authorize requests render and approve without throwing', async () => {
@@ -540,13 +621,22 @@ test('Claude-shaped authorize requests render and approve without throwing', asy
 	)
 
 	expect(postResponse.status).toBe(200)
-	await expect(postResponse.json()).resolves.toEqual({
-		ok: true,
-		redirectTo:
-			'https://claude.ai/api/mcp/auth_callback?code=demo&state=x5z9jORTCRNTmZ5_fiH7tdVWDVbiPujOHtUkyHzBvmc',
+	const claudePayload = (await postResponse.json()) as {
+		ok: boolean
+		redirectTo: string
+	}
+	expect(claudePayload.ok).toBe(true)
+	expectClientAuthorizationRedirect(claudePayload.redirectTo, {
+		originPath: 'https://claude.ai/api/mcp/auth_callback',
+		params: {
+			code: 'demo',
+			state: 'x5z9jORTCRNTmZ5_fiH7tdVWDVbiPujOHtUkyHzBvmc',
+		},
+		iss: 'https://heykody.dev',
 	})
 	expect(capturedOptions?.request.resource).toBe('https://heykody.dev/mcp')
 	expect(capturedOptions?.request.scope).toEqual(['profile', 'email'])
+	expect(capturedOptions?.request.issuer).toBe('https://heykody.dev')
 })
 
 test('Gemini-shaped authorize requests default resource to /mcp when omitted', async () => {
@@ -580,10 +670,16 @@ test('Gemini-shaped authorize requests default resource to /mcp when omitted', a
 	)
 
 	expect(postResponse.status).toBe(200)
-	await expect(postResponse.json()).resolves.toEqual({
-		ok: true,
-		redirectTo:
-			'https://oauth-redirect.googleusercontent.com/r/user_bound_custom-mcp-106664623666703652842-heykody_dev?code=demo&state=gemini-demo-state',
+	const geminiPayload = (await postResponse.json()) as {
+		ok: boolean
+		redirectTo: string
+	}
+	expect(geminiPayload.ok).toBe(true)
+	expectClientAuthorizationRedirect(geminiPayload.redirectTo, {
+		originPath:
+			'https://oauth-redirect.googleusercontent.com/r/user_bound_custom-mcp-106664623666703652842-heykody_dev',
+		params: { code: 'demo', state: 'gemini-demo-state' },
+		iss: 'https://heykody.dev',
 	})
 	expect(capturedOptions?.request.resource).toBe('https://heykody.dev/mcp')
 	expect(geminiAuthRequestWithoutResource.resource).toBeUndefined()
@@ -618,9 +714,15 @@ test('session approval uses stable user id when cookie email is stale', async ()
 	)
 
 	expect(response.status).toBe(200)
-	await expect(response.json()).resolves.toEqual({
-		ok: true,
-		redirectTo: 'https://example.com/callback?code=stale-session',
+	const stalePayload = (await response.json()) as {
+		ok: boolean
+		redirectTo: string
+	}
+	expect(stalePayload.ok).toBe(true)
+	expectClientAuthorizationRedirect(stalePayload.redirectTo, {
+		originPath: 'https://example.com/callback',
+		params: { code: 'stale-session' },
+		iss: 'https://example.com',
 	})
 	expect(capturedOptions?.metadata).toMatchObject({ email: currentEmail })
 	expect(capturedOptions?.props).toMatchObject({ email: currentEmail })
@@ -728,9 +830,15 @@ test('authorize rejects unverified accounts before creating a grant', async () =
 		createEnv(helpers, await createDatabase('password123')),
 	)
 	expect(verifiedResponse.status).toBe(200)
-	await expect(verifiedResponse.json()).resolves.toEqual({
-		ok: true,
-		redirectTo: 'https://example.com/callback?code=verified-ok',
+	const verifiedPayload = (await verifiedResponse.json()) as {
+		ok: boolean
+		redirectTo: string
+	}
+	expect(verifiedPayload.ok).toBe(true)
+	expectClientAuthorizationRedirect(verifiedPayload.redirectTo, {
+		originPath: 'https://example.com/callback',
+		params: { code: 'verified-ok' },
+		iss: 'https://example.com',
 	})
 	expect(completeAuthorization).toHaveBeenCalledTimes(1)
 })
@@ -883,10 +991,14 @@ test('worker entrypoint advertises MCP resource metadata on both RFC 9728 paths'
 	)
 	expect(discovery.status).toBe(200)
 	const metadata = (await discovery.json()) as {
+		issuer?: string
+		authorization_response_iss_parameter_supported?: boolean
 		client_id_metadata_document_supported?: boolean
 		code_challenge_methods_supported?: Array<string>
 		token_endpoint_auth_methods_supported?: Array<string>
 	}
+	expect(metadata.issuer).toBe('https://heykody.dev')
+	expect(metadata.authorization_response_iss_parameter_supported).toBe(true)
 	expect(metadata.client_id_metadata_document_supported).toBe(true)
 	expect(metadata.code_challenge_methods_supported).toEqual(['S256'])
 	expect(metadata.token_endpoint_auth_methods_supported).toContain('none')
@@ -1664,6 +1776,7 @@ test('malformed max_age does not redirect authorize GET to itself', async () => 
 		/max_age must be a non-negative integer/i,
 	)
 	expect(silentRedirect.searchParams.get('state')).toBe('demo')
+	expect(silentRedirect.searchParams.get('iss')).toBe('https://example.com')
 })
 
 test('authorize recovers when a pre-hydration submit clobbers the OAuth query', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Unblock Codex (and other RFC 9207 clients) so Kody MCP login can finish after the user approves OAuth.

## Why

Josh Hamilton (Verified Tinkerer) reported Codex onboarding fails after approving Kody OAuth:

```
Your approval reached Codex, but login failed with:
Authorization server response missing required issuer: expected https://kody.codes
```

Live `https://kody.codes/.well-known/oauth-authorization-server` advertises `authorization_response_iss_parameter_supported: true` and `issuer: "https://kody.codes"`. Strict clients require that same `iss` on the authorization response (RFC 9207).

## Root cause

Two gaps lined up:

1. **`@cloudflare/workers-oauth-provider` only adds `iss` on success when `AuthRequest.issuer` is set.** `parseAuthRequest` does set it from the request origin, and the existing ChatGPT workers test already expected `iss` on that path. If that field is missing or dropped, `completeAuthorization` returns `redirect_uri?code=…` with no `iss`.
2. **Hand-rolled client redirects never set `iss`.** Deny (`access_denied`) and silent OIDC error redirects (`createOidcClientErrorRedirectUrl`) sent the client back to `redirect_uri` with `error`/`state` only. Codex still requires `iss` on those callbacks and reports a missing issuer.

The production miss is most likely (2) if Codex landed on an error callback after the approve UI, or (1) if `issuer` was not on the `AuthRequest` passed to `completeAuthorization`. This change does not invent a second issuer: `iss` is always `getAppBaseUrl`, the same value as `/.well-known/openid-configuration` and oauth-authorization-server.

## Summary

- Assign `AuthRequest.issuer` from `getAppBaseUrl` after a successful parse so the provider helper can include `iss`.
- Stamp `iss` on every outbound client redirect (approve JSON/`302`, deny, silent OIDC errors) so a forgotten provider field cannot omit it.
- Document RFC 9207 `iss` on authorize responses in the authentication architecture doc.
- Tests: helper unit coverage, mocked provider success without `iss` still stamps `https://kody.codes`, deny and silent OIDC error redirects include `iss`, discovery advertises the flag.

## Testing

- Pre-push: `test:node` (3157) and `test:workers` (354) passed.
- Focused: 25 oauth-handlers + oauth-authorization-response tests passed, including `authorize success and deny redirects include RFC 9207 iss for the kody.codes issuer`.
- `npm run validate` passed (format, lint, typecheck, node/workers/mcp/e2e, knip, docs, builds).
- Preview `https://kody-pr-2279.kody-a99.workers.dev` as `me@kentcdodds.com`: discovery issuer is the preview origin and `authorization_response_iss_parameter_supported` is true. Session approve and deny both return `redirect_uri` with `iss` equal to that issuer (`http://127.0.0.1/oauth/callback?…&iss=https://kody-pr-2279.kody-a99.workers.dev`).

## System changes

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends existing primitives</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `79480fed` · **Head:** `29137b8b`

**Classification:** extends — MCP OAuth authorization responses always include RFC 9207 `iss` matching the discovery issuer.

### Primitives touched

| Primitive      | Group | Impact                                                                 |
| -------------- | ----- | ---------------------------------------------------------------------- |
| `mcp-oauth`    | auth  | extends — success and error client redirects stamp `iss`               |
| `app-sessions` | auth  | composes — same authorize file, session cookie behavior unchanged      |

### Change flow

Approve and deny both return the client to `redirect_uri` with `iss` equal to `getAppBaseUrl`.

```mermaid
sequenceDiagram
	actor Client
	participant mcpOauth as mcp-oauth
	participant appSessions as app-sessions
	Client->>mcpOauth: GET or POST /oauth/authorize
	mcpOauth->>appSessions: resolve browser session for approve
	appSessions-->>mcpOauth: signed-in account
	alt approve
		mcpOauth->>mcpOauth: set AuthRequest.issuer and stamp iss on redirectTo
		mcpOauth-->>Client: 302 redirect_uri with code and iss
	else deny or OIDC client error
		mcpOauth->>mcpOauth: stamp iss on error redirect_uri
		mcpOauth-->>Client: 302 redirect_uri with error and iss
	end
```

### Before / after

```
before: redirect_uri?code=…           (iss only if provider remembered issuer)
before: redirect_uri?error=access_denied   (no iss)
after:  redirect_uri?code=…&iss=<getAppBaseUrl>
after:  redirect_uri?error=access_denied&iss=<getAppBaseUrl>
```

</details>

<!-- system-recap:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb16aa3b-1baf-4754-b83e-0ac02e2c54b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb16aa3b-1baf-4754-b83e-0ac02e2c54b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - OAuth authorization redirects now include the RFC 9207 `iss` parameter on successful and error responses.
  - Existing redirect parameters are preserved, while conflicting issuer values are replaced with the configured application issuer.
  - OAuth discovery metadata now indicates the configured issuer and support for authorization response issuer parameters.

- **Bug Fixes**
  - Error redirects, including access-denied and client-error responses, now consistently include issuer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->